### PR TITLE
Consolidate MoneroWalletRpc

### DIFF
--- a/Monero.Test/TestMoneroWalletCommon.cs
+++ b/Monero.Test/TestMoneroWalletCommon.cs
@@ -1,5 +1,7 @@
-﻿using Monero.Common;
+﻿using System.Text;
+using Monero.Common;
 using Monero.Daemon;
+using Monero.Daemon.Common;
 using Monero.Test.Utils;
 using Monero.Wallet;
 using Monero.Wallet.Common;
@@ -7,7 +9,43 @@ using Monero.Wallet.Common;
 
 namespace Monero.Test;
 
-public abstract class TestMoneroWalletCommon
+public abstract class MoneroWalletCommonFixture : IDisposable
+{
+    public MoneroWallet wallet;
+    public MoneroDaemonRpc daemon;
+
+    public MoneroWalletCommonFixture(MoneroWallet wallet, MoneroDaemonRpc daemon)
+    {
+        // Before All
+        this.wallet = wallet;
+        this.daemon = daemon;
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    public virtual void Dispose(bool disposing)
+    {
+        // After All
+
+        if (disposing != true) return;
+
+        // try to stop mining
+        if (daemon != null)
+        {
+            try { daemon.StopMining(); }
+            catch (MoneroError e) { }
+        }
+
+        // close wallet
+        if (wallet != null) wallet.Close(true);
+    }
+}
+
+public abstract class TestMoneroWalletCommon : IDisposable
 {
     // test constants
     protected static readonly bool LITE_MODE = false;
@@ -15,13 +53,15 @@ public abstract class TestMoneroWalletCommon
     protected static readonly bool TEST_RELAYS = true;
     protected static readonly bool TEST_NOTIFICATIONS = true;
     protected static readonly bool TEST_RESETS = false;
-    private static readonly int MAX_TX_PROOFS = 25; // maximum number of transactions to check for each proof, undefined to check all
-    private static readonly int SEND_MAX_DIFF = 60;
-    private static readonly int SEND_DIVISOR = 10;
-    private static readonly int NUM_BLOCKS_LOCKED = 10;
+    private static readonly int MAX_TX_PROOFS = 25; // maximum number of transactions to _check for each proof, undefined to _check all
+    private static readonly ulong SEND_MAX_DIFF = 60;
+    private static readonly ulong SEND_DIVISOR = 10;
+    private static readonly ulong NUM_BLOCKS_LOCKED = 10;
 
     // instance variables
-    protected MoneroWallet wallet = new MoneroWalletRpc("");        // wallet instance to test
+
+    protected MoneroWalletCommonFixture fixture;
+    protected MoneroWallet wallet;        // wallet instance to test
     protected MoneroDaemonRpc daemon;     // daemon instance to test
 
     protected MoneroDaemonRpc GetTestDaemon() { return TestUtils.GetDaemonRpc(); }
@@ -29,15 +69,63 @@ public abstract class TestMoneroWalletCommon
     protected MoneroWallet OpenWallet(string path, string password) { return OpenWallet(new MoneroWalletConfig().SetPath(path).SetPassword(password)); }
     protected abstract MoneroWallet OpenWallet(MoneroWalletConfig config);
     protected abstract MoneroWallet CreateWallet(MoneroWalletConfig config);
-    protected void CloseWallet(MoneroWallet wallet) { CloseWallet(wallet, false); }
+    protected virtual void CloseWallet(MoneroWallet wallet) { CloseWallet(wallet, false); }
     protected abstract void CloseWallet(MoneroWallet wallet, bool save);
     protected abstract List<string> GetSeedLanguages();
+
+    protected TestMoneroWalletCommon(MoneroWalletCommonFixture walletFixture)
+    {
+        fixture = walletFixture;
+        daemon = walletFixture.daemon;
+        wallet = walletFixture.wallet;
+
+        // Before each
+
+        // stop mining
+        if (daemon != null)
+        {
+            MoneroMiningStatus status = new();
+            try { status = daemon.GetMiningStatus(); }
+            catch (Exception ex) { }
+            if (status.IsActive() == true && wallet != null) wallet.StopMining();
+            else if (wallet == null) Console.WriteLine("WARNING: wallet is null");
+        }
+        else
+        {
+            Console.WriteLine("WARNING: daemon is null");
+        }
+    }
+
+    public void Dispose()
+    {
+        DisposeInternal();
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void DisposeInternal()
+    {
+        // After each
+
+        try
+        {
+            if (daemon.GetMiningStatus().IsActive() == true)
+            {
+                Console.WriteLine("WARNING: Mining is still active after tests");
+                daemon.StopMining();
+            }
+        }
+        catch (Exception ex)
+        {
+
+        }
+
+    }
 
     #region Begin Tests
 
     // Can create a random wallet
     [Fact]
-    public void TestCreateWalletRandom()
+    public virtual void TestCreateWalletRandom()
     {
         Assert.True(TEST_NON_RELAYS);
         Exception? e1 = null;  // emulating Java "finally" but compatible with other languages
@@ -95,7 +183,7 @@ public abstract class TestMoneroWalletCommon
 
     // Can create a wallet from a seed.
     [Fact]
-    public void TestCreateWalletFromSeed()
+    public virtual void TestCreateWalletFromSeed()
     {
         Assert.True(TEST_NON_RELAYS);
         Exception? e1 = null;  // emulating Java "finally" but compatible with other languages
@@ -158,7 +246,7 @@ public abstract class TestMoneroWalletCommon
 
     // Can create a wallet from a seed with a seed offset
     [Fact]
-    public void TestCreateWalletFromSeedWithOffset()
+    public virtual void TestCreateWalletFromSeedWithOffset()
     {
         Assert.True(TEST_NON_RELAYS);
         Exception e1 = null;  // emulating Java "finally" but compatible with other languages
@@ -193,7 +281,7 @@ public abstract class TestMoneroWalletCommon
 
     // Can create a wallet from keys
     [Fact]
-    public void TestCreateWalletFromKeys()
+    public virtual void TestCreateWalletFromKeys()
     {
         Assert.True(TEST_NON_RELAYS);
         Exception e1 = null; // emulating Java "finally" but compatible with other languages
@@ -229,9 +317,9 @@ public abstract class TestMoneroWalletCommon
             CloseWallet(wallet);
             if (e2 != null) throw e2;
 
-            // recreate test wallet from spend key
+            // recreate test wallet from spend _key
             if (wallet.GetWalletType() != MoneroWalletType.RPC)
-            { // TODO monero-wallet-rpc: cannot create wallet from spend key?
+            { // TODO monero-wallet-rpc: cannot create wallet from spend _key?
                 wallet = CreateWallet(new MoneroWalletConfig().SetPrivateSpendKey(privateSpendKey).SetRestoreHeight(daemon.GetHeight()));
                 e2 = null;
                 try
@@ -276,7 +364,7 @@ public abstract class TestMoneroWalletCommon
 
     // Can create wallets with subaddress lookahead
     [Fact]
-    public void TestSubaddressLookahead()
+    public virtual void TestSubaddressLookahead()
     {
         Assert.True(TEST_NON_RELAYS);
         Exception? e1 = null;  // emulating Java "finally" but compatible with other languages
@@ -289,9 +377,9 @@ public abstract class TestMoneroWalletCommon
 
             // transfer funds to subaddress with high index
             wallet.CreateTx(new MoneroTxConfig()
-                .SetAccountIndex(0)
-                .AddDestination(receiver.GetSubaddress(0, 85000).GetAddress(), TestUtils.MAX_FEE)
-                .SetRelay(true));
+                    .SetAccountIndex(0)
+                    .AddDestination(receiver.GetSubaddress(0, 85000).GetAddress(), TestUtils.MAX_FEE)
+                    .SetRelay(true));
 
             // observe unconfirmed funds
             Thread.Sleep(1000);
@@ -309,7 +397,7 @@ public abstract class TestMoneroWalletCommon
 
     // Can get the wallet's version
     [Fact]
-    public void TestGetVersion()
+    public virtual void TestGetVersion()
     {
         Assert.True(TEST_NON_RELAYS);
         MoneroVersion version = wallet.GetVersion();
@@ -320,7 +408,7 @@ public abstract class TestMoneroWalletCommon
 
     // Can get the wallet's path
     [Fact]
-    public void TestGetPath()
+    public virtual void TestGetPath()
     {
         Assert.True(TEST_NON_RELAYS);
 
@@ -328,7 +416,7 @@ public abstract class TestMoneroWalletCommon
         MoneroWallet wallet = CreateWallet(new MoneroWalletConfig());
 
         // set a random attribute
-        string uuid = Guid.NewGuid().ToString();
+        string uuid = GenUtils.GetGuid();
         wallet.SetAttribute("uuid", uuid);
 
         // record the wallet's path then save and close
@@ -345,7 +433,7 @@ public abstract class TestMoneroWalletCommon
 
     // Can set the daemon connection
     [Fact]
-    public void TestSetDaemonConnection()
+    public virtual void TestSetDaemonConnection()
     {
         // create random wallet with default daemon connection
         MoneroWallet wallet = CreateWallet(new MoneroWalletConfig());
@@ -408,7 +496,7 @@ public abstract class TestMoneroWalletCommon
 
     // Can use a connection manager
     [Fact]
-    public void TestConnectionManager()
+    public virtual void TestConnectionManager()
     {
 
         // create connection manager with monerod connections
@@ -474,7 +562,7 @@ public abstract class TestMoneroWalletCommon
 
     // Can get the seed
     [Fact]
-    public void TestGetSeed()
+    public virtual void TestGetSeed()
     {
         Assert.True(TEST_NON_RELAYS);
         string seed = wallet.GetSeed();
@@ -484,7 +572,7 @@ public abstract class TestMoneroWalletCommon
 
     // Can get the language of the seed
     [Fact]
-    public void TestGetSeedLanguage()
+    public virtual void TestGetSeedLanguage()
     {
         Assert.True(TEST_NON_RELAYS);
         string language = wallet.GetSeedLanguage();
@@ -493,7 +581,7 @@ public abstract class TestMoneroWalletCommon
 
     // Can get a list of supported languages for the seed
     [Fact]
-    public void TestGetSeedLanguages()
+    public virtual void TestGetSeedLanguages()
     {
         Assert.True(TEST_NON_RELAYS);
         List<string> languages = GetSeedLanguages();
@@ -501,36 +589,36 @@ public abstract class TestMoneroWalletCommon
         foreach (string language in languages) Assert.True(language.Length > 0);
     }
 
-    // Can get the private view key
+    // Can get the private view _key
     [Fact]
-    public void TestGetPrivateViewKey()
+    public virtual void TestGetPrivateViewKey()
     {
         Assert.True(TEST_NON_RELAYS);
         string privateViewKey = wallet.GetPrivateViewKey();
         MoneroUtils.ValidatePrivateViewKey(privateViewKey);
     }
 
-    // Can get the private spend key
+    // Can get the private spend _key
     [Fact]
-    public void TestGetPrivateSpendKey()
+    public virtual void TestGetPrivateSpendKey()
     {
         Assert.True(TEST_NON_RELAYS);
         string privateSpendKey = wallet.GetPrivateSpendKey();
         MoneroUtils.ValidatePrivateSpendKey(privateSpendKey);
     }
 
-    // Can get the public view key
+    // Can get the public view _key
     [Fact]
-    public void TestGetPublicViewKey()
+    public virtual void TestGetPublicViewKey()
     {
         Assert.True(TEST_NON_RELAYS);
         string publicViewKey = wallet.GetPublicViewKey();
         MoneroUtils.ValidatePrivateSpendKey(publicViewKey);
     }
 
-    // Can get the public view key
+    // Can get the public view _key
     [Fact]
-    public void TestGetPublicSpendKey()
+    public virtual void TestGetPublicSpendKey()
     {
         Assert.True(TEST_NON_RELAYS);
         string publicSpendKey = wallet.GetPublicSpendKey();
@@ -539,7 +627,7 @@ public abstract class TestMoneroWalletCommon
 
     // Can get the primary address
     [Fact]
-    public void TestGetPrimaryAddress()
+    public virtual void TestGetPrimaryAddress()
     {
         Assert.True(TEST_NON_RELAYS);
         string primaryAddress = wallet.GetPrimaryAddress();
@@ -549,7 +637,7 @@ public abstract class TestMoneroWalletCommon
 
     // Can get the address of a subaddress at a specified account and subaddress index
     [Fact]
-    public void TestGetSubaddressAddress()
+    public virtual void TestGetSubaddressAddress()
     {
         Assert.True(TEST_NON_RELAYS);
         Assert.True(wallet.GetPrimaryAddress() == (wallet.GetSubaddress(0, 0)).GetAddress());
@@ -564,7 +652,7 @@ public abstract class TestMoneroWalletCommon
 
     // Can get addresses out of range of used accounts and subaddresses
     [Fact]
-    public void TestGetSubaddressAddressOutOfRange()
+    public virtual void TestGetSubaddressAddressOutOfRange()
     {
         Assert.True(TEST_NON_RELAYS);
         List<MoneroAccount> accounts = wallet.GetAccounts(true);
@@ -575,5 +663,5764 @@ public abstract class TestMoneroWalletCommon
         Assert.True(address.Length > 0);
     }
 
+    // Can get the account and subaddress indices of an address
+    [Fact]
+    public virtual void TestGetAddressIndices()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // get last subaddress to test
+        List<MoneroAccount> accounts = wallet.GetAccounts(true);
+        int accountIdx = accounts.Count - 1;
+        int subaddressIdx = accounts[accountIdx].GetSubaddresses().Count - 1;
+
+        if (accountIdx < 0) throw new MoneroError("Wallet has no accounts");
+        if (subaddressIdx < 0) throw new MoneroError("Wallet has no subaddresses");
+
+        string address = wallet.GetAddress((uint)accountIdx, (uint)subaddressIdx);
+        Assert.NotNull(address);
+
+        // get address index
+        MoneroSubaddress subaddress = wallet.GetAddressIndex(address);
+        var subaddressAccountIdx = subaddress.GetAccountIndex();
+        Assert.Equal((uint)accountIdx, subaddressAccountIdx);
+        Assert.Equal((uint)subaddressIdx, subaddress.GetIndex());
+
+        // test valid but unfound address
+        string nonWalletAddress = TestUtils.GetExternalWalletAddress();
+        try
+        {
+            subaddress = wallet.GetAddressIndex(nonWalletAddress);
+            throw new Exception("Should have thrown exception");
+        }
+        catch (MoneroError e)
+        {
+            Assert.Equal("Address doesn't belong to the wallet", e.Message);
+        }
+
+        // test invalid address
+        try
+        {
+            subaddress = wallet.GetAddressIndex("this is definitely not an address");
+            throw new Exception("Should have thrown exception");
+        }
+        catch (MoneroError e)
+        {
+            Assert.Equal("Invalid address", e.Message);
+        }
+    }
+
+    // Can get an integrated address given a payment id
+    [Fact]
+    public virtual void TestGetIntegratedAddress()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // save address for later comparison
+        string address = wallet.GetPrimaryAddress();
+
+        // test valid payment id
+        string paymentId = "03284e41c342f036";
+        MoneroIntegratedAddress integratedAddress = wallet.GetIntegratedAddress(null, paymentId);
+        Assert.Equal(integratedAddress.GetStandardAddress(), address);
+        Assert.Equal(integratedAddress.GetPaymentId(), paymentId);
+
+        // test null payment id which generates a new one
+        integratedAddress = wallet.GetIntegratedAddress();
+        Assert.Equal(integratedAddress.GetStandardAddress(), address);
+        Assert.False(integratedAddress.GetPaymentId().Length == 0);
+
+        // test with primary address
+        string primaryAddress = wallet.GetPrimaryAddress();
+        integratedAddress = wallet.GetIntegratedAddress(primaryAddress, paymentId);
+        Assert.Equal(integratedAddress.GetStandardAddress(), primaryAddress);
+        Assert.Equal(integratedAddress.GetPaymentId(), paymentId);
+
+        // test with subaddress
+        if (wallet.GetSubaddresses(0).Count < 2) wallet.CreateSubaddress(0);
+        string subaddress = wallet.GetSubaddress(0, 1).GetAddress();
+        try
+        {
+            integratedAddress = wallet.GetIntegratedAddress(subaddress, null);
+            throw new Exception("Getting integrated address from subaddress should have failed");
+        }
+        catch (MoneroError e)
+        {
+            Assert.Equal("Subaddress shouldn't be used", e.Message);
+        }
+
+        // test invalid payment id
+        string invalidPaymentId = "invalid_payment_id_123456";
+        try
+        {
+            integratedAddress = wallet.GetIntegratedAddress(null, invalidPaymentId);
+            throw new Exception("Getting integrated address with invalid payment id " + invalidPaymentId + " should have thrown exception");
+        }
+        catch (MoneroError e)
+        {
+            Assert.Equal("Invalid payment ID: " + invalidPaymentId, e.Message);
+        }
+    }
+
+    // Can decode an integrated address
+    [Fact]
+    public virtual void TestDecodeIntegratedAddress()
+    {
+        Assert.True(TEST_NON_RELAYS);
+        MoneroIntegratedAddress integratedAddress = wallet.GetIntegratedAddress(null, "03284e41c342f036");
+        MoneroIntegratedAddress decodedAddress = wallet.DecodeIntegratedAddress(integratedAddress.ToString());
+        Assert.True(integratedAddress.Equals(decodedAddress));
+
+        // decode invalid address
+        try
+        {
+            wallet.DecodeIntegratedAddress("bad address");
+            throw new Exception("Should have failed decoding bad address");
+        }
+        catch (MoneroError err)
+        {
+            Assert.Equal("Invalid address", err.Message);
+        }
+    }
+
+    // Can sync (without progress)
+    // TODO: test syncing from start height
+    [Fact]
+    public virtual void TestSyncWithoutProgress()
+    {
+        Assert.True(TEST_NON_RELAYS);
+        ulong numBlocks = 100;
+        ulong chainHeight = daemon.GetHeight();
+        Assert.True(chainHeight >= numBlocks);
+        MoneroSyncResult result = wallet.Sync(chainHeight - numBlocks);  // sync end of chain
+        Assert.True(result.GetNumBlocksFetched() >= 0);
+        Assert.NotNull(result.GetReceivedMoney());
+    }
+
+    // Is equal to a ground truth wallet according to on-chain data
+    [Fact(Skip = "Full wallet not implemented")]
+    public virtual void TestWalletEqualityGroundTruth()
+    {
+        Assert.True(TEST_NON_RELAYS);
+        TestUtils.WALLET_TX_TRACKER.WaitForWalletTxsToClearPool(wallet);
+        MoneroWallet walletGt = TestUtils.CreateWalletGroundTruth(TestUtils.NETWORK_TYPE, TestUtils.SEED, null, TestUtils.FIRST_RECEIVE_HEIGHT);
+        try
+        {
+            WalletEqualityUtils.TestWalletEqualityOnChain(walletGt, wallet);
+        }
+        finally
+        {
+            walletGt.Close();
+        }
+    }
+
+    // Can get the current height that the wallet is synchronized to
+    [Fact]
+    public virtual void TestGetHeight()
+    {
+        Assert.True(TEST_NON_RELAYS);
+        ulong height = wallet.GetHeight();
+        Assert.True(height >= 0);
+    }
+
+    // Can get a blockchain height by date
+    [Fact]
+    public virtual void TestGetHeightByDate()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // collect dates to test starting 100 days ago
+        ulong DAY_MS = 24 * 60 * 60 * 1000;
+        DateTime yesterday = DateTime.UtcNow.AddDays(-1); // TODO monero-project: today's date can throw exception as "in future" so we test up to yesterday
+        List<DateTime> dates = new List<DateTime>();
+        for (int i = 99; i >= 0; i--)
+        {
+            dates.Add(yesterday.AddDays(-i)); // subtract i days
+        }
+
+        // test heights by date
+        ulong? lastHeight = null;
+        foreach (DateTime date in dates)
+        {
+            ulong _height = wallet.GetHeightByDate(date.Year, date.Month, date.Day);
+            Assert.True(_height >= 0);
+            if (lastHeight != null) Assert.True(_height >= lastHeight);
+            lastHeight = _height;
+        }
+
+        Assert.True(lastHeight >= 0);
+        ulong height = wallet.GetHeight();
+        Assert.True(height >= 0);
+
+        // test future date
+        try
+        {
+            DateTime tomorrow = yesterday.AddDays(2);
+            wallet.GetHeightByDate(tomorrow.Year + 1900, tomorrow.Month + 1, tomorrow.Day);
+            Assert.Fail("Expected exception on future date");
+        }
+        catch (MoneroError err)
+        {
+            Assert.Equal("specified date is in the future", err.Message);
+        }
+    }
+
+    // Can get the locked and unlocked balances of the wallet, accounts, and subaddresses
+    [Fact]
+    public virtual void TestGetAllBalances()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // fetch accounts with all info as reference
+        List<MoneroAccount> accounts = wallet.GetAccounts(true);
+
+        // test that balances add up between accounts and wallet
+        ulong accountsBalance = 0;
+        ulong accountsUnlockedBalance = 0;
+        foreach (MoneroAccount account in accounts)
+        {
+            accountsBalance += (ulong)account.GetBalance()!;
+            accountsUnlockedBalance += (ulong)account.GetUnlockedBalance()!;
+
+            // test that balances add up between subaddresses and accounts
+            ulong subaddressesBalance = 0;
+            ulong subaddressesUnlockedBalance = 0;
+            foreach (MoneroSubaddress subaddress in account.GetSubaddresses())
+            {
+                subaddressesBalance += subaddress.GetBalance() ?? 0;
+                subaddressesUnlockedBalance += subaddress.GetUnlockedBalance() ?? 0;
+
+                // test that balances are consistent with getAccounts() call
+                Assert.Equal((wallet.GetBalance(subaddress.GetAccountIndex(), subaddress.GetIndex())).ToString(), subaddress.GetBalance().ToString());
+                Assert.Equal((wallet.GetUnlockedBalance(subaddress.GetAccountIndex(), subaddress.GetIndex())).ToString(), subaddress.GetUnlockedBalance().ToString());
+            }
+
+            Assert.Equal((wallet.GetBalance(account.GetIndex())).ToString(), subaddressesBalance.ToString());
+            Assert.Equal((wallet.GetUnlockedBalance(account.GetIndex())).ToString(), subaddressesUnlockedBalance.ToString());
+        }
+
+        TestUtils.TestUnsignedBigInteger(accountsBalance);
+        TestUtils.TestUnsignedBigInteger(accountsUnlockedBalance);
+        Assert.Equal((wallet.GetBalance()).ToString(), accountsBalance.ToString());
+        Assert.Equal((wallet.GetUnlockedBalance()).ToString(), accountsUnlockedBalance.ToString());
+    }
+
+    // Can get accounts without subaddresses
+    [Fact]
+    public virtual void TestGetAccountsWithoutSubaddresses()
+    {
+        Assert.True(TEST_NON_RELAYS);
+        List<MoneroAccount> accounts = wallet.GetAccounts();
+        Assert.False(accounts.Count == 0);
+        foreach (MoneroAccount account in accounts)
+        {
+            TestAccount(account);
+            Assert.Null(account.GetSubaddresses());
+        }
+    }
+
+    // Can get accounts with subaddresses
+    [Fact]
+    public virtual void TestGetAccountsWithSubaddresses()
+    {
+        Assert.True(TEST_NON_RELAYS);
+        List<MoneroAccount> accounts = wallet.GetAccounts(true);
+        Assert.False(accounts.Count == 0);
+        foreach (MoneroAccount account in accounts)
+        {
+            TestAccount(account);
+            Assert.False(account.GetSubaddresses().Count == 0);
+        }
+    }
+
+    // Can get an account at a specified index
+    [Fact]
+    public virtual void TestGetAccount()
+    {
+        Assert.True(TEST_NON_RELAYS);
+        List<MoneroAccount> accounts = wallet.GetAccounts();
+        Assert.False(accounts.Count == 0);
+        foreach (MoneroAccount account in accounts)
+        {
+            TestAccount(account);
+
+            uint? accountIdx = account.GetIndex();
+
+            if (accountIdx == null)
+            {
+                throw new Exception("Account index is null");
+            }
+
+            // test without subaddresses
+            MoneroAccount retrieved = wallet.GetAccount((uint)accountIdx);
+            Assert.Null(retrieved.GetSubaddresses());
+
+            // test with subaddresses
+            retrieved = wallet.GetAccount((uint)accountIdx, true);
+            Assert.NotNull(retrieved.GetSubaddresses());
+            Assert.False(retrieved.GetSubaddresses().Count == 0);
+        }
+    }
+
+    // Can create a new account without a label
+    [Fact]
+    public virtual void TestCreateAccountWithoutLabel()
+    {
+        Assert.True(TEST_NON_RELAYS);
+        List<MoneroAccount> accountsBefore = wallet.GetAccounts();
+        MoneroAccount createdAccount = wallet.CreateAccount();
+        TestAccount(createdAccount);
+        Assert.Equal(accountsBefore.Count, (wallet.GetAccounts()).Count - 1);
+    }
+
+    // Can create a new account with a label
+    [Fact]
+    public virtual void TestCreateAccountWithLabel()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // create account with label
+        List<MoneroAccount> accountsBefore = wallet.GetAccounts();
+        string label = Guid.NewGuid().ToString();
+        MoneroAccount createdAccount = wallet.CreateAccount(label);
+        TestAccount(createdAccount);
+        Assert.Equal(accountsBefore.Count, wallet.GetAccounts().Count - 1);
+        Assert.Equal(label, wallet.GetSubaddress((uint)createdAccount.GetIndex(), 0).GetLabel());
+
+        // fetch and test account
+        createdAccount = wallet.GetAccount((uint)createdAccount.GetIndex());
+        TestAccount(createdAccount);
+
+        // create account with same label
+        createdAccount = wallet.CreateAccount(label);
+        TestAccount(createdAccount);
+        Assert.Equal(accountsBefore.Count, (wallet.GetAccounts()).Count - 2);
+        Assert.Equal(label, wallet.GetSubaddress((uint)createdAccount.GetIndex(), 0).GetLabel());
+
+        // fetch and test account
+        createdAccount = wallet.GetAccount((uint)createdAccount.GetIndex());
+        TestAccount(createdAccount);
+    }
+
+    // Can set account labels
+    [Fact]
+    public virtual void TestSetAccountLabel()
+    {
+        // create account
+        if (wallet.GetAccounts().Count < 2)
+        {
+            wallet.CreateAccount();
+        }
+
+        // set account label
+        string label = GenUtils.GetGuid();
+        wallet.SetAccountLabel(1, label);
+        Assert.Equal(label, wallet.GetSubaddress(1, 0).GetLabel());
+    }
+
+    // Can get subaddresses at a specified account index
+    [Fact]
+    public virtual void TestGetSubaddresses()
+    {
+        Assert.True(TEST_NON_RELAYS);
+        List<MoneroAccount> accounts = wallet.GetAccounts();
+        Assert.False(accounts.Count == 0);
+        foreach (MoneroAccount account in accounts)
+        {
+            List<MoneroSubaddress> subaddresses = wallet.GetSubaddresses((uint)account.GetIndex());
+            Assert.False(subaddresses.Count == 0);
+            foreach (MoneroSubaddress subaddress in subaddresses)
+            {
+                TestSubaddress(subaddress);
+                Assert.Equal(account.GetIndex(), subaddress.GetAccountIndex());
+            }
+        }
+    }
+
+    // Can get subaddresses at specified account and subaddress indices
+    [Fact]
+    public virtual void TestGetSubaddressesByIndices()
+    {
+        Assert.True(TEST_NON_RELAYS);
+        List<MoneroAccount> accounts = wallet.GetAccounts();
+        Assert.False(accounts.Count == 0);
+        foreach (MoneroAccount account in accounts)
+        {
+
+            // get subaddresses
+            List<MoneroSubaddress> subaddresses = wallet.GetSubaddresses((uint)account.GetIndex());
+            Assert.True(subaddresses.Count > 0);
+
+            // remove a subaddress for query if possible
+            if (subaddresses.Count > 1) subaddresses.RemoveAt(0);
+
+            // get subaddress indices
+            List<uint> subaddressIndices = new();
+            foreach (MoneroSubaddress subaddress in subaddresses)
+            {
+                subaddressIndices.Add((uint)subaddress.GetIndex());
+            }
+
+            Assert.True(subaddressIndices.Count > 0);
+
+            // fetch subaddresses by indices
+            List<MoneroSubaddress> fetchedSubaddresses = wallet.GetSubaddresses((uint)account.GetIndex(), subaddressIndices);
+
+            // original subaddresses (minus one removed if applicable) is equal to fetched subaddresses
+            int i = 0;
+
+            foreach (MoneroSubaddress subaddr in subaddresses)
+            {
+                Assert.True(subaddr.Equals(fetchedSubaddresses[i]));
+                i++;
+            }
+        }
+    }
+
+    // Can get a subaddress at a specified account and subaddress index
+    [Fact]
+    public virtual void TestGetSubaddressByIndex()
+    {
+        Assert.True(TEST_NON_RELAYS);
+        List<MoneroAccount> accounts = wallet.GetAccounts();
+        Assert.True(accounts.Count > 0);
+        foreach (MoneroAccount account in accounts)
+        {
+            uint accountIdx = (uint)account.GetIndex();
+
+            List<MoneroSubaddress> subaddresses = wallet.GetSubaddresses(accountIdx);
+            Assert.True(subaddresses.Count > 0);
+
+            foreach (MoneroSubaddress subaddress in subaddresses)
+            {
+                TestSubaddress(subaddress);
+                uint subaddressIdx = (uint)subaddress.GetIndex();
+                Assert.True(subaddress.Equals(wallet.GetSubaddress(accountIdx, subaddressIdx)));
+                Assert.True(subaddress.Equals((wallet.GetSubaddresses(accountIdx, new List<uint>() { subaddressIdx })[0]))); // test plural call with single subaddr number
+            }
+        }
+    }
+
+    // Can create a subaddress with and without a label
+    [Fact]
+    public virtual void TestCreateSubaddress()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // create subaddresses across accounts
+        List<MoneroAccount> accounts = wallet.GetAccounts();
+        if (accounts.Count < 2) wallet.CreateAccount();
+        accounts = wallet.GetAccounts();
+        Assert.True(accounts.Count > 1);
+        for (uint accountIdx = 0; accountIdx < 2; accountIdx++)
+        {
+            // create subaddress with no label
+            List<MoneroSubaddress> subaddresses = wallet.GetSubaddresses(accountIdx);
+            MoneroSubaddress subaddress = wallet.CreateSubaddress(accountIdx);
+            Assert.Null(subaddress.GetLabel());
+            TestSubaddress(subaddress);
+            List<MoneroSubaddress> subaddressesNew = wallet.GetSubaddresses(accountIdx);
+            Assert.Equal(subaddressesNew.Count - 1, subaddresses.Count);
+            Assert.True(subaddress.Equals(subaddressesNew[subaddressesNew.Count - 1]));
+
+            // create subaddress with label
+            subaddresses = wallet.GetSubaddresses(accountIdx);
+            string uuid = GenUtils.GetGuid();
+            subaddress = wallet.CreateSubaddress(accountIdx, uuid);
+            Assert.Equal(uuid, subaddress.GetLabel());
+            TestSubaddress(subaddress);
+            subaddressesNew = wallet.GetSubaddresses(accountIdx);
+            Assert.Equal(subaddresses.Count, subaddressesNew.Count - 1);
+            Assert.True(subaddress.Equals(subaddressesNew[subaddressesNew.Count - 1]));
+        }
+    }
+
+    // Can set subaddress labels
+    [Fact]
+    public virtual void TestSetSubaddressLabel()
+    {
+
+        // create subaddresses
+        while (wallet.GetSubaddresses(0).Count < 3)
+        {
+            wallet.CreateSubaddress(0);
+        }
+
+        // set subaddress labels
+        for (uint subaddressIdx = 0; subaddressIdx < wallet.GetSubaddresses(0).Count; subaddressIdx++)
+        {
+            string label = GenUtils.GetGuid();
+            wallet.SetSubaddressLabel(0, subaddressIdx, label);
+            Assert.Equal(label, wallet.GetSubaddress(0, subaddressIdx).GetLabel());
+        }
+    }
+
+    // Can get transactions in the wallet
+    [Fact]
+    public virtual void TestGetTxsWallet()
+    {
+        Assert.True(TEST_NON_RELAYS);
+        bool nonDefaultIncoming = false;
+        List<MoneroTxWallet> txs = GetAndTestTxs(wallet, null, null, true);
+        Assert.False(txs.Count == 0, "Wallet has no txs to test");
+        Assert.True(TestUtils.FIRST_RECEIVE_HEIGHT == (ulong)txs[0].GetHeight(), "First _tx's restore height must match the restore height in TestUtils");
+
+        // build test context
+        TxContext ctx = new TxContext();
+        ctx.Wallet = wallet;
+
+        // test each transaction
+        Dictionary<ulong, MoneroBlock> blockPerHeight = [];
+        for (int i = 0; i < txs.Count; i++)
+        {
+            TestTxWallet(txs[i], ctx);
+
+            // test merging equivalent txs
+            MoneroTxWallet copy1 = txs[i].Clone();
+            MoneroTxWallet copy2 = txs[i].Clone();
+            if (copy1.IsConfirmed() == true) copy1.SetBlock(txs[i].GetBlock().Clone().SetTxs([copy1]));
+            if (copy2.IsConfirmed() == true) copy2.SetBlock(txs[i].GetBlock().Clone().SetTxs([copy2]));
+            MoneroTxWallet merged = copy1.Merge(copy2);
+            TestTxWallet(merged, ctx);
+
+            // find non-default incoming
+            if (txs[i].GetIncomingTransfers() != null)
+            { // TODO: txs1[i].IsIncoming()
+                foreach (MoneroIncomingTransfer transfer in txs[i].GetIncomingTransfers())
+                {
+                    if (transfer.GetAccountIndex() != 0 && transfer.GetSubaddressIndex() != 0) nonDefaultIncoming = true;
+                }
+            }
+
+            // ensure unique block reference per height
+            if (txs[i].IsConfirmed() == true)
+            {
+                MoneroBlock? block = blockPerHeight.GetValueOrDefault((ulong)txs[i].GetHeight()!);
+                if (block == null) blockPerHeight.Add((ulong)txs[i].GetHeight()!, txs[i].GetBlock()!);
+                else
+                {
+                    Assert.Equal(block, txs[i].GetBlock());
+                    Assert.True(block == txs[i].GetBlock(), "Block references for same height must be same");
+                }
+            }
+        }
+
+        // ensure non-default account and subaddress tested
+        Assert.True(nonDefaultIncoming, "No incoming transfers found to non-default account and subaddress; run send-to-multiple tests first");
+    }
+
+    // Can get transactions by hash
+    [Fact]
+    public virtual void TestGetTxsByHash()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        int maxNumTxs = 10;  // max number of txs to test
+
+        // fetch all txs for testing
+        List<MoneroTxWallet> txs = wallet.GetTxs();
+        Assert.True(txs.Count > 1, "Test requires at least 2 txs to fetch by hash");
+
+        // randomly pick a few for fetching by hash
+        txs.Shuffle();
+        txs = txs.GetRange(0, Math.Min(txs.Count, maxNumTxs));
+
+        // test fetching by hash
+        MoneroTxWallet fetchedTx = wallet.GetTx(txs[0].GetHash());
+        Assert.Equal(txs[0].GetHash(), fetchedTx.GetHash());
+        TestTxWallet(fetchedTx);
+
+        // test fetching by hashes
+        string txId1 = txs[0].GetHash();
+        string txId2 = txs[1].GetHash();
+        List<MoneroTxWallet> fetchedTxs = wallet.GetTxs([txId1, txId2]);
+        Assert.Equal(2, fetchedTxs.Count);
+
+        // test fetching by hashes as collection
+        List<string> txHashes = new();
+        foreach (MoneroTxWallet tx in txs) txHashes.Add(tx.GetHash());
+        fetchedTxs = wallet.GetTxs(txHashes);
+        Assert.Equal(txs.Count, fetchedTxs.Count);
+        for (int i = 0; i < txs.Count; i++)
+        {
+            Assert.Equal(txs[i].GetHash(), fetchedTxs[i].GetHash());
+            TestTxWallet(fetchedTxs[i]);
+        }
+
+        // test fetching with missing _tx hashes
+        string missingTxHash = "d01ede9cde813b2a693069b640c4b99c5adbdb49fbbd8da2c16c8087d0c3e320";
+        txHashes.Add(missingTxHash);
+        fetchedTxs = wallet.GetTxs(txHashes);
+        Assert.Equal(txs.Count, fetchedTxs.Count);
+        for (int i = 0; i < txs.Count; i++)
+        {
+            Assert.Equal(txs[i].GetHash(), fetchedTxs[i].GetHash());
+            TestTxWallet(fetchedTxs[i]);
+        }
+    }
+
+    // Can get transactions with additional configuration
+    [Fact]
+    public virtual void TestGetTxsWithQuery()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // get random transactions for testing
+        List<MoneroTxWallet> randomTxs = GetRandomTransactions(wallet, null, 3, 5);
+        foreach (MoneroTxWallet randomTx in randomTxs) TestTxWallet(randomTx, null);
+
+        // get transactions by hash
+        List<string> txHashes = new List<string>();
+        foreach (MoneroTxWallet randomTx in randomTxs)
+        {
+            txHashes.Add(randomTx.GetHash());
+            List<MoneroTxWallet> _txs = GetAndTestTxs(wallet, new MoneroTxQuery().SetHash(randomTx.GetHash()), null, true);
+            Assert.Single(_txs);
+            MoneroTxWallet merged = _txs[0].Merge(randomTx.Clone()); // txs change with chain so _check mergeability
+            TestTxWallet(merged, null);
+        }
+
+        // get transactions by hashes
+        List<MoneroTxWallet> txs = GetAndTestTxs(wallet, new MoneroTxQuery().SetHashes(txHashes), null, null);
+        Assert.Equal(txs.Count, randomTxs.Count);
+        foreach (MoneroTxWallet tx in txs) Assert.Contains(tx.GetHash(), txHashes);
+
+        // get transactions with an outgoing transfer
+        TxContext ctx = new TxContext();
+        ctx.HasOutgoingTransfer = true;
+        txs = GetAndTestTxs(wallet, new MoneroTxQuery().SetIsOutgoing(true), ctx, true);
+        foreach (MoneroTxWallet tx in txs)
+        {
+            Assert.True(tx.IsOutgoing());
+            Assert.NotNull(tx.GetOutgoingTransfer());
+            TestTransfer(tx.GetOutgoingTransfer(), null);
+        }
+
+        // get transactions without an outgoing transfer
+        ctx.HasOutgoingTransfer = false;
+        txs = GetAndTestTxs(wallet, new MoneroTxQuery().SetIsOutgoing(false), ctx, true);
+        foreach (MoneroTxWallet tx in txs) Assert.Null(tx.GetOutgoingTransfer());
+
+        // get transactions with incoming transfers
+        ctx = new TxContext();
+        ctx.HasIncomingTransfers = true;
+        txs = GetAndTestTxs(wallet, new MoneroTxQuery().SetIsIncoming(true), ctx, true);
+        foreach (MoneroTxWallet tx in txs)
+        {
+            Assert.True(tx.IsIncoming());
+            Assert.True(tx.GetIncomingTransfers().Count > 0);
+            foreach (MoneroIncomingTransfer transfer in tx.GetIncomingTransfers())
+            {
+                TestTransfer(transfer, null);
+            }
+        }
+
+        // get transactions without incoming transfers
+        ctx.HasIncomingTransfers = false;
+        txs = GetAndTestTxs(wallet, new MoneroTxQuery().SetIsIncoming(false), ctx, true);
+        foreach (MoneroTxWallet tx in txs)
+        {
+            Assert.False(tx.IsIncoming());
+            Assert.Null(tx.GetIncomingTransfers());
+        }
+
+        // get transactions associated with an account
+        uint accountIdx = 1;
+        txs = wallet.GetTxs(new MoneroTxQuery().SetTransferQuery(new MoneroTransferQuery().SetAccountIndex(accountIdx)));
+        foreach (MoneroTxWallet tx in txs)
+        {
+            bool _found = false;
+            if (tx.IsOutgoing() == true && tx.GetOutgoingTransfer().GetAccountIndex() == accountIdx) _found = true;
+            else if (tx.GetIncomingTransfers() != null)
+            {
+                foreach (MoneroTransfer transfer in tx.GetIncomingTransfers())
+                {
+                    if (transfer.GetAccountIndex() == accountIdx)
+                    {
+                        _found = true;
+                        break;
+                    }
+                }
+            }
+            Assert.True(_found, ("Transaction is not associated with account " + accountIdx + ":\n" + tx.ToString()));
+        }
+
+        // get transactions with incoming transfers to an account
+        txs = wallet.GetTxs(new MoneroTxQuery().SetTransferQuery(new MoneroTransferQuery().SetIsIncoming(true).SetAccountIndex(accountIdx)));
+        foreach (MoneroTxWallet tx in txs)
+        {
+            Assert.True(tx.GetIncomingTransfers().Count > 0);
+            bool _found = false;
+            foreach (MoneroTransfer transfer in tx.GetIncomingTransfers())
+            {
+                if (transfer.GetAccountIndex() == accountIdx)
+                {
+                    _found = true;
+                    break;
+                }
+            }
+            Assert.True(_found, "No incoming transfers to account " + accountIdx + " found:\n" + tx.ToString());
+        }
+
+        // get txs with manually built query that are confirmed and have an outgoing transfer from account 0
+        ctx = new TxContext();
+        ctx.HasOutgoingTransfer = true;
+        MoneroTxQuery txQuery = new MoneroTxQuery();
+        txQuery.SetIsConfirmed(true);
+        txQuery.SetTransferQuery(new MoneroTransferQuery().SetAccountIndex(0).SetIsOutgoing(true));
+        txs = GetAndTestTxs(wallet, txQuery, ctx, true);
+        foreach (MoneroTxWallet tx in txs)
+        {
+            if (tx.IsConfirmed() != true) Console.WriteLine(tx);
+            Assert.Equal(true, tx.IsConfirmed());
+            Assert.True(tx.IsOutgoing());
+            Assert.Equal(0, (int)tx.GetOutgoingTransfer().GetAccountIndex());
+        }
+
+        // get txs with outgoing transfers that have destinations to account 1
+        txs = GetAndTestTxs(wallet, new MoneroTxQuery().SetTransferQuery(new MoneroTransferQuery().SetHasDestinations(true).SetAccountIndex(0)), null, null);
+        foreach (MoneroTxWallet tx in txs)
+        {
+            Assert.True(tx.IsOutgoing());
+            Assert.True(tx.GetOutgoingTransfer().GetDestinations().Count > 0);
+        }
+
+        // include outputs with transactions
+        ctx = new TxContext();
+        ctx.IncludeOutputs = true;
+        txs = GetAndTestTxs(wallet, new MoneroTxQuery().SetIncludeOutputs(true), ctx, true);
+        bool found = false;
+        foreach (MoneroTxWallet tx in txs)
+        {
+            if (tx.GetOutputs() != null)
+            {
+                Assert.True(tx.GetOutputs().Count > 0);
+                found = true;
+            }
+            else
+            {
+                Assert.True(tx.IsOutgoing() == true || (tx.IsIncoming() == true && tx.IsConfirmed() != true)); // TODO: monero-wallet-rpc: return outputs for unconfirmed txs
+            }
+        }
+        Assert.True(found, "No outputs found in txs");
+
+        // get txs with input query // TODO: no inputs returned to filter
+        //    MoneroTxWallet outgoingTx = wallet.GetTxs(new MoneroTxQuery().SetIsOutgoing(true))[0];
+        //    List<MoneroTxWallet> outgoingTxs = wallet.GetTxs(new MoneroTxQuery().SetInputQuery(new MoneroOutputQuery().SetKeyImage(new MoneroKeyImage().SetHex(outgoingTx.GetInputsWallet()[0].GetKeyImage().GetHex()))));
+        //    Assert.Equal(1, outgoingTxs.Count);
+        //    Assert.Equal(outgoingTx.GetHash(), outgoingTxs[0].GetHash());
+
+        // get txs with output query
+        MoneroOutputQuery outputQuery = new MoneroOutputQuery().SetIsSpent(false).SetAccountIndex(1).SetSubaddressIndex(2);
+        txs = wallet.GetTxs(new MoneroTxQuery().SetOutputQuery(outputQuery));
+        Assert.False(txs.Count == 0);
+        foreach (MoneroTxWallet tx in txs)
+        {
+            Assert.False(tx.GetOutputs() == null || tx.GetOutputs().Count == 0);
+            found = false;
+            foreach (MoneroOutputWallet output in tx.GetOutputsWallet())
+            {
+                if (output.IsSpent() == false && output.GetAccountIndex() == 1 && output.GetSubaddressIndex() == 2)
+                {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) Assert.Fail("Tx does not contain specified output");
+        }
+
+        // get unlocked txs
+        txs = wallet.GetTxs(new MoneroTxQuery().SetIsLocked(false));
+        Assert.False(txs.Count == 0);
+        foreach (MoneroTxWallet tx in txs)
+        {
+            Assert.False(tx.IsLocked());
+        }
+
+        // get confirmed transactions sent from/to same wallet with a transfer with destinations
+        txs = wallet.GetTxs(new MoneroTxQuery().SetIsIncoming(true).SetIsOutgoing(true).SetIncludeOutputs(true).SetIsConfirmed(true).SetTransferQuery(new MoneroTransferQuery().SetHasDestinations(true)));
+        Assert.False(txs.Count == 0);
+        foreach (MoneroTxWallet tx in txs)
+        {
+            Assert.True(tx.IsIncoming());
+            Assert.True(tx.IsOutgoing());
+            Assert.True(tx.IsConfirmed());
+            Assert.False(tx.GetOutputsWallet().Count == 0);
+            Assert.NotNull(tx.GetOutgoingTransfer());
+            Assert.NotNull(tx.GetOutgoingTransfer().GetDestinations());
+            Assert.False(tx.GetOutgoingTransfer().GetDestinations().Count == 0);
+        }
+    }
+
+    // Can get transactions by height
+    [Fact]
+    public virtual void TestGetTxsByHeight()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // get all confirmed txs for testing
+        List<MoneroTxWallet> txs = wallet.GetTxs(new MoneroTxQuery().SetIsConfirmed(true));
+
+        // collect all _tx heights
+        List<ulong> txHeights = new List<ulong>();
+        foreach (MoneroTxWallet tx in txs) txHeights.Add((ulong)tx.GetHeight());
+
+        // get height that most txs occur at
+        Dictionary<ulong, uint> heightCounts = CountNumInstances(txHeights);
+        Assert.False(heightCounts.Count == 0, "Wallet has no confirmed txs; run send tests");
+        HashSet<ulong> heightModes = GetModes(heightCounts);
+        ulong modeHeight = heightModes.First();
+
+        // fetch txs at mode height
+        List<MoneroTxWallet> modeTxs = wallet.GetTxs(new MoneroTxQuery().SetHeight(modeHeight));
+        Assert.Equal((int)heightCounts[modeHeight], modeTxs.Count);
+        foreach (MoneroTxWallet tx in modeTxs)
+        {
+            Assert.Equal(modeHeight, tx.GetHeight());
+        }
+
+        // fetch txs at mode height by range
+        List<MoneroTxWallet> modeTxsByRange = wallet.GetTxs(new MoneroTxQuery().SetMinHeight(modeHeight).SetMaxHeight(modeHeight));
+        Assert.Equal(modeTxs.Count, modeTxsByRange.Count);
+        int i = 0;
+        foreach (MoneroTxWallet modeTx in modeTxs)
+        {
+            Assert.True(modeTx.Equals(modeTxsByRange[i]));
+            i++;
+        }
+
+        // fetch all txs by range
+        var fetchedTxs = wallet.GetTxs(new MoneroTxQuery().SetMinHeight(txs.First().GetHeight())
+            .SetMaxHeight(txs.Last().GetHeight()));
+
+        Assert.Equal(txs.Count, fetchedTxs.Count);
+
+        int j = 0;
+
+        foreach (var fetchedTx in fetchedTxs)
+        {
+            Assert.True(fetchedTx.Equals(txs[j]));
+            j++;
+        }
+
+        // test some filtered by range
+        {
+            txs = wallet.GetTxs(new MoneroTxQuery().SetIsConfirmed(true));
+            Assert.True(txs.Count > 0, "No transactions; run send to multiple test");
+
+            // get and sort block heights in ascending order
+            List<ulong> heights = new List<ulong>();
+            foreach (MoneroTxWallet tx in txs)
+            {
+                ulong? height = tx.GetBlock().GetHeight();
+                Assert.NotNull(height);
+                heights.Add((ulong)height);
+            }
+
+            heights.Sort();
+
+            // pick minimum and maximum heights for filtering
+            ulong minHeight = 0;//-1;
+            ulong maxHeight = 0;//-1;
+            if (heights.Count == 1)
+            {
+                minHeight = 0;
+                maxHeight = heights.First() - 1;
+            }
+            else
+            {
+                minHeight = heights.First() + 1;
+                maxHeight = heights.Last() - 1;
+            }
+
+            // Assert. some transactions filtered
+            int unfilteredCount = txs.Count;
+            txs = GetAndTestTxs(wallet, new MoneroTxQuery().SetMinHeight(minHeight).SetMaxHeight(maxHeight), null, true);
+            Assert.True(txs.Count < unfilteredCount);
+            foreach (MoneroTx tx in txs)
+            {
+                ulong? height = tx.GetBlock().GetHeight();
+                Assert.True(height >= minHeight && height <= maxHeight);
+            }
+        }
+    }
+
+    // Can get transactions with payment id
+    [Fact]
+    public virtual void TestGetTxsWithPaymentIds()
+    {
+        Assert.True(TEST_NON_RELAYS && !LITE_MODE);
+
+        // get random transactions with payment ids for testing
+        List<MoneroTxWallet> randomTxs = GetRandomTransactions(wallet, new MoneroTxQuery().SetHasPaymentId(true), 2, 5);
+        Assert.False(randomTxs.Count == 0, "No txs with payment ids to test");
+        foreach (MoneroTxWallet randomTx in randomTxs)
+        {
+            Assert.NotNull(randomTx.GetPaymentId());
+        }
+
+        // get transactions by payment id
+        List<string> paymentIds = new List<string>();
+        foreach (MoneroTxWallet tx in randomTxs) paymentIds.Add(tx.GetPaymentId());
+        Assert.True(paymentIds.Count > 1);
+        foreach (string paymentId in paymentIds)
+        {
+            List<MoneroTxWallet> _txs = GetAndTestTxs(wallet, new MoneroTxQuery().SetPaymentId(paymentId), null, null);
+            Assert.True(_txs.Count > 0);
+            Assert.NotNull(_txs[0].GetPaymentId());
+            MoneroUtils.ValidatePaymentId(_txs[0].GetPaymentId());
+        }
+
+        // get transactions by payment hashes
+        List<MoneroTxWallet> txs = GetAndTestTxs(wallet, new MoneroTxQuery().SetPaymentIds(paymentIds), null, null);
+        foreach (MoneroTxWallet tx in txs)
+        {
+            Assert.Contains(tx.GetPaymentId(), paymentIds);
+        }
+    }
+
+    // Returns all known fields of txs regardless of filtering
+    [Fact]
+    public virtual void TestGetTxsFieldsWithFiltering()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // fetch wallet txs
+        List<MoneroTxWallet> txs = wallet.GetTxs(new MoneroTxQuery().SetIsConfirmed(true));
+        foreach (MoneroTxWallet tx in txs)
+        {
+
+            // find _tx sent to same wallet with incoming transfer in different account than src account
+            if (tx.GetOutgoingTransfer() == null || tx.GetIncomingTransfers() == null) continue;
+            foreach (MoneroTransfer transfer in tx.GetIncomingTransfers())
+            {
+                if (transfer.GetAccountIndex() == tx.GetOutgoingTransfer().GetAccountIndex()) continue;
+
+                // fetch _tx with filtering
+                List<MoneroTxWallet> filteredTxs = wallet.GetTxs(new MoneroTxQuery().SetTransferQuery(new MoneroTransferQuery().SetIsIncoming(true).SetAccountIndex(transfer.GetAccountIndex())));
+                var query = new MoneroTxQuery().SetHashes([tx.GetHash()]);
+
+                MoneroTxWallet? filteredTx = null;
+                foreach (var fTx in filteredTxs)
+                {
+                    if (query.MeetsCriteria(fTx))
+                    {
+                        filteredTx = fTx;
+                        break;
+                    }
+                }
+
+                Assert.NotNull(filteredTx);
+
+                // txs should be the same (mergeable)
+                Assert.Equal(tx.GetHash(), filteredTx.GetHash());
+                tx.Merge(filteredTx);
+
+                // test is done
+                return;
+            }
+        }
+
+        // test did not fully execute
+        throw new Exception("Test requires _tx sent from/to different accounts of same wallet but none found; run send tests");
+    }
+
+    // Validates inputs when getting transactions
+    [Fact]
+    public virtual void TestValidateInputsGetTxs()
+    {
+        Assert.True(TEST_NON_RELAYS && !LITE_MODE);
+
+        // fetch random txs for testing
+        List<MoneroTxWallet> randomTxs = GetRandomTransactions(wallet, null, 3, 5);
+
+        // valid, invalid, and unknown _tx hashes for tests
+        string txHash = randomTxs[0].GetHash();
+        string invalidHash = "invalid_id";
+        string unknownHash1 = "6c4982f2499ece80e10b627083c4f9b992a00155e98bcba72a9588ccb91d0a61";
+        string unknownHash2 = "ff397104dd875882f5e7c66e4f852ee134f8cf45e21f0c40777c9188bc92e943";
+
+        // fetch unknown _tx hash
+        Assert.Null(wallet.GetTx(unknownHash1));
+
+        // fetch unknown _tx hash using query
+        Assert.Empty(wallet.GetTxs(new MoneroTxQuery().SetHash(unknownHash1)));
+
+        // fetch unknown _tx hash in collection
+        List<MoneroTxWallet> txs = wallet.GetTxs([txHash, unknownHash1]);
+        Assert.Single(txs);
+        Assert.Equal(txHash, txs[0].GetHash());
+
+        // fetch unknown _tx hashes in collection
+        txs = wallet.GetTxs([txHash, unknownHash1, unknownHash2]);
+        Assert.Single(txs);
+        Assert.Equal(txHash, txs[0].GetHash());
+
+        // fetch invalid hash
+        Assert.Null(wallet.GetTx(invalidHash));
+
+        // fetch invalid hash collection
+        txs = wallet.GetTxs([txHash, invalidHash]);
+        Assert.Single(txs);
+        Assert.Equal(txHash, txs[0].GetHash());
+
+        // fetch invalid hashes in collection
+        txs = wallet.GetTxs([txHash, invalidHash, "invalid_hash_2"]);
+        Assert.Single(txs);
+        Assert.Equal(txHash, txs[0].GetHash());
+
+        // test collection of invalid hashes
+        txs = wallet.GetTxs(new MoneroTxQuery().SetHashes([txHash, invalidHash, "invalid_hash_2"]));
+        Assert.Single(txs);
+        foreach (MoneroTxWallet tx in txs) TestTxWallet(tx);
+    }
+
+    // Can get transfers in the wallet, accounts, and subaddresses
+    [Fact]
+    public virtual void TestGetTransfers()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // get all transfers
+        GetAndTestTransfers(wallet, null, null, true);
+
+        // get transfers by account index
+        bool nonDefaultIncoming = false;
+        foreach (MoneroAccount account in wallet.GetAccounts(true))
+        {
+            List<MoneroTransfer> accountTransfers = GetAndTestTransfers(wallet, new MoneroTransferQuery().SetAccountIndex(account.GetIndex()), null, null);
+            foreach (MoneroTransfer transfer in accountTransfers) Assert.Equal(transfer.GetAccountIndex(), account.GetIndex());
+
+            // get transfers by subaddress index
+            List<MoneroTransfer> subaddressTransfers = new List<MoneroTransfer>();
+            foreach (MoneroSubaddress subaddress in account.GetSubaddresses()!)
+            {
+                List<MoneroTransfer> _transfers = GetAndTestTransfers(wallet, new MoneroTransferQuery().SetAccountIndex(subaddress.GetAccountIndex()).SetSubaddressIndex(subaddress.GetIndex()), null, null);
+                foreach (MoneroTransfer transfer in _transfers)
+                {
+
+                    // test account and subaddress indices
+                    Assert.Equal(subaddress.GetAccountIndex(), transfer.GetAccountIndex());
+                    if (transfer.IsIncoming() == true)
+                    {
+                        MoneroIncomingTransfer inTransfer = (MoneroIncomingTransfer)transfer;
+                        Assert.Equal(subaddress.GetIndex(), inTransfer.GetSubaddressIndex());
+                        if (transfer.GetAccountIndex() != 0 && inTransfer.GetSubaddressIndex() != 0) nonDefaultIncoming = true;
+                    }
+                    else
+                    {
+                        MoneroOutgoingTransfer outTransfer = (MoneroOutgoingTransfer)transfer;
+                        Assert.Contains((uint)subaddress.GetIndex()!, outTransfer.GetSubaddressIndices()!);
+                        if (transfer.GetAccountIndex() != 0)
+                        {
+                            foreach (int subaddrIdx in outTransfer.GetSubaddressIndices()!)
+                            {
+                                if (subaddrIdx > 0)
+                                {
+                                    nonDefaultIncoming = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+
+                    // don't add duplicates TODO monero-wallet-rpc: duplicate outgoing transfers returned foreach different subaddress indices, way to return outgoing subaddress indices?
+                    bool found = false;
+                    foreach (MoneroTransfer subaddressTransfer in subaddressTransfers)
+                    {
+                        if (transfer.ToString().Equals(subaddressTransfer.ToString()) && transfer.GetTx()!.GetHash()!.Equals(subaddressTransfer.GetTx()!.GetHash()))
+                        {
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (!found) subaddressTransfers.Add(transfer);
+                }
+            }
+            Assert.Equal(accountTransfers.Count, subaddressTransfers.Count);
+
+            // collect unique subaddress indices
+            HashSet<uint> subaddressIndices = new HashSet<uint>();
+            foreach (MoneroTransfer transfer in subaddressTransfers)
+            {
+                if (transfer.IsIncoming() == true) subaddressIndices.Add((uint)((MoneroIncomingTransfer)transfer).GetSubaddressIndex());
+                else
+                {
+                    foreach (var subIdx in ((MoneroOutgoingTransfer)transfer).GetSubaddressIndices()) subaddressIndices.Add(subIdx);
+                }
+            }
+
+            // get and test transfers by subaddress indices
+            List<MoneroTransfer> transfers = GetAndTestTransfers(wallet, new MoneroTransferQuery().SetAccountIndex(account.GetIndex()).SetSubaddressIndices(new List<uint>(subaddressIndices)), null, null);
+            //if (transfers.Count != subaddressTransfers.Count) System.out.println("WARNING: outgoing transfers always from subaddress 0 (monero-wallet-rpc #5171)");
+            Assert.Equal(subaddressTransfers.Count, transfers.Count); // TODO monero-wallet-rpc: these may not be equal because outgoing transfers are always from subaddress 0 (#5171) and/or incoming transfers from/to same account are occluded (#4500)
+            foreach (MoneroTransfer transfer in transfers)
+            {
+                Assert.Equal(transfer.GetAccountIndex(), account.GetIndex());
+                if (transfer.IsIncoming() == true) Assert.Contains((uint)((MoneroIncomingTransfer)transfer).GetSubaddressIndex(), subaddressIndices);
+                else
+                {
+                    HashSet<uint> intersections = new HashSet<uint>(subaddressIndices);
+                    intersections.IntersectWith(((MoneroOutgoingTransfer)transfer).GetSubaddressIndices());
+                    Assert.True(intersections.Count > 0, "Subaddresses must overlap");
+                }
+            }
+        }
+
+        // ensure transfer found with non-zero account and subaddress indices
+        Assert.True(nonDefaultIncoming, "No transfers found in non-default account and subaddress; run send-to-multiple tests");
+    }
+
+    // Can get transfers with additional configuration
+    [Fact]
+    public virtual void TestGetTransfersWithQuery()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // get incoming transfers
+        List<MoneroTransfer> transfers = GetAndTestTransfers(wallet, new MoneroTransferQuery().SetIsIncoming(true), null, true);
+        foreach (MoneroTransfer transfer in transfers) Assert.True(transfer.IsIncoming());
+
+        // get outgoing transfers
+        transfers = GetAndTestTransfers(wallet, new MoneroTransferQuery().SetIsOutgoing(true), null, true);
+        foreach (MoneroTransfer transfer in transfers) Assert.True(transfer.IsOutgoing());
+
+        // get confirmed transfers to account 0
+        transfers = GetAndTestTransfers(wallet, new MoneroTransferQuery().SetAccountIndex(0).SetTxQuery(new MoneroTxQuery().SetIsConfirmed(true)), null, true);
+        foreach (MoneroTransfer transfer in transfers)
+        {
+            Assert.Equal(0, (int)transfer.GetAccountIndex());
+            Assert.True(transfer.GetTx().IsConfirmed());
+        }
+
+        // get confirmed transfers to [1, 2]
+        transfers = GetAndTestTransfers(wallet, new MoneroTransferQuery().SetAccountIndex(1).SetSubaddressIndex(2).SetTxQuery(new MoneroTxQuery().SetIsConfirmed(true)), null, true);
+        foreach (MoneroTransfer transfer in transfers)
+        {
+            Assert.Equal(1, (int)transfer.GetAccountIndex());
+            if (transfer.IsIncoming() == true) Assert.Equal(2, (int)((MoneroIncomingTransfer)transfer).GetSubaddressIndex());
+            else Assert.Contains((uint)2, ((MoneroOutgoingTransfer)transfer).GetSubaddressIndices());
+            Assert.True(transfer.GetTx().IsConfirmed());
+        }
+
+        // get transfers in the _tx pool
+        transfers = GetAndTestTransfers(wallet, new MoneroTransferQuery().SetTxQuery(new MoneroTxQuery().SetInTxPool(true)), null, null);
+        foreach (MoneroTransfer transfer in transfers)
+        {
+            Assert.Equal(true, transfer.GetTx().InTxPool());
+        }
+
+        // get random transactions
+        List<MoneroTxWallet> txs = GetRandomTransactions(wallet, null, 3, 5);
+
+        // get transfers with a _tx hash
+        List<string> txHashes = new List<string>();
+        foreach (MoneroTxWallet tx in txs)
+        {
+            txHashes.Add(tx.GetHash());
+            transfers = GetAndTestTransfers(wallet, new MoneroTransferQuery().SetTxQuery(new MoneroTxQuery().SetHash(tx.GetHash())), null, true);
+            foreach (MoneroTransfer transfer in transfers) Assert.Equal(tx.GetHash(), transfer.GetTx().GetHash());
+        }
+
+        // get transfers with _tx hashes
+        transfers = GetAndTestTransfers(wallet, new MoneroTransferQuery().SetTxQuery(new MoneroTxQuery().SetHashes(txHashes)), null, true);
+        foreach (MoneroTransfer transfer in transfers) Assert.Contains(transfer.GetTx().GetHash(), txHashes);
+
+        // TODO: test that transfers with the same txHash have the same _tx reference
+
+        // TODO: test transfers destinations
+
+        // get transfers with pre-built query that are confirmed and have outgoing destinations
+        MoneroTransferQuery transferQuery = new MoneroTransferQuery();
+        transferQuery.SetIsOutgoing(true);
+        transferQuery.SetHasDestinations(true);
+        transferQuery.SetTxQuery(new MoneroTxQuery().SetIsConfirmed(true));
+        transfers = GetAndTestTransfers(wallet, transferQuery, null, null);
+        foreach (MoneroTransfer transfer in transfers)
+        {
+            Assert.Equal(true, transfer.IsOutgoing());
+            Assert.True(((MoneroOutgoingTransfer)transfer).GetDestinations().Count > 0);
+            Assert.Equal(true, transfer.GetTx().IsConfirmed());
+        }
+
+        // get incoming transfers to account 0 which has outgoing transfers (i.e. originated from the same wallet)
+        transfers = wallet.GetTransfers(new MoneroTransferQuery().SetAccountIndex(1).SetIsIncoming(true).SetTxQuery(new MoneroTxQuery().SetIsOutgoing(true)));
+        Assert.False(transfers.Count == 0);
+        foreach (MoneroTransfer transfer in transfers)
+        {
+            Assert.True(transfer.IsIncoming());
+            Assert.Equal(1, (int)transfer.GetAccountIndex());
+            Assert.True(transfer.GetTx().IsOutgoing());
+            Assert.Null(transfer.GetTx().GetOutgoingTransfer());
+        }
+
+        // get incoming transfers to a specific address
+        string subaddress = wallet.GetAddress(1, 0);
+        transfers = wallet.GetTransfers(new MoneroTransferQuery().SetIsIncoming(true).SetAddress(subaddress));
+        Assert.True(transfers.Count > 0);
+        foreach (MoneroTransfer transfer in transfers)
+        {
+            Assert.True(transfer is MoneroIncomingTransfer);
+            Assert.True(1 == (uint)transfer.GetAccountIndex());
+            Assert.True(0 == (uint)((MoneroIncomingTransfer)transfer).GetSubaddressIndex());
+            Assert.Equal(subaddress, ((MoneroIncomingTransfer)transfer).GetAddress());
+        }
+    }
+
+    // Validates inputs when getting transfers
+    [Fact]
+    public virtual void TestValidateInputsGetTransfers()
+    {
+        Assert.True(TEST_NON_RELAYS && !LITE_MODE);
+
+        // test with invalid hash
+        List<MoneroTransfer> transfers = wallet.GetTransfers(new MoneroTransferQuery().SetTxQuery(new MoneroTxQuery().SetHash("invalid_id")));
+        Assert.Empty(transfers);
+
+        // test invalid hash in collection
+        List<MoneroTxWallet> randomTxs = GetRandomTransactions(wallet, null, 3, 5);
+        transfers = wallet.GetTransfers(new MoneroTransferQuery().SetTxQuery(new MoneroTxQuery().SetHashes([randomTxs[0].GetHash(), "invalid_id"])));
+        Assert.True(transfers.Count > 0);
+        MoneroTxWallet tx = transfers[0].GetTx();
+        foreach (MoneroTransfer transfer in transfers) Assert.True(tx == transfer.GetTx());
+
+        // test unused subaddress indices
+        transfers = wallet.GetTransfers(new MoneroTransferQuery().SetAccountIndex(0).SetSubaddressIndices([1234907]));
+        Assert.True(transfers.Count == 0);
+    }
+
+    // Can get incoming and outgoing transfers using convenience methods
+    [Fact]
+    public virtual void TestGetIncomingOutgoingTransfers()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // get incoming transfers
+        List<MoneroIncomingTransfer> inTransfers = wallet.GetIncomingTransfers();
+        Assert.False(inTransfers.Count == 0);
+        foreach (MoneroIncomingTransfer transfer in inTransfers)
+        {
+            Assert.True(transfer.IsIncoming());
+            TestTransfer(transfer, null);
+        }
+
+        // get incoming transfers with query
+        ulong? amount = inTransfers[0].GetAmount();
+        uint? accountIdx = inTransfers[0].GetAccountIndex();
+        uint? subaddressIdx = inTransfers[0].GetSubaddressIndex();
+        inTransfers = wallet.GetIncomingTransfers(new MoneroTransferQuery().SetAmount(amount).SetAccountIndex(accountIdx).SetSubaddressIndex(subaddressIdx).SetTxQuery(new MoneroTxQuery().SetIsConfirmed(true)));
+        Assert.False(inTransfers.Count == 0);
+        foreach (MoneroIncomingTransfer transfer in inTransfers)
+        {
+            Assert.True(transfer.IsIncoming());
+            Assert.Equal(amount, transfer.GetAmount());
+            Assert.Equal(accountIdx, (uint)transfer.GetAccountIndex());
+            Assert.Equal(subaddressIdx, (uint)transfer.GetSubaddressIndex());
+            TestTransfer(transfer, null);
+        }
+
+        // get incoming transfers with contradictory query
+        try
+        {
+            inTransfers = wallet.GetIncomingTransfers(new MoneroTransferQuery().SetIsIncoming(false));
+        }
+        catch (MoneroError e)
+        {
+            Assert.Equal("Transfer query contradicts getting incoming transfers", e.Message);
+        }
+
+        // get outgoing transfers
+        List<MoneroOutgoingTransfer> outTransfers = wallet.GetOutgoingTransfers();
+        Assert.False(outTransfers.Count == 0);
+        foreach (MoneroOutgoingTransfer transfer in outTransfers)
+        {
+            Assert.True(transfer.IsOutgoing());
+            TestTransfer(transfer, null);
+        }
+
+        // get outgoing transfers with query
+        outTransfers = wallet.GetOutgoingTransfers(new MoneroTransferQuery().SetAccountIndex(accountIdx).SetSubaddressIndex(subaddressIdx));
+        Assert.False(outTransfers.Count == 0);
+        foreach (MoneroOutgoingTransfer transfer in outTransfers)
+        {
+            Assert.True(transfer.IsOutgoing());
+            Assert.Equal(accountIdx, (uint)transfer.GetAccountIndex());
+            Assert.Contains((uint)subaddressIdx, transfer.GetSubaddressIndices());
+            TestTransfer(transfer, null);
+        }
+
+        // get outgoing transfers with contradictory query
+        try
+        {
+            outTransfers = wallet.GetOutgoingTransfers(new MoneroTransferQuery().SetIsOutgoing(false));
+        }
+        catch (MoneroError e)
+        {
+            Assert.Equal("Transfer query contradicts getting outgoing transfers", e.Message);
+        }
+    }
+
+    // Can get outputs in the wallet, accounts, and subaddresses
+    [Fact]
+    public virtual void TestGetOutputs()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // get all outputs
+        GetAndTestOutputs(wallet, null, true);
+
+        // get outputs for each account
+        bool nonDefaultIncoming = false;
+        List<MoneroAccount> accounts = wallet.GetAccounts(true);
+        foreach (MoneroAccount account in accounts)
+        {
+
+            // determine if account is used
+            bool isUsed = false;
+            foreach (MoneroSubaddress subaddress in account.GetSubaddresses()!) if (subaddress.IsUsed() == true) isUsed = true;
+
+            // get outputs by account index
+            List<MoneroOutputWallet> accountOutputs = GetAndTestOutputs(wallet, new MoneroOutputQuery().SetAccountIndex(account.GetIndex()), isUsed);
+            foreach (MoneroOutputWallet output in accountOutputs) Assert.Equal(account.GetIndex(), output.GetAccountIndex());
+
+            // get outputs by subaddress index
+            List<MoneroOutputWallet> subaddressOutputs = new List<MoneroOutputWallet>();
+            foreach (MoneroSubaddress subaddress in account.GetSubaddresses()!)
+            {
+                List<MoneroOutputWallet> _outputs = GetAndTestOutputs(wallet, new MoneroOutputQuery().SetAccountIndex(account.GetIndex()).SetSubaddressIndex(subaddress.GetIndex()), subaddress.IsUsed());
+                foreach (MoneroOutputWallet output in _outputs)
+                {
+                    Assert.Equal(subaddress.GetAccountIndex(), output.GetAccountIndex());
+                    Assert.Equal(subaddress.GetIndex(), output.GetSubaddressIndex());
+                    if (output.GetAccountIndex() != 0 && output.GetSubaddressIndex() != 0) nonDefaultIncoming = true;
+                    subaddressOutputs.Add(output);
+                }
+            }
+            Assert.Equal(subaddressOutputs.Count, accountOutputs.Count);
+
+            // get outputs by subaddress indices
+            HashSet<uint> subaddressIndices = new HashSet<uint>();
+            foreach (MoneroOutputWallet output in subaddressOutputs) subaddressIndices.Add((uint)output.GetSubaddressIndex()!);
+            List<MoneroOutputWallet> outputs = GetAndTestOutputs(wallet, new MoneroOutputQuery().SetAccountIndex(account.GetIndex()).SetSubaddressIndices(new List<uint>(subaddressIndices)), isUsed);
+            Assert.Equal(outputs.Count, subaddressOutputs.Count);
+            foreach (MoneroOutputWallet output in outputs)
+            {
+                Assert.Equal(account.GetIndex(), output.GetAccountIndex());
+                Assert.Contains((uint)output.GetSubaddressIndex(), subaddressIndices);
+            }
+        }
+
+        // ensure output found with non-zero account and subaddress indices
+        Assert.True(nonDefaultIncoming, "No outputs found in non-default account and subaddress; run send-to-multiple tests");
+    }
+
+    // Can get outputs with additional configuration
+    [Fact]
+    public virtual void TestGetOutputsWithQuery()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // get unspent outputs to account 0
+        List<MoneroOutputWallet> outputs = GetAndTestOutputs(wallet, new MoneroOutputQuery().SetAccountIndex(0).SetIsSpent(false), null);
+        foreach (MoneroOutputWallet output in outputs)
+        {
+            Assert.True(0 == (uint)output.GetAccountIndex());
+            Assert.Equal(false, output.IsSpent());
+        }
+
+        // get spent outputs to account 1
+        outputs = GetAndTestOutputs(wallet, new MoneroOutputQuery().SetAccountIndex(1).SetIsSpent(true), true);
+        foreach (MoneroOutputWallet output in outputs)
+        {
+            Assert.Equal(1, (int)output.GetAccountIndex());
+            Assert.Equal(true, output.IsSpent());
+        }
+
+        // get random transactions
+        List<MoneroTxWallet> txs = GetRandomTransactions(wallet, new MoneroTxQuery().SetIsConfirmed(true), 3, 5);
+
+        // get outputs with a _tx hash
+        List<string> txHashes = new List<string>();
+        foreach (MoneroTxWallet tx in txs)
+        {
+            txHashes.Add(tx.GetHash());
+            outputs = GetAndTestOutputs(wallet, new MoneroOutputQuery().SetTxQuery(new MoneroTxQuery().SetHash(tx.GetHash())), true);
+            foreach (MoneroOutputWallet output in outputs) Assert.Equal(output.GetTx().GetHash(), tx.GetHash());
+        }
+
+        // get outputs with _tx hashes
+        outputs = GetAndTestOutputs(wallet, new MoneroOutputQuery().SetTxQuery(new MoneroTxQuery().SetHashes(txHashes)), true);
+        foreach (MoneroOutputWallet output in outputs) Assert.Contains(output.GetTx().GetHash(), txHashes);
+
+        // get confirmed outputs to specific subaddress with pre-built query
+        uint accountIdx = 0;
+        uint subaddressIdx = 1;
+        MoneroOutputQuery outputQuery = new MoneroOutputQuery();
+        outputQuery.SetAccountIndex(accountIdx).SetSubaddressIndex(subaddressIdx);
+        outputQuery.SetTxQuery(new MoneroTxQuery().SetIsConfirmed(true));
+        outputQuery.SetMinAmount(TestUtils.MAX_FEE);
+        outputs = GetAndTestOutputs(wallet, outputQuery, true);
+        foreach (MoneroOutputWallet output in outputs)
+        {
+            Assert.Equal(accountIdx, (uint)output.GetAccountIndex());
+            Assert.Equal(subaddressIdx, (uint)output.GetSubaddressIndex());
+            Assert.Equal(true, output.GetTx().IsConfirmed());
+            Assert.True(output.GetAmount() >= TestUtils.MAX_FEE);
+        }
+
+        // get output by _key image
+        string keyImage = outputs[0].GetKeyImage().GetHex();
+        outputs = wallet.GetOutputs(new MoneroOutputQuery().SetKeyImage(new MoneroKeyImage(keyImage)));
+        Assert.Single(outputs);
+        Assert.Equal(keyImage, outputs[0].GetKeyImage().GetHex());
+
+        // get outputs whose transaction is confirmed and has incoming and outgoing transfers
+        outputs = wallet.GetOutputs(new MoneroOutputQuery().SetTxQuery(new MoneroTxQuery().SetIsConfirmed(true).SetIsIncoming(true).SetIsOutgoing(true).SetIncludeOutputs(true)));
+        Assert.False(outputs.Count == 0);
+        foreach (MoneroOutputWallet output in outputs)
+        {
+            Assert.True(output.GetTx().IsIncoming());
+            Assert.True(output.GetTx().IsOutgoing());
+            Assert.True(output.GetTx().IsConfirmed());
+            Assert.False(output.GetTx().GetOutputsWallet().Count == 0);
+            Assert.Contains(output, output.GetTx().GetOutputsWallet());
+        }
+    }
+
+    // Validates inputs when getting wallet outputs
+    [Fact]
+    public virtual void TestValidateInputsGetOutputs()
+    {
+        Assert.True(TEST_NON_RELAYS && !LITE_MODE);
+
+        // test with invalid hash
+        List<MoneroOutputWallet> outputs = wallet.GetOutputs(new MoneroOutputQuery().SetTxQuery(new MoneroTxQuery().SetHash("invalid_id")));
+        Assert.True(0 == outputs.Count);
+
+        // test invalid hash in collection
+        List<MoneroTxWallet> randomTxs = GetRandomTransactions(wallet, new MoneroTxQuery().SetIsConfirmed(true).SetIncludeOutputs(true), 3, 5);
+        foreach (MoneroTxWallet randomTx in randomTxs) Assert.False(randomTx.GetOutputs().Count == 0);
+        outputs = wallet.GetOutputs(new MoneroOutputQuery().SetTxQuery(new MoneroTxQuery().SetHashes([randomTxs[0].GetHash(), "invalid_id"])));
+        Assert.False(outputs.Count == 0);
+        Assert.Equal(outputs.Count, randomTxs[0].GetOutputs().Count);
+        MoneroTxWallet tx = outputs[0].GetTx();
+        foreach (MoneroOutputWallet output in outputs) Assert.True(tx == output.GetTx());
+    }
+
+    // Can export outputs in hex format
+    [Fact]
+    public virtual void TestExportOutputs()
+    {
+        Assert.True(TEST_NON_RELAYS);
+        string outputsHex = wallet.ExportOutputs();
+        Assert.NotNull(outputsHex);  // TODO: this will fail if wallet has no outputs; run these tests on new wallet
+        Assert.True(outputsHex.Length > 0);
+
+        // wallet exports outputs since last export by default
+        outputsHex = wallet.ExportOutputs();
+        string outputsHexAll = wallet.ExportOutputs(true);
+        Assert.True(outputsHexAll.Length > outputsHex.Length);
+    }
+
+    // Can import outputs in hex format
+    [Fact]
+    public virtual void TestImportOutputs()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // export outputs hex
+        string outputsHex = wallet.ExportOutputs();
+
+        // import outputs hex
+        if (outputsHex != null)
+        {
+            int numImported = wallet.ImportOutputs(outputsHex);
+            Assert.True(numImported >= 0);
+        }
+    }
+
+    // Has correct accounting across accounts, subaddresses, txs, transfers, and outputs
+    [Fact]
+    public virtual void TestAccounting()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // pre-fetch wallet balances, accounts, subaddresses, and txs
+        ulong walletBalance = wallet.GetBalance();
+        ulong walletUnlockedBalance = wallet.GetUnlockedBalance();
+        List<MoneroAccount> accounts = wallet.GetAccounts(true);  // includes subaddresses
+
+        // test wallet balance
+        TestUtils.TestUnsignedBigInteger(walletBalance);
+        TestUtils.TestUnsignedBigInteger(walletUnlockedBalance);
+        Assert.True(walletBalance >= walletUnlockedBalance);
+
+        // test that wallet balance equals sum of account balances
+        ulong accountsBalance = 0;
+        ulong accountsUnlockedBalance = 0;
+        foreach (MoneroAccount account in accounts)
+        {
+            TestAccount(account); // test that account balance equals sum of subaddress balances
+            accountsBalance += (ulong)account.GetBalance()!;
+            accountsUnlockedBalance += (ulong)account.GetUnlockedBalance()!;
+        }
+        Assert.Equal(walletBalance, accountsBalance);
+        Assert.Equal(walletUnlockedBalance, accountsUnlockedBalance);
+
+        // balance may not equal sum of unspent outputs if unconfirmed txs
+        // TODO monero-wallet-rpc: reason not to return unspent outputs on unconfirmed txs? then this isn't necessary
+        List<MoneroTxWallet> txs = wallet.GetTxs();
+        bool hasUnconfirmedTx = false;
+        foreach (MoneroTxWallet tx in txs) if (tx.InTxPool() == true) hasUnconfirmedTx = true;
+
+        // wallet balance is sum of all unspent outputs
+        ulong walletSum = 0;
+        foreach (MoneroOutputWallet output in wallet.GetOutputs(new MoneroOutputQuery().SetIsSpent(false))) walletSum += (ulong)output.GetAmount()!;
+        if (!walletBalance.Equals(walletSum))
+        {
+            // txs may have changed in between calls so retry test
+            walletSum = 0;
+            foreach (MoneroOutputWallet output in wallet.GetOutputs(new MoneroOutputQuery().SetIsSpent(false))) walletSum += (ulong)output.GetAmount()!;
+            if (!walletBalance.Equals(walletSum)) Assert.True(hasUnconfirmedTx, "Wallet balance must equal sum of unspent outputs if no unconfirmed txs");
+        }
+
+        // account balances are sum of their unspent outputs
+        foreach (MoneroAccount account in accounts)
+        {
+            ulong accountSum = 0;
+            List<MoneroOutputWallet> accountOutputs = wallet.GetOutputs(new MoneroOutputQuery().SetAccountIndex(account.GetIndex()).SetIsSpent(false));
+            foreach (MoneroOutputWallet output in accountOutputs) accountSum += (ulong)output.GetAmount()!;
+            if (!account.GetBalance().Equals(accountSum)) Assert.True(hasUnconfirmedTx, "Account balance must equal sum of its unspent outputs if no unconfirmed txs");
+
+            // subaddress balances are sum of their unspent outputs
+            foreach (MoneroSubaddress subaddress in account.GetSubaddresses()!)
+            {
+                ulong subaddressSum = 0;
+                List<MoneroOutputWallet> subaddressOutputs = wallet.GetOutputs(new MoneroOutputQuery().SetAccountIndex(account.GetIndex()).SetSubaddressIndex(subaddress.GetIndex()).SetIsSpent(false));
+                foreach (MoneroOutputWallet output in subaddressOutputs) subaddressSum += (ulong)output.GetAmount()!;
+                if (!subaddress.GetBalance().Equals(subaddressSum)) Assert.True(hasUnconfirmedTx, "Subaddress balance must equal sum of its unspent outputs if no unconfirmed txs");
+            }
+        }
+    }
+
+    // Can checkReserve a transfer using the transaction's secret key and the destination
+    [Fact]
+    public virtual void TestCheckTxKey()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // get random txs that are confirmed and have outgoing destinations
+        List<MoneroTxWallet> txs;
+        try
+        {
+            txs = GetRandomTransactions(wallet, new MoneroTxQuery().SetIsConfirmed(true).SetTransferQuery(new MoneroTransferQuery().SetHasDestinations(true)), 1, MAX_TX_PROOFS);
+        }
+        catch (Exception e)
+        {
+            if (e.Message.Contains("found with")) Assert.Fail("No txs with outgoing destinations found; run send Tests");
+            throw;
+        }
+
+        // Test good checks
+        Assert.True(txs.Count > 0, "No transactions found with outgoing destinations");
+        foreach (MoneroTxWallet _tx in txs)
+        {
+            string _key = wallet.GetTxKey(_tx.GetHash());
+            Assert.False(_tx.GetOutgoingTransfer().GetDestinations().Count == 0);
+            foreach (MoneroDestination dest in _tx.GetOutgoingTransfer().GetDestinations())
+            {
+                MoneroCheckTx _check = wallet.CheckTxKey(_tx.GetHash(), _key, dest.GetAddress());
+                if (dest.GetAmount() > 0)
+                {
+                    // TODO monero-wallet-rpc: indicates amount received amount is 0 despite transaction with transfer to this address
+                    // TODO monero-wallet-rpc: returns 0-4 errors, not consistent
+                    //        Assert.True(_check.GetReceivedAmount().CompareTo(BigInteger.valueOf(0)) > 0);
+                    if (_check.GetReceivedAmount().Equals(0))
+                    {
+                        Console.WriteLine("WARNING: _key proof indicates no funds received despite transfer (txid=" + _tx.GetHash() + ", _key=" + _key + ", address=" + dest.GetAddress() + ", amount=" + dest.GetAmount() + ")");
+                    }
+                }
+                else Assert.True(_check.GetReceivedAmount().Equals(0));
+                TestCheckTx(_tx, _check);
+            }
+        }
+
+        // Test get _tx _key with invalid hash
+        try
+        {
+            wallet.GetTxKey("invalid_tx_id");
+            Assert.Fail("Should throw exception foreach invalid _key");
+        }
+        catch (MoneroError e)
+        {
+            TestInvalidTxHashError(e);
+        }
+
+        // Test _check with invalid _tx hash
+        MoneroTxWallet tx = txs[0];
+        string key = wallet.GetTxKey(tx.GetHash());
+        MoneroDestination destination = tx.GetOutgoingTransfer().GetDestinations()[0];
+        try
+        {
+            wallet.CheckTxKey("invalid_tx_id", key, destination.GetAddress());
+            Assert.Fail("Should have thrown exception");
+        }
+        catch (MoneroError e)
+        {
+            TestInvalidTxHashError(e);
+        }
+
+        // Test _check with invalid _key
+        try
+        {
+            wallet.CheckTxKey(tx.GetHash(), "invalid_tx_key", destination.GetAddress());
+            Assert.Fail("Should have thrown exception");
+        }
+        catch (MoneroError e)
+        {
+            TestInvalidTxKeyError(e);
+        }
+
+        // Test _check with invalid address
+        try
+        {
+            wallet.CheckTxKey(tx.GetHash(), key, "invalid_tx_address");
+            throw new Exception("Should have thrown exception");
+        }
+        catch (MoneroError e)
+        {
+            TestInvalidAddressError(e);
+        }
+
+        // Test _check with different address
+        string? differentAddress = null;
+        foreach (MoneroTxWallet aTx in wallet.GetTxs())
+        {
+            if (aTx.GetOutgoingTransfer() == null || aTx.GetOutgoingTransfer().GetDestinations() == null) continue;
+            foreach (MoneroDestination aDestination in aTx.GetOutgoingTransfer().GetDestinations())
+            {
+                if (!aDestination.GetAddress().Equals(destination.GetAddress()))
+                {
+                    differentAddress = aDestination.GetAddress();
+                    break;
+                }
+            }
+        }
+        if (differentAddress == null) throw new Exception("Could not get a different outgoing address to Test; run send Tests");
+        MoneroCheckTx check = wallet.CheckTxKey(tx.GetHash(), key, differentAddress);
+        Assert.True(check.IsGood());
+        Assert.True(check.GetReceivedAmount() >= 0);
+        TestCheckTx(tx, check);
+    }
+
+    // Can prove a transaction by getting its sig
+    [Fact]
+    public virtual void TestCheckTxProof()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // get random txs with outgoing destinations
+        List<MoneroTxWallet> txs;
+        try
+        {
+            txs = GetRandomTransactions(wallet, new MoneroTxQuery().SetTransferQuery(new MoneroTransferQuery().SetHasDestinations(true)), 2, MAX_TX_PROOFS);
+        }
+        catch (Exception e)
+        {
+            if (e.Message.Contains("found with")) Assert.Fail("No txs with outgoing destinations found; run send Tests");
+            throw;
+        }
+
+        // Test good checks with messages
+        foreach (MoneroTxWallet _tx in txs)
+        {
+            foreach (MoneroDestination dest in _tx.GetOutgoingTransfer().GetDestinations())
+            {
+                string sig = wallet.GetTxProof(_tx.GetHash(), dest.GetAddress(), "This transaction definitely happened.");
+                MoneroCheckTx _check = wallet.CheckTxProof(_tx.GetHash(), dest.GetAddress(), "This transaction definitely happened.", sig);
+                TestCheckTx(_tx, _check);
+            }
+        }
+
+        // Test good checkReserve without message
+        MoneroTxWallet tx = txs[0];
+        MoneroDestination destination = tx.GetOutgoingTransfer().GetDestinations()[0];
+        string signature = wallet.GetTxProof(tx.GetHash(), destination.GetAddress());
+        MoneroCheckTx check = wallet.CheckTxProof(tx.GetHash(), destination.GetAddress(), null, signature);
+        TestCheckTx(tx, check);
+
+        // Test get proof with invalid hash
+        try
+        {
+            wallet.GetTxProof("invalid_tx_id", destination.GetAddress());
+            throw new Exception("Should throw exception for invalid key");
+        }
+        catch (MoneroError e)
+        {
+            TestInvalidTxHashError(e);
+        }
+
+        // Test checkReserve with invalid _tx hash
+        try
+        {
+            wallet.CheckTxProof("invalid_tx_id", destination.GetAddress(), null, signature);
+            Assert.Fail("Should have thrown exception");
+        }
+        catch (MoneroError e)
+        {
+            TestInvalidTxHashError(e);
+        }
+
+        // Test checkReserve with invalid address
+        try
+        {
+            wallet.CheckTxProof(tx.GetHash(), "invalid_tx_address", null, signature);
+            Assert.Fail("Should have thrown exception");
+        }
+        catch (MoneroError e)
+        {
+            TestInvalidAddressError(e);
+        }
+
+        // Test checkReserve with wrong message
+        signature = wallet.GetTxProof(tx.GetHash(), destination.GetAddress(), "This is the right message");
+        check = wallet.CheckTxProof(tx.GetHash(), destination.GetAddress(), "This is the wrong message", signature);
+        Assert.False(check.IsGood());
+        TestCheckTx(tx, check);
+
+        // Test checkReserve with wrong sig
+        string wrongSignature = wallet.GetTxProof(txs[1].GetHash(), txs[1].GetOutgoingTransfer().GetDestinations()[0].GetAddress(), "This is the right message");
+        try
+        {
+            check = wallet.CheckTxProof(tx.GetHash(), destination.GetAddress(), "This is the right message", wrongSignature);
+            Assert.False(check.IsGood());
+        }
+        catch (MoneroError e)
+        {
+            TestInvalidSignatureError(e);
+        }
+
+        // Test checkReserve with empty sig
+        try
+        {
+            check = wallet.CheckTxProof(tx.GetHash(), destination.GetAddress(), "This is the right message", "");
+            Assert.False(check.IsGood());
+        }
+        catch (MoneroError e)
+        {
+            Assert.Equal("Must provide sig to checkReserve _tx proof", e.Message);
+        }
+    }
+
+    // Can prove a spend using a generated signature and no destination public address
+    [Fact]
+    public virtual void TestCheckSpendProof()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // get random confirmed outgoing txs
+        List<MoneroTxWallet> txs = GetRandomTransactions(wallet, new MoneroTxQuery().SetIsIncoming(false).SetInTxPool(false).SetIsFailed(false), 2, MAX_TX_PROOFS);
+        foreach (MoneroTxWallet _tx in txs)
+        {
+            Assert.Equal(true, _tx.IsConfirmed());
+            Assert.Null(_tx.GetIncomingTransfers());
+            Assert.NotNull(_tx.GetOutgoingTransfer());
+        }
+
+        // test good checks with messages
+        foreach (MoneroTxWallet _tx in txs)
+        {
+            string sig = wallet.GetSpendProof(_tx.GetHash(), "I am a message.");
+            Assert.True(wallet.CheckSpendProof(_tx.GetHash(), "I am a message.", sig));
+        }
+
+        // test good checkReserve without message
+        MoneroTxWallet tx = txs[0];
+        string signature = wallet.GetSpendProof(tx.GetHash());
+        Assert.True(wallet.CheckSpendProof(tx.GetHash(), null, signature));
+
+        // test get proof with invalid hash
+        try
+        {
+            wallet.GetSpendProof("invalid_tx_id");
+            throw new Exception("Should throw exception foreach invalid key");
+        }
+        catch (MoneroError e)
+        {
+            TestInvalidTxHashError(e);
+        }
+
+        // test checkReserve with invalid _tx hash
+        try
+        {
+            wallet.CheckSpendProof("invalid_tx_id", null, signature);
+            throw new Exception("Should have thrown exception");
+        }
+        catch (MoneroError e)
+        {
+            TestInvalidTxHashError(e);
+        }
+
+        // test checkReserve with invalid message
+        signature = wallet.GetSpendProof(tx.GetHash(), "This is the right message");
+        Assert.False(wallet.CheckSpendProof(tx.GetHash(), "This is the wrong message", signature));
+
+        // test checkReserve with wrong sig
+        signature = wallet.GetSpendProof(txs[1].GetHash(), "This is the right message");
+        Assert.False(wallet.CheckSpendProof(tx.GetHash(), "This is the right message", signature));
+    }
+
+    // Can prove reserves in the wallet
+    [Fact]
+    public virtual void TestGetReserveProofWallet()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // get proof of entire wallet
+        string signature = wallet.GetReserveProofWallet("Test message");
+
+        // checkReserve proof of entire wallet
+        MoneroCheckReserve check = wallet.CheckReserveProof(wallet.GetPrimaryAddress(), "Test message", signature);
+        Assert.True(check.IsGood());
+        TestCheckReserve(check);
+        ulong balance = wallet.GetBalance();
+        if (!balance.Equals(check.GetTotalAmount()))
+        {  // TODO monero-wallet-rpc: this checkReserve Assert.Fails with unconfirmed txs
+            List<MoneroTxWallet> unconfirmedTxs = wallet.GetTxs(new MoneroTxQuery().SetInTxPool(true));
+            Assert.True(unconfirmedTxs.Count > 0, "Reserve amount must equal balance unless wallet has unconfirmed txs");
+        }
+
+        // Test different wallet address
+        string differentAddress = TestUtils.GetExternalWalletAddress();
+        try
+        {
+            wallet.CheckReserveProof(differentAddress, "Test message", signature);
+            Assert.Fail("Should have thrown exception");
+        }
+        catch (MoneroError e)
+        {
+            TestNoSubaddressError(e);
+        }
+
+        // Test subaddress
+        try
+        {
+            wallet.CheckReserveProof((wallet.GetSubaddress(0, 1)).GetAddress(), "Test message", signature);
+            Assert.Fail("Should have thrown exception");
+        }
+        catch (MoneroError e)
+        {
+            TestNoSubaddressError(e);
+        }
+
+        // Test wrong message
+        check = wallet.CheckReserveProof(wallet.GetPrimaryAddress(), "Wrong message", signature);
+        Assert.False(check.IsGood());  // TODO: specifically Test reserve checks, probably separate objects
+        TestCheckReserve(check);
+
+        // Test wrong signature
+        try
+        {
+            wallet.CheckReserveProof(wallet.GetPrimaryAddress(), "Test message", "wrong signature");
+            Assert.Fail("Should have thrown exception");
+        }
+        catch (MoneroError e)
+        {
+            TestSignatureHeaderCheckError(e);
+        }
+    }
+
+    // Can prove reserves in an account
+    [Fact]
+    public virtual void TestGetReserveProofAccount()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // Test proofs of accounts
+        int numNonZeroTests = 0;
+        string msg = "Test message";
+        List<MoneroAccount> accounts = wallet.GetAccounts();
+        string? signature = null;
+        foreach (MoneroAccount account in accounts)
+        {
+            if (account.GetBalance() > 0)
+            {
+                ulong checkAmount = ((ulong)account.GetBalance()!) / 2;
+                signature = wallet.GetReserveProofAccount((uint)account.GetIndex()!, checkAmount, msg);
+                MoneroCheckReserve checkReserve = wallet.CheckReserveProof(wallet.GetPrimaryAddress(), msg, signature);
+                Assert.True(checkReserve.IsGood());
+                TestCheckReserve(checkReserve);
+                Assert.True(checkReserve.GetTotalAmount() >= checkAmount);
+                numNonZeroTests++;
+            }
+            else
+            {
+                try
+                {
+                    wallet.GetReserveProofAccount((uint)account.GetIndex(), (ulong)account.GetBalance(), msg);
+                    throw new Exception("Should have thrown exception");
+                }
+                catch (MoneroError e)
+                {
+                    Assert.Equal(-1, (int)e.GetCode());
+                    try
+                    {
+                        wallet.GetReserveProofAccount((uint)account.GetIndex(), TestUtils.MAX_FEE, msg);
+                        throw new Exception("Should have thrown exception");
+                    }
+                    catch (MoneroError e2)
+                    {
+                        Assert.Equal(-1, (int)e2.GetCode());
+                    }
+                }
+            }
+        }
+        Assert.True(numNonZeroTests > 1, "Must have more than one account with non-zero balance; run send-to-multiple Tests");
+
+        // Test error when not enough balance foreach requested minimum reserve amount
+        try
+        {
+            string proof = wallet.GetReserveProofAccount(0, (ulong)accounts[0].GetBalance() + TestUtils.MAX_FEE, "Test message");
+            Console.WriteLine("Account balance: " + wallet.GetBalance(0));
+            Console.WriteLine("accounts[0] balance: " + accounts[0].GetBalance());
+            MoneroCheckReserve reserve = wallet.CheckReserveProof(wallet.GetPrimaryAddress(), "Test message", proof);
+            try
+            {
+                wallet.GetReserveProofAccount(0, (ulong)accounts[0].GetBalance() + TestUtils.MAX_FEE, "Test message");
+                throw new Exception("expecting this to succeed");
+            }
+            catch (Exception e)
+            {
+                Assert.Equal("expecting this to succeed", e.Message);
+            }
+            //Console.WriteLine("Check reserve proof: " + JsonUtils.serialize(reserve));
+            Assert.Fail("Should have thrown exception but got reserve proof: https://github.Com/monero-project/monero/issues/6595");
+        }
+        catch (MoneroError e)
+        {
+            Assert.Equal(-1, (int)e.GetCode());
+        }
+
+        // Test different wallet address
+        string differentAddress = TestUtils.GetExternalWalletAddress();
+        try
+        {
+            wallet.CheckReserveProof(differentAddress, "Test message", signature);
+            Assert.Fail("Should have thrown exception");
+        }
+        catch (MoneroError e)
+        {
+            Assert.Equal(-1, (int)e.GetCode());
+        }
+
+        // Test subaddress
+        try
+        {
+            wallet.CheckReserveProof((wallet.GetSubaddress(0, 1)).GetAddress(), "Test message", signature);
+            Assert.Fail("Should have thrown exception");
+        }
+        catch (MoneroError e)
+        {
+            Assert.Equal(-1, (int)e.GetCode());
+        }
+
+        // Test wrong message
+        MoneroCheckReserve check = wallet.CheckReserveProof(wallet.GetPrimaryAddress(), "Wrong message", signature);
+        Assert.False(check.IsGood()); // TODO: specifically Test reserve checks, probably separate objects
+        TestCheckReserve(check);
+
+        // Test wrong signature
+        try
+        {
+            wallet.CheckReserveProof(wallet.GetPrimaryAddress(), "Test message", "wrong signature");
+            Assert.Fail("Should have thrown exception");
+        }
+        catch (MoneroError e)
+        {
+            Assert.Equal(-1, (int)e.GetCode());
+        }
+    }
+
+    // Can get and set a transaction note
+    [Fact]
+    public virtual void TestSetTxNote()
+    {
+        Assert.True(TEST_NON_RELAYS);
+        List<MoneroTxWallet> txs = GetRandomTransactions(wallet, null, 1, 5);
+
+        // set notes
+        string uuid = GenUtils.GetGuid();
+        for (int i = 0; i < txs.Count; i++)
+        {
+            wallet.SetTxNote(txs[i].GetHash(), uuid + i);
+        }
+
+        // get notes
+        for (int i = 0; i < txs.Count; i++)
+        {
+            Assert.Equal(wallet.GetTxNote(txs[i].GetHash()), uuid + i);
+        }
+    }
+
+    // Can get and set multiple transaction notes
+    // TODO: why does getting cached txs take 2 seconds when should already be cached?
+    [Fact]
+    public virtual void TestSetTxNotes()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // set tx notes
+        string uuid = GenUtils.GetGuid();
+        List<MoneroTxWallet> txs = wallet.GetTxs();
+        Assert.True(txs.Count >= 3, "Test requires 3 or more wallet transactions; run send tests");
+        List<string> txHashes = new List<string>();
+        List<string> txNotes = new List<string>();
+        for (int i = 0; i < txHashes.Count; i++)
+        {
+            txHashes.Add(txs[i].GetHash());
+            txNotes.Add(uuid + i);
+        }
+        wallet.SetTxNotes(txHashes, txNotes);
+
+        // get tx notes
+        txNotes = wallet.GetTxNotes(txHashes);
+        for (int i = 0; i < txHashes.Count; i++)
+        {
+            Assert.Equal(uuid + i, txNotes[i]);
+        }
+
+        // TODO: test that get transaction has note
+    }
+
+    // Can export signed key images
+    [Fact]
+    public virtual void TestExportKeyImages()
+    {
+        Assert.True(TEST_NON_RELAYS);
+        List<MoneroKeyImage> images = wallet.ExportKeyImages(true);
+        Assert.True(images.Count > 0, "No signed key images in wallet");
+        foreach (MoneroKeyImage image in images)
+        {
+            Assert.True(image is MoneroKeyImage);
+            Assert.True(image.GetHex().Length > 0);
+            Assert.True(image.GetSignature().Length > 0);
+        }
+
+        // wallet exports key images since last export by default
+        images = wallet.ExportKeyImages();
+        List<MoneroKeyImage> imagesAll = wallet.ExportKeyImages(true);
+        Assert.True(imagesAll.Count > images.Count);
+    }
+
+    // Can get new key images from the last import
+    [Fact]
+    public virtual void TestGetNewKeyImagesFromLastImport()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // get outputs hex
+        string outputsHex = wallet.ExportOutputs();
+
+        // import outputs hex
+        if (outputsHex != null)
+        {
+            int numImported = wallet.ImportOutputs(outputsHex);
+            Assert.True(numImported >= 0);
+        }
+
+        // get and test new key images from last import
+        List<MoneroKeyImage> images = wallet.GetNewKeyImagesFromLastImport();
+        if (images.Count == 0) Assert.Fail("No new key images in last import"); // TODO: these are already known to the wallet, so no new key images will be imported
+        foreach (MoneroKeyImage image in images)
+        {
+            Assert.True(image.GetHex().Length > 0);
+            Assert.True(image.GetSignature().Length > 0);
+        }
+    }
+
+    // Can import key images
+    // TODO monero-project: importing key images can cause erasure of incoming transfers per wallet2.Cpp:11957
+    [Fact]
+    public virtual void TestImportKeyImages()
+    {
+        Assert.True(TEST_NON_RELAYS);
+        List<MoneroKeyImage> images = wallet.ExportKeyImages();
+        Assert.True(images.Count > 0, "Wallet does not have any key images; run send tests");
+        MoneroKeyImageImportResult result = wallet.ImportKeyImages(images);
+        Assert.True(result.GetHeight() > 0);
+
+        // determine if non-zero spent and unspent amounts are expected
+        List<MoneroTxWallet> txs = wallet.GetTxs(new MoneroTxQuery().SetIsOutgoing(true).SetIsConfirmed(true));
+        ulong balance = wallet.GetBalance();
+        bool hasSpent = txs.Count > 0;
+        bool hasUnspent = balance > 0;
+
+        // test amounts
+        TestUtils.TestUnsignedBigInteger(result.GetSpentAmount(), hasSpent);
+        TestUtils.TestUnsignedBigInteger(result.GetUnspentAmount(), hasUnspent);
+    }
+
+    // Supports view-only and offline wallets to create, sign, and submit transactions
+    [Fact]
+    public virtual void TestViewOnlyAndOfflineWallets()
+    {
+        Assert.True(!LITE_MODE && (TEST_NON_RELAYS || TEST_RELAYS));
+
+        // create view-only and offline wallets
+        MoneroWallet viewOnlyWallet = CreateWallet(new MoneroWalletConfig().SetPrimaryAddress(wallet.GetPrimaryAddress()).SetPrivateViewKey(wallet.GetPrivateViewKey()).SetRestoreHeight(TestUtils.FIRST_RECEIVE_HEIGHT));
+        MoneroWallet offlineWallet = CreateWallet(new MoneroWalletConfig().SetPrimaryAddress(wallet.GetPrimaryAddress()).SetPrivateViewKey(wallet.GetPrivateViewKey()).SetPrivateSpendKey(wallet.GetPrivateSpendKey()).SetServerUri(TestUtils.OFFLINE_SERVER_URI).SetRestoreHeight(0l));
+        Assert.False(offlineWallet.IsConnectedToDaemon());
+        viewOnlyWallet.Sync();
+
+        // test tx signing with wallets
+        try
+        {
+            CheckViewOnlyAndOfflineWallets(viewOnlyWallet, offlineWallet);
+        }
+        finally
+        {
+            CloseWallet(viewOnlyWallet);
+            CloseWallet(offlineWallet);
+        }
+    }
+
+    // Can sign and verify messages
+    // TODO: test with view-only wallet
+    [Fact]
+    public virtual void TestSignAndVerifyMessages()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // message to sign and subaddresses to test
+        string msg = "This is a super important message which needs to be signed and verified.";
+        List<MoneroSubaddress> subaddresses = [new MoneroSubaddress(0, 0), new MoneroSubaddress(0, 1), new MoneroSubaddress(1, 0)];
+
+        // test signing message with subaddresses
+        foreach (MoneroSubaddress subaddress in subaddresses)
+        {
+
+            // sign and verify message with spend key
+            string signature = wallet.SignMessage(msg, MoneroMessageSignatureType.SIGN_WITH_SPEND_KEY, (uint)subaddress.GetAccountIndex(), (uint)subaddress.GetIndex());
+            MoneroMessageSignatureResult result = wallet.VerifyMessage(msg, wallet.GetAddress((uint)subaddress.GetAccountIndex(), (uint)subaddress.GetIndex()), signature);
+            Assert.True(new MoneroMessageSignatureResult(true, false, MoneroMessageSignatureType.SIGN_WITH_SPEND_KEY, 2).Equals(result));
+
+            // verify message with incorrect address
+            result = wallet.VerifyMessage(msg, wallet.GetAddress(0, 2), signature);
+            Assert.True(new MoneroMessageSignatureResult(false, null, null, null).Equals(result));
+
+            // verify message with invalid address
+            result = wallet.VerifyMessage(msg, "invalid address", signature);
+            Assert.True(new MoneroMessageSignatureResult(false, null, null, null).Equals(result));
+
+            // verify message with external address
+            result = wallet.VerifyMessage(msg, TestUtils.GetExternalWalletAddress(), signature);
+            Assert.True(new MoneroMessageSignatureResult(false, null, null, null).Equals(result));
+
+            // sign and verify message with view key
+            signature = wallet.SignMessage(msg, MoneroMessageSignatureType.SIGN_WITH_VIEW_KEY, (uint)subaddress.GetAccountIndex(), (uint)subaddress.GetIndex());
+            result = wallet.VerifyMessage(msg, wallet.GetAddress((uint)subaddress.GetAccountIndex(), (uint)subaddress.GetIndex()), signature);
+            Assert.True(new MoneroMessageSignatureResult(true, false, MoneroMessageSignatureType.SIGN_WITH_VIEW_KEY, 2).Equals(result));
+
+            // verify message with incorrect address
+            result = wallet.VerifyMessage(msg, wallet.GetAddress(0, 2), signature);
+            Assert.True(new MoneroMessageSignatureResult(false, null, null, null).Equals(result));
+
+            // verify message with external address
+            result = wallet.VerifyMessage(msg, TestUtils.GetExternalWalletAddress(), signature);
+            Assert.True(new MoneroMessageSignatureResult(false, null, null, null).Equals(result));
+
+            // verify message with invalid address
+            result = wallet.VerifyMessage(msg, "invalid address", signature);
+            Assert.True(new MoneroMessageSignatureResult(false, null, null, null).Equals(result));
+        }
+    }
+
+    // Has an address book
+    [Fact]
+    public virtual void TestAddressBook()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // initial state
+        List<MoneroAddressBookEntry> entries = wallet.GetAddressBookEntries();
+        int numEntriesStart = entries.Count;
+        foreach (MoneroAddressBookEntry entry in entries) TestAddressBookEntry(entry);
+
+        // test adding standard addresses
+        int NUM_ENTRIES = 5;
+        string address = TestUtils.GetExternalWalletAddress();
+        List<uint> indices = new List<uint>();
+        for (int i = 0; i < NUM_ENTRIES; i++)
+        {
+            indices.Add(wallet.AddAddressBookEntry(address, "hi there!"));
+        }
+        entries = wallet.GetAddressBookEntries();
+        Assert.Equal(numEntriesStart + NUM_ENTRIES, entries.Count);
+        foreach (int idx in indices)
+        {
+            bool found = false;
+            foreach (MoneroAddressBookEntry entry in entries)
+            {
+                if (idx == entry.GetIndex())
+                {
+                    TestAddressBookEntry(entry);
+                    Assert.Equal(entry.GetAddress(), address);
+                    Assert.Equal("hi there!", entry.GetDescription());
+                    found = true;
+                    break;
+                }
+            }
+            Assert.True(found, "Index " + idx + " not found in address book indices");
+        }
+
+        // edit each address book entry
+        foreach (uint idx in indices)
+        {
+            wallet.EditAddressBookEntry(idx, false, null, true, "hello there!!");
+        }
+        entries = wallet.GetAddressBookEntries(indices);
+        foreach (MoneroAddressBookEntry entry in entries)
+        {
+            Assert.Equal("hello there!!", entry.GetDescription());
+        }
+
+        // delete entries at starting index
+        uint deleteIdx = indices[0];
+        for (int i = 0; i < indices.Count; i++)
+        {
+            wallet.DeleteAddressBookEntry(deleteIdx);
+        }
+        entries = wallet.GetAddressBookEntries();
+        Assert.Equal(entries.Count, numEntriesStart);
+
+        // test adding integrated addresses
+        indices = new List<uint>();
+        string paymentId = "03284e41c342f03"; // payment id less one character
+        Dictionary<uint, MoneroIntegratedAddress> integratedAddresses = [];
+        Dictionary<uint, string> integratedDescriptions = [];
+        for (int i = 0; i < NUM_ENTRIES; i++)
+        {
+            MoneroIntegratedAddress integratedAddress = wallet.GetIntegratedAddress(null, paymentId + i); // create unique integrated address
+            string uuid = GenUtils.GetGuid();
+            uint idx = wallet.AddAddressBookEntry(integratedAddress.ToString(), uuid);
+            indices.Add(idx);
+            integratedAddresses.Add(idx, integratedAddress);
+            integratedDescriptions.Add(idx, uuid);
+        }
+        entries = wallet.GetAddressBookEntries();
+        Assert.Equal(entries.Count, numEntriesStart + NUM_ENTRIES);
+        foreach (uint idx in indices)
+        {
+            bool found = false;
+            foreach (MoneroAddressBookEntry entry in entries)
+            {
+                if (idx == entry.GetIndex())
+                {
+                    TestAddressBookEntry(entry);
+                    Assert.Equal(integratedDescriptions[idx], entry.GetDescription());
+                    Assert.Equal(integratedAddresses[idx].ToString(), entry.GetAddress());
+                    Assert.Null(entry.GetPaymentId());
+                    found = true;
+                    break;
+                }
+            }
+            Assert.True(found, "Index " + idx + " not found in address book indices");
+        }
+
+        // delete entries at starting index
+        deleteIdx = indices[0];
+        for (int i = 0; i < indices.Count; i++)
+        {
+            wallet.DeleteAddressBookEntry(deleteIdx);
+        }
+        entries = wallet.GetAddressBookEntries();
+        Assert.Equal(numEntriesStart, entries.Count);
+    }
+
+    // Can get and set arbitrary key/value attributes
+    [Fact]
+    public virtual void TestSetAttributes()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // set attributes
+        Dictionary<string, string> attrs = [];
+        for (int i = 0; i < 5; i++)
+        {
+            string key = "attr" + i;
+            string val = GenUtils.GetGuid();
+            attrs.Add(key, val);
+            wallet.SetAttribute(key, val);
+        }
+
+        // test attributes
+        foreach (string key in attrs.Keys)
+        {
+            Assert.Equal(wallet.GetAttribute(key), attrs[key]);
+        }
+
+        // get an undefined attribute
+        Assert.Null(wallet.GetAttribute("unset_key"));
+    }
+
+    // Can convert between a tx config and payment URI
+    [Fact]
+    public virtual void TestGetPaymentUri()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // test with address and amount
+        MoneroTxConfig config1 = new MoneroTxConfig().SetAddress(wallet.GetAddress(0, 0)).SetAmount(0);
+        string uri = wallet.GetPaymentUri(config1);
+        MoneroTxConfig config2 = wallet.ParsePaymentUri(uri);
+        Assert.True(config1.Equals(config2));
+
+        // test with subaddress and all fields
+        config1.GetDestinations()[0].SetAddress(wallet.GetSubaddress(0, 1).GetAddress());
+        config1.GetDestinations()[0].SetAmount(425000000000);
+        config1.SetRecipientName("John Doe");
+        config1.SetNote("OMZG XMR FTW");
+        uri = wallet.GetPaymentUri(config1);
+        config2 = wallet.ParsePaymentUri(uri);
+        Assert.True(config1.Equals(config2));
+
+        // test with undefined address
+        string address = config1.GetDestinations()[0].GetAddress();
+        config1.GetDestinations()[0].SetAddress(null);
+        try
+        {
+            wallet.GetPaymentUri(config1);
+            Assert.Fail("Should have thrown RPC exception with invalid parameters");
+        }
+        catch (MoneroError e)
+        {
+            Assert.Contains("Cannot make URI from supplied parameters", e.Message);
+        }
+        config1.GetDestinations()[0].SetAddress(address);
+
+        // test with standalone payment id
+        config1.SetPaymentId("03284e41c342f03603284e41c342f03603284e41c342f03603284e41c342f036");
+        try
+        {
+            wallet.GetPaymentUri(config1);
+            Assert.Fail("Should have thrown RPC exception with invalid parameters");
+        }
+        catch (MoneroError e)
+        {
+            Assert.Contains("Cannot make URI from supplied parameters", e.Message);
+        }
+    }
+
+    // Can start and stop mining
+    [Fact]
+    public virtual void TestMining()
+    {
+        Assert.True(TEST_NON_RELAYS);
+        MoneroMiningStatus status = daemon.GetMiningStatus();
+        if (status.IsActive() == true) wallet.StopMining();
+        wallet.StartMining(1, false, true);
+        wallet.StopMining();
+    }
+
+    // Can change the wallet password
+    [Fact]
+    public virtual void TestChangePassword()
+    {
+
+        // create random wallet
+        MoneroWallet wallet = CreateWallet(new MoneroWalletConfig().SetPassword(TestUtils.WALLET_PASSWORD));
+        string path = wallet.GetPath();
+
+        // change password
+        string newPassword = "";
+        wallet.ChangePassword(TestUtils.WALLET_PASSWORD, newPassword);
+
+        // close wallet without saving
+        CloseWallet(wallet);
+
+        // old password does not work (password change is auto saved)
+        try
+        {
+            OpenWallet(new MoneroWalletConfig().SetPath(path).SetPassword(TestUtils.WALLET_PASSWORD));
+            Assert.Fail("Should have thrown");
+        }
+        catch (Exception e)
+        {
+            Assert.True(e.Message.ToLower().Contains("failed to open wallet") || e.Message.ToLower().Contains("invalid password")); // TODO: different errors from rpc and wallet2
+        }
+
+        // open wallet with new password
+        wallet = OpenWallet(new MoneroWalletConfig().SetPath(path).SetPassword(newPassword));
+
+        // change password with incorrect password
+        try
+        {
+            wallet.ChangePassword("badpassword", newPassword);
+            Assert.Fail("Should have thrown");
+        }
+        catch (Exception e)
+        {
+            Assert.Equal("Invalid original password.", e.Message);
+        }
+
+        // save and close
+        CloseWallet(wallet, true);
+
+        // open wallet
+        wallet = OpenWallet(new MoneroWalletConfig().SetPath(path).SetPassword(newPassword));
+
+        // close wallet
+        CloseWallet(wallet);
+    }
+
+    // Can save and close the wallet in a single call
+    [Fact]
+    public virtual void TestSaveAndClose()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // create random wallet
+        string password = "";
+        MoneroWallet wallet = CreateWallet(new MoneroWalletConfig().SetPassword(password));
+        string path = wallet.GetPath();
+
+        // set an attribute
+        string uuid = GenUtils.GetGuid();
+        wallet.SetAttribute("id", uuid);
+
+        // close the wallet without saving
+        CloseWallet(wallet);
+
+        // re-open the wallet and ensure attribute was not saved
+        wallet = OpenWallet(path, password);
+        Assert.Null(wallet.GetAttribute("id"));
+
+        // set the attribute and close with saving
+        wallet.SetAttribute("id", uuid);
+        CloseWallet(wallet, true);
+
+        // re-open the wallet and ensure attribute was saved
+        wallet = OpenWallet(new MoneroWalletConfig().SetPath(path).SetPassword(password));
+        Assert.Equal(uuid, wallet.GetAttribute("id"));
+        CloseWallet(wallet);
+    }
+
     #endregion
+
+    #region Test Relays
+
+    // Validates inputs when sending funds
+    [Fact]
+    public virtual void TestValidateInputsSendingFunds()
+    {
+
+        // try sending with invalid address
+        try
+        {
+            wallet.CreateTx(new MoneroTxConfig().SetAddress("my invalid address").SetAccountIndex(0).SetAmount(TestUtils.MAX_FEE));
+            Assert.Fail("Should have thrown");
+        }
+        catch (MoneroError err)
+        {
+            Assert.Equal("Invalid destination address", err.Message);
+        }
+    }
+
+    // Can sync with txs in the pool sent from/to the same account
+    // TODO: this test fails because wallet does not recognize pool tx sent from/to same account
+    [Fact]
+    public virtual void TestSyncWithPoolSameAccounts()
+    {
+        Assert.True(TEST_NON_RELAYS);
+        TestSyncWithPoolSubmit(new MoneroTxConfig()
+            .SetAccountIndex(0)
+            .SetAddress(wallet.GetPrimaryAddress())
+            .SetAmount(TestUtils.MAX_FEE * 5)
+            .SetRelay(false));
+    }
+
+    // Can sync with txs submitted and discarded from the pool
+    [Fact]
+    public virtual void TestSyncWithPoolSubmitAndDiscard()
+    {
+        Assert.True(TEST_NON_RELAYS);
+        TestSyncWithPoolSubmit(new MoneroTxConfig()
+            .SetAccountIndex(2)
+            .SetAddress(wallet.GetPrimaryAddress())
+            .SetAmount(TestUtils.MAX_FEE * 5)
+            .SetRelay(false));
+    }
+
+    // Can sync with txs submitted and relayed from the pool
+    [Fact]
+    public virtual void TestSyncWithPoolSubmitAndRelay()
+    {
+        Assert.True(TEST_RELAYS && !LITE_MODE);
+        TestSyncWithPoolSubmit(new MoneroTxConfig()
+            .SetAccountIndex(2)
+            .SetAddress(wallet.GetPrimaryAddress())
+            .SetAmount(TestUtils.MAX_FEE * 5)
+            .SetRelay(true));
+    }
+
+    // Can sync with txs relayed to the pool
+    [Fact]
+    public virtual void TestSyncWithPoolRelay()
+    {
+        Assert.True(TEST_RELAYS && !LITE_MODE);
+
+        // wait one time for wallet txs in the pool to clear
+        // TODO monero-project: update from pool does not prevent creating double spend tx
+        TestUtils.WALLET_TX_TRACKER.WaitForWalletTxsToClearPool(wallet);
+
+        // record wallet balances before submitting tx to pool
+        ulong balanceBefore = wallet.GetBalance();
+        ulong unlockedBalanceBefore = wallet.GetUnlockedBalance();
+
+        // create config
+        MoneroTxConfig config = new MoneroTxConfig()
+                .SetAccountIndex(2)
+                .SetAddress(wallet.GetPrimaryAddress())
+                .SetAmount(TestUtils.MAX_FEE * 5);
+
+        // create tx to relay
+        MoneroTxWallet tx = wallet.CreateTx(config);
+
+        // create another tx using same config which would be double spend
+        MoneroTxWallet txDoubleSpend = wallet.CreateTx(config);
+
+        // relay first tx directly to daemon
+        MoneroSubmitTxResult result = daemon.SubmitTxHex(tx.GetFullHex());
+        if (result.IsGood() != true) throw new Exception("Transaction could not be submitted to the pool");
+        Assert.True(result.IsGood());
+
+        // sync wallet which updates from pool
+        wallet.Sync();
+
+        // collect issues to report at end of test
+        List<string> issues = new List<string>();
+
+        try
+        {
+
+            // wallet should be aware of tx
+            try
+            {
+                MoneroTxWallet fetched = wallet.GetTx(tx.GetHash());
+                Assert.NotNull(fetched);
+            }
+            catch (MoneroError e)
+            {
+                throw new Exception("Wallet should be aware of its tx in pool after syncing");
+            }
+
+            // test wallet balances
+            if (unlockedBalanceBefore.CompareTo(wallet.GetUnlockedBalance()) != 1) issues.Add("WARNING: unlocked balance should have decreased after relaying tx directly to the daemon");
+            ulong expectedBalance = balanceBefore - ((ulong)tx.GetOutgoingAmount()) - ((ulong)tx.GetFee());
+            if (!expectedBalance.Equals(wallet.GetBalance())) issues.Add("WARNING: expected balance after relaying tx directly to the daemon to be " + expectedBalance + " but was " + wallet.GetBalance());
+
+            // submit double spend tx
+            MoneroSubmitTxResult resultDoubleSpend = daemon.SubmitTxHex(txDoubleSpend.GetFullHex(), true);
+            if (resultDoubleSpend.IsGood() == true)
+            {
+                daemon.FlushTxPool(txDoubleSpend.GetHash());
+                throw new Exception("Tx submit result should have been double spend");
+            }
+
+            // sync wallet which updates from pool
+            wallet.Sync();
+
+            // create tx using same config which is no longer double spend
+            MoneroTxWallet? tx2 = null;
+            try
+            {
+                tx2 = wallet.CreateTx(config.Clone().SetRelay(true));
+            }
+            catch (Exception e)
+            {
+                issues.Add("WARNING: creating and sending tx through wallet should succeed after syncing wallet with pool but creates a double spend"); // TODO monero-project: this fails meaning wallet did not recognize tx relayed directly to pool
+            }
+
+            // submit the transaction to the pool and test
+            if (tx2 != null)
+            {
+                MoneroSubmitTxResult result2 = daemon.SubmitTxHex(tx2.GetFullHex(), true);
+                if (result2.IsDoubleSpend() == true) issues.Add("WARNING: creating and submitting tx to daemon should succeed after syncing wallet with pool but was a double spend");
+                else Assert.True(result.IsGood());
+                wallet.Sync();
+                wallet.GetTx(tx2.GetHash()); // wallet is aware of tx2
+                daemon.FlushTxPool(tx2.GetHash());
+            }
+
+            // should be no issues
+            Assert.True(0 == issues.Count, "testSyncWithPoolRelay() issues: " + issues);
+        }
+        finally
+        {
+            TestUtils.WALLET_TX_TRACKER.Reset(); // all wallets need to wait for tx to confirm to reliably sync tx
+        }
+    }
+
+    // Can send to self
+    [Fact]
+    public virtual void TestSendToSelf()
+    {
+        Assert.True(TEST_RELAYS);
+
+        // wait for txs to confirm and for sufficient unlocked balance
+        TestUtils.WALLET_TX_TRACKER.WaitForWalletTxsToClearPool(wallet);
+        ulong amount = TestUtils.MAX_FEE * 3;
+        TestUtils.WALLET_TX_TRACKER.WaitForUnlockedBalance(wallet, 0, null, amount);
+
+        // collect sender balances before
+        ulong balance1 = wallet.GetBalance();
+        ulong unlockedBalance1 = wallet.GetUnlockedBalance();
+
+        // test error sending funds to self with integrated subaddress
+        // TODO (monero-project): sending funds to self with integrated subaddress throws error: https://github.Com/monero-project/monero/issues/8380
+        try
+        {
+            wallet.CreateTx(new MoneroTxConfig()
+                    .SetAccountIndex(0)
+                    .SetAddress(MoneroUtils.GetIntegratedAddress(TestUtils.NETWORK_TYPE, wallet.GetSubaddress(0, 1).GetAddress(), null).GetIntegratedAddress())
+                    .SetAmount(amount)
+                    .SetRelay(true));
+            throw new Exception("Should have failed sending to self with integrated subaddress");
+        }
+        catch (MoneroError err)
+        {
+            if (!err.Message.Contains("Total received by")) throw;
+        }
+
+        // send funds to self
+        MoneroTxWallet tx = wallet.CreateTx(new MoneroTxConfig()
+                .SetAccountIndex(0)
+                .SetAddress(wallet.GetIntegratedAddress().GetIntegratedAddress())
+                .SetAmount(amount)
+                .SetRelay(true));
+
+        // test balances after
+        ulong balance2 = wallet.GetBalance();
+        ulong unlockedBalance2 = wallet.GetUnlockedBalance();
+        Assert.True(unlockedBalance2.CompareTo(unlockedBalance1) < 0); // unlocked balance should decrease
+        ulong expectedBalance = balance1 - ((uint)tx.GetFee());
+        if (!expectedBalance.Equals(balance2)) Console.WriteLine("Expected=" + expectedBalance + " - Actual=" + balance2 + " = " + (expectedBalance - (balance2)));
+        Assert.True(expectedBalance == balance2, "Balance after send was not balance before - fee");
+    }
+
+    // Can send to external wallet
+    [Fact]
+    public virtual void TestSendToExternal()
+    {
+        Assert.True(TEST_RELAYS);
+        MoneroWallet? recipient = null;
+        try
+        {
+            // wait for txs to confirm and for sufficient unlocked balance
+            TestUtils.WALLET_TX_TRACKER.WaitForWalletTxsToClearPool(wallet);
+            ulong amount = TestUtils.MAX_FEE * 3;
+            TestUtils.WALLET_TX_TRACKER.WaitForUnlockedBalance(wallet, 0, null, amount);
+
+            // create recipient wallet
+            recipient = CreateWallet(new MoneroWalletConfig());
+
+            // collect sender balances before
+            ulong balance1 = wallet.GetBalance();
+            ulong unlockedBalance1 = wallet.GetUnlockedBalance();
+
+            // send funds to recipient
+            MoneroTxWallet tx = wallet.CreateTx(new MoneroTxConfig()
+                    .SetAccountIndex(0)
+                    .SetAddress(wallet.GetIntegratedAddress(recipient.GetPrimaryAddress(), "54491f3bb3572a37").GetIntegratedAddress())
+                    .SetAmount(amount)
+                    .SetRelay(true));
+
+            // test sender balances after
+            ulong balance2 = wallet.GetBalance();
+            ulong unlockedBalance2 = wallet.GetUnlockedBalance();
+            Assert.True(unlockedBalance2.CompareTo(unlockedBalance1) < 0); // unlocked balance should decrease
+            ulong expectedBalance = balance1 - ((ulong)tx.GetOutgoingAmount()) - ((ulong)tx.GetFee());
+            Assert.True(expectedBalance == balance2, "Balance after send was not balance before - net tx amount - fee (5 - 1 != 4 test)");
+
+            // test recipient balance after
+            recipient.Sync();
+            Assert.False(wallet.GetTxs(new MoneroTxQuery().SetIsConfirmed(false)).Count == 0);
+            Assert.Equal(amount, recipient.GetBalance());
+        }
+        finally
+        {
+            if (recipient != null && !recipient.IsClosed()) CloseWallet(recipient);
+        }
+    }
+
+    // Can send from multiple subaddresses in a single transaction
+    [Fact]
+    public virtual void TestSendFromSubaddresses()
+    {
+        Assert.True(TEST_RELAYS);
+        TestSendFromMultiple(null);
+    }
+
+    // Can send from multiple subaddresses in split transactions
+    [Fact]
+    public virtual void TestSendFromSubaddressesSplit()
+    {
+        Assert.True(TEST_RELAYS);
+        TestSendFromMultiple(new MoneroTxConfig().SetCanSplit(true));
+    }
+
+    // Can send to an address in a single transaction
+    [Fact]
+    public virtual void TestSend()
+    {
+        Assert.True(TEST_RELAYS);
+        TestSendToSingle(new MoneroTxConfig().SetCanSplit(false));
+    }
+
+    // Can send to an address in a single transaction with a payment id
+    // NOTE: this test will be invalid when payment hashes are fully removed
+    [Fact]
+    public virtual void TestSendWithPaymentId()
+    {
+        Assert.True(TEST_RELAYS);
+        MoneroIntegratedAddress integratedAddress = wallet.GetIntegratedAddress();
+        string paymentId = integratedAddress.GetPaymentId();
+        try
+        {
+            TestSendToSingle(new MoneroTxConfig().SetCanSplit(false).SetPaymentId(paymentId + paymentId + paymentId + paymentId));  // 64 character payment id
+            Assert.Fail("Should have thrown");
+        }
+        catch (MoneroError e)
+        {
+            Assert.Equal("Standalone payment IDs are obsolete. Use subaddresses or integrated addresses instead", e.Message);
+        }
+    }
+
+    // Can send to an address with split transactions
+    [Fact]
+    public virtual void TestSendSplit()
+    {
+        Assert.True(TEST_RELAYS);
+        TestSendToSingle(new MoneroTxConfig().SetCanSplit(true).SetRelay(true));
+    }
+
+    // Can create then relay a transaction to send to a single address
+    [Fact]
+    public virtual void TestCreateThenRelay()
+    {
+        Assert.True(TEST_RELAYS);
+        TestSendToSingle(new MoneroTxConfig().SetCanSplit(false));
+    }
+
+    // Can create then relay split transactions to send to a single address
+    [Fact]
+    public virtual void TestCreateThenRelaySplit()
+    {
+        Assert.True(TEST_RELAYS);
+        TestSendToSingle(new MoneroTxConfig().SetCanSplit(true));
+    }
+
+    // Can send to multiple addresses in a single transaction
+    [Fact]
+    public virtual void TestSendToMultiple()
+    {
+        Assert.True(TEST_RELAYS);
+        SendToMultiple(5, 3, false);
+    }
+
+    // Can send to multiple addresses in split transactions
+    [Fact]
+    public virtual void TestSendToMultipleSplit()
+    {
+        Assert.True(TEST_RELAYS);
+        SendToMultiple(3, 15, true);
+    }
+
+    // Can send dust to multiple addresses in split transactions
+    [Fact]
+    public virtual void TestSendDustToMultipleSplit()
+    {
+        Assert.True(TEST_RELAYS);
+        var fee = daemon.GetFeeEstimate().GetFee();
+        if (fee == null) throw new Exception("Fee estimate is null");
+        ulong dustAmt = ((ulong)fee) / 2;
+        SendToMultiple(5, 3, true, dustAmt);
+    }
+
+    // Can subtract fees from destinations
+    [Fact]
+    public virtual void TestSubtractFeeFrom()
+    {
+        Assert.True(TEST_RELAYS);
+        SendToMultiple(5, 3, false, null, true);
+    }
+
+    // Cannot subtract fees from destinations in split transactions
+    [Fact]
+    public virtual void TestSubtractFeeFromSplit()
+    {
+        Assert.True(TEST_RELAYS);
+        SendToMultiple(3, 15, true, null, true);
+    }
+
+    // Can sweep individual outputs identified by their key images
+    [Fact]
+    public virtual void TestSweepOutputs()
+    {
+        Assert.True(TEST_RELAYS);
+        TestUtils.WALLET_TX_TRACKER.WaitForWalletTxsToClearPool(wallet);
+
+        // test config
+        int numOutputs = 3;
+
+        // get outputs to sweep (not spent, unlocked, and amount >= fee)
+        List<MoneroOutputWallet> spendableUnlockedOutputs = wallet.GetOutputs(new MoneroOutputQuery().SetIsSpent(false).SetTxQuery(new MoneroTxQuery().SetIsLocked(false)));
+        List<MoneroOutputWallet> outputsToSweep = new List<MoneroOutputWallet>();
+        for (int i = 0; i < spendableUnlockedOutputs.Count && outputsToSweep.Count < numOutputs; i++)
+        {
+            if (((ulong)spendableUnlockedOutputs[i].GetAmount()).CompareTo(TestUtils.MAX_FEE) > 0) outputsToSweep.Add(spendableUnlockedOutputs[i]);  // output cannot be swept if amount does not cover fee
+        }
+        Assert.True(outputsToSweep.Count >= numOutputs, "Wallet does not have enough sweepable outputs; run send tests");
+
+        // sweep each output by key image
+        foreach (MoneroOutputWallet output in outputsToSweep)
+        {
+            TestOutputWallet(output);
+            Assert.False(output.IsSpent());
+            Assert.False(output.IsLocked());
+            if (((ulong)output.GetAmount()).CompareTo(TestUtils.MAX_FEE) <= 0) continue;
+
+            // sweep output to address
+            string address = wallet.GetAddress((uint)output.GetAccountIndex(), (uint)output.GetSubaddressIndex());
+            MoneroTxConfig config = new MoneroTxConfig().SetAddress(address).SetKeyImage(output.GetKeyImage().GetHex()).SetRelay(true);
+            MoneroTxWallet tx = wallet.SweepOutput(config);
+
+            // test resulting tx
+            TxContext ctx = new TxContext();
+            ctx.Wallet = wallet;
+            ctx.Config = config;
+            ctx.Config.SetCanSplit(false);
+            ctx.IsSendResponse = true;
+            ctx.IsSweepResponse = true;
+            ctx.IsSweepOutputResponse = true;
+            TestTxWallet(tx, ctx);
+        }
+
+        // get outputs after sweeping
+        List<MoneroOutputWallet> afterOutputs = wallet.GetOutputs();
+
+        // swept outputs are now spent
+        foreach (MoneroOutputWallet afterOutput in afterOutputs)
+        {
+            foreach (MoneroOutputWallet output in outputsToSweep)
+            {
+                if (output.GetKeyImage().GetHex().Equals(afterOutput.GetKeyImage().GetHex()))
+                {
+                    Assert.True(afterOutput.IsSpent(), "Output should be spent");
+                }
+            }
+        }
+    }
+
+    // Can sweep dust without relaying
+    [Fact]
+    public virtual void TestSweepDustNoRelay()
+    {
+        Assert.True(TEST_RELAYS);
+        TestUtils.WALLET_TX_TRACKER.WaitForWalletTxsToClearPool(wallet);
+
+        // sweep dust which returns empty list if no dust to sweep (dust does not exist after rct)
+        List<MoneroTxWallet> txs = wallet.SweepDust(false);
+        if (txs.Count == 0) return;
+
+        // test txs
+        TxContext ctx = new TxContext();
+        ctx.IsSendResponse = true;
+        ctx.Config = new MoneroTxConfig().SetRelay(false);
+        ctx.IsSweepResponse = true;
+        foreach (MoneroTxWallet tx in txs)
+        {
+            TestTxWallet(tx, ctx);
+        }
+
+        // relay txs
+        List<string> metadatas = new List<string>();
+        foreach (MoneroTxWallet tx in txs) metadatas.Add(tx.GetMetadata());
+        List<string> txHashes = wallet.RelayTxs(metadatas);
+        Assert.Equal(txHashes.Count, txs.Count);
+        foreach (string txHash in txHashes) Assert.Equal(64, txHash.Length);
+
+        // fetch and test txs
+        txs = wallet.GetTxs(new MoneroTxQuery().SetHashes(txHashes));
+        ctx.Config.SetRelay(true);
+        foreach (MoneroTxWallet tx in txs)
+        {
+            TestTxWallet(tx, ctx);
+        }
+    }
+
+    // Can sweep dust
+    [Fact]
+    public virtual void TestSweepDust()
+    {
+        Assert.True(TEST_RELAYS);
+        TestUtils.WALLET_TX_TRACKER.WaitForWalletTxsToClearPool(wallet);
+
+        // sweep dust which returns empty list if no dust to sweep (dust does not exist after rct)
+        List<MoneroTxWallet> txs = wallet.SweepDust(true);
+
+        // test any txs
+        TxContext ctx = new TxContext();
+        ctx.Wallet = wallet;
+        ctx.Config = null;
+        ctx.IsSendResponse = true;
+        ctx.IsSweepResponse = true;
+        foreach (MoneroTxWallet tx in txs)
+        {
+            TestTxWallet(tx, ctx);
+        }
+    }
+
+    // TODO: test sending to multiple accounts
+    // Can update a locked tx sent from/to the same account as blocks are added to the chain
+    [Fact]
+    public virtual void TestUpdateLockedSameAccount()
+    {
+        Assert.True(TEST_RELAYS && TEST_NOTIFICATIONS);
+        MoneroTxConfig config = new MoneroTxConfig()
+                .SetAddress(wallet.GetPrimaryAddress())
+                .SetAmount(TestUtils.MAX_FEE)
+                .SetAccountIndex(0)
+                .SetCanSplit(false)
+                .SetRelay(true);
+        TestSendAndUpdateTxs(config);
+    }
+
+    // Can update split locked txs sent from/to the same account as blocks are added to the chain
+    [Fact]
+    public virtual void TestUpdateLockedSameAccountSplit()
+    {
+        Assert.True(TEST_RELAYS && TEST_NOTIFICATIONS && !LITE_MODE);
+        MoneroTxConfig config = new MoneroTxConfig()
+                .SetAccountIndex(0)
+                .SetAddress(wallet.GetPrimaryAddress())
+                .SetAmount(TestUtils.MAX_FEE)
+                .SetCanSplit(true)
+                .SetRelay(true);
+        TestSendAndUpdateTxs(config);
+    }
+
+    // Can update a locked tx sent from/to different accounts as blocks are added to the chain
+    [Fact]
+    public virtual void TestUpdateLockedDifferentAccounts()
+    {
+        Assert.True(TEST_RELAYS && TEST_NOTIFICATIONS && !LITE_MODE);
+        MoneroTxConfig config = new MoneroTxConfig()
+                .SetAccountIndex(0)
+                .SetAddress(wallet.GetSubaddress(1, 0).GetAddress())
+                .SetAmount(TestUtils.MAX_FEE)
+                .SetCanSplit(false)
+                .SetRelay(true);
+        TestSendAndUpdateTxs(config);
+    }
+
+    // Can update locked, split txs sent from/to different accounts as blocks are added to the chain
+    [Fact]
+    public virtual void TestUpdateLockedDifferentAccountsSplit()
+    {
+        Assert.True(TEST_RELAYS && TEST_NOTIFICATIONS && !LITE_MODE);
+        MoneroTxConfig config = new MoneroTxConfig()
+                .SetAccountIndex(0)
+                .SetAddress(wallet.GetSubaddress(1, 0).GetAddress())
+                .SetAmount(TestUtils.MAX_FEE)
+                .SetAccountIndex(0)
+                .SetRelay(true);
+        TestSendAndUpdateTxs(config);
+    }
+
+    #region Relays Utils
+
+    private void TestSyncWithPoolSubmit(MoneroTxConfig config)
+    {
+        // wait for txs to confirm and for sufficient unlocked balance
+        // TODO monero-project: update from pool does not prevent creating double spend tx
+        TestUtils.WALLET_TX_TRACKER.WaitForWalletTxsToClearPool(wallet);
+        Assert.Null(config.GetSubaddressIndices());
+        TestUtils.WALLET_TX_TRACKER.WaitForUnlockedBalance(wallet, config.GetAccountIndex(), null, config.GetAmount());
+
+        // record wallet balances before submitting tx to pool
+        ulong balanceBefore = wallet.GetBalance();
+        ulong unlockedBalanceBefore = wallet.GetUnlockedBalance();
+
+        // create tx but do not relay
+        MoneroTxConfig configNoRelay = config.Clone().SetRelay(false);
+        MoneroTxConfig configNoRelayCopy = configNoRelay.Clone();
+        MoneroTxWallet tx = wallet.CreateTx(configNoRelay);
+
+        // create tx using same config which is double spend
+        MoneroTxWallet txDoubleSpend = wallet.CreateTx(configNoRelay);
+
+        // test that config is unchanged
+        Assert.True(configNoRelayCopy != configNoRelay);
+        Assert.Equal(configNoRelayCopy, configNoRelay);
+
+        // submit tx directly to the pool but do not relay
+        MoneroSubmitTxResult result = daemon.SubmitTxHex(tx.GetFullHex(), true);
+        if (result.IsGood() != true) throw new Exception("Transaction could not be submitted to the pool");
+        Assert.True(result.IsGood());
+
+        // sync wallet which checks pool
+        wallet.Sync();
+
+        // test result and flush on finally
+        try
+        {
+
+            // wallet should be aware of tx
+            try
+            {
+                MoneroTxWallet fetched = wallet.GetTx(tx.GetHash());
+                Assert.NotNull(fetched);
+            }
+            catch (MoneroError e)
+            {
+                Assert.Fail("Wallet should be aware of its tx in pool after syncing");
+            }
+
+            // submit double spend tx
+            MoneroSubmitTxResult resultDoubleSpend = daemon.SubmitTxHex(txDoubleSpend.GetFullHex(), true);
+            if (resultDoubleSpend.IsGood() == true)
+            {
+                daemon.FlushTxPool(txDoubleSpend.GetHash());
+                throw new Exception("Tx submit result should have been double spend");
+            }
+
+            // relay if configured
+            if (config.GetRelay() == true) daemon.RelayTxByHash(tx.GetHash());
+
+            // sync wallet which updates from pool
+            wallet.Sync();
+
+            // TODO monero-project: this code fails which indicates issues // TODO (monero-project): sync txs from pool
+            bool runFailingCoreCode = false;
+            if (runFailingCoreCode)
+            {
+
+                // wallet balances should change
+                if (balanceBefore == wallet.GetBalance()) throw new Exception("Wallet balance should revert to original after flushing tx from pool without relaying");
+                if (unlockedBalanceBefore == wallet.GetUnlockedBalance()) throw new Exception("Wallet unlocked balance should revert to original after flushing tx from pool without relaying");  // TODO: test exact amounts, maybe in ux test
+
+                // create tx using same config which is no longer double spend
+                MoneroTxWallet tx2 = wallet.CreateTx(configNoRelay);
+                MoneroSubmitTxResult result2 = daemon.SubmitTxHex(tx2.GetFullHex(), true);
+
+                // test result and flush on finally
+                try
+                {
+                    if (result2.IsDoubleSpend() == true) throw new Exception("Wallet created double spend transaction after syncing with the pool");
+                    Assert.True(result.IsGood());
+                    wallet.Sync();
+                    wallet.GetTx(tx2.GetHash()); // wallet is aware of tx2
+                }
+                finally
+                {
+                    daemon.FlushTxPool(tx2.GetHash());
+                }
+            }
+        }
+        finally
+        {
+            if (config.GetRelay() != true)
+            {
+
+                // flush the tx from the pool
+                daemon.FlushTxPool(tx.GetHash());
+
+                // sync wallet which checks pool
+                wallet.Sync();
+
+                // wallet should no longer be aware of tx
+                try
+                {
+                    wallet.GetTx(tx.GetHash());
+                    Assert.Fail("Wallet should no longer be aware of tx which was not relayed and was manually removed from pool");
+                }
+                catch (MoneroError e)
+                {
+                    // exception expected
+                }
+
+                // wallet balances should be restored
+                if (balanceBefore != wallet.GetBalance()) throw new Exception("Wallet balance should be same as original since tx was flushed and not relayed");
+                if (unlockedBalanceBefore != wallet.GetUnlockedBalance()) throw new Exception("Wallet unlocked balance should be same as original since tx was flushed and not relayed");
+            }
+            else
+            {
+                TestUtils.WALLET_TX_TRACKER.Reset(); // all wallets need to wait for tx to confirm in order to reliably sync
+            }
+        }
+    }
+
+    private void TestSendFromMultiple(MoneroTxConfig? config)
+    {
+        TestUtils.WALLET_TX_TRACKER.WaitForWalletTxsToClearPool(wallet);
+        if (config == null) config = new MoneroTxConfig();
+
+        int NUM_SUBADDRESSES = 2; // number of subaddresses to send from
+
+        // get first account with (NUM_SUBADDRESSES + 1) subaddresses with unlocked balances
+        List<MoneroAccount> accounts = wallet.GetAccounts(true);
+        Assert.True(accounts.Count >= 2, "This test requires at least 2 accounts; run send-to-multiple tests");
+        MoneroAccount srcAccount = null;
+        List<MoneroSubaddress> unlockedSubaddresses = new List<MoneroSubaddress>();
+        bool hasBalance = false;
+        foreach (MoneroAccount account in accounts)
+        {
+            unlockedSubaddresses.Clear();
+            int numSubaddressBalances = 0;
+            foreach (MoneroSubaddress subaddress in account.GetSubaddresses())
+            {
+                if (((ulong)subaddress.GetBalance()).CompareTo(TestUtils.MAX_FEE) > 0) numSubaddressBalances++;
+                if (((ulong)subaddress.GetUnlockedBalance()).CompareTo(TestUtils.MAX_FEE) > 0) unlockedSubaddresses.Add(subaddress);
+            }
+            if (numSubaddressBalances >= NUM_SUBADDRESSES + 1) hasBalance = true;
+            if (unlockedSubaddresses.Count >= NUM_SUBADDRESSES + 1)
+            {
+                srcAccount = account;
+                break;
+            }
+        }
+        Assert.True(hasBalance, "Wallet does not have account with " + (NUM_SUBADDRESSES + 1) + " subaddresses with balances; run send-to-multiple tests");
+        Assert.True(unlockedSubaddresses.Count >= NUM_SUBADDRESSES + 1, "Wallet is waiting on unlocked funds");
+
+        // determine the indices of the first two subaddresses with unlocked balances
+        List<uint> fromSubaddressIndices = new List<uint>();
+        for (int i = 0; i < NUM_SUBADDRESSES; i++)
+        {
+            fromSubaddressIndices.Add((uint)unlockedSubaddresses[i].GetIndex());
+        }
+
+        // determine the amount to send
+        ulong sendAmount = 0;
+        foreach (int fromSubaddressIdx in fromSubaddressIndices)
+        {
+            sendAmount = sendAmount + ((ulong)srcAccount.GetSubaddresses()[fromSubaddressIdx].GetUnlockedBalance());
+        }
+        sendAmount = sendAmount / SEND_DIVISOR;
+
+        ulong fromBalance = 0;
+        ulong fromUnlockedBalance = 0;
+        foreach (uint subaddressIdx in fromSubaddressIndices)
+        {
+            MoneroSubaddress subaddress = wallet.GetSubaddress((uint)srcAccount.GetIndex(), subaddressIdx);
+            fromBalance = fromBalance + ((ulong)subaddress.GetBalance());
+            fromUnlockedBalance = fromUnlockedBalance + ((ulong)subaddress.GetUnlockedBalance());
+        }
+
+        // send from the first subaddresses with unlocked balances
+        string address = wallet.GetPrimaryAddress();
+        config.SetDestinations([new MoneroDestination(address, sendAmount)]);
+        config.SetAccountIndex(srcAccount.GetIndex());
+        config.SetSubaddressIndices(fromSubaddressIndices);
+        config.SetRelay(true);
+        MoneroTxConfig configCopy = config.Clone();
+        List<MoneroTxWallet> txs = new List<MoneroTxWallet>();
+        if (config.GetCanSplit() != false)
+        {
+            txs.AddRange(wallet.CreateTxs(config));
+        }
+        else txs.Add(wallet.CreateTx(config));
+        if (config.GetCanSplit() == false) Assert.Single(txs);  // must have exactly one tx if no split
+
+        // test that config is unchanged
+        Assert.True(configCopy != config);
+        Assert.Equal(configCopy, config);
+
+        // test that balances of intended subaddresses decreased
+        List<MoneroAccount> accountsAfter = wallet.GetAccounts(true);
+        Assert.Equal(accounts.Count, accountsAfter.Count);
+        bool srcUnlockedBalancedDecreased = false;
+        for (int i = 0; i < accounts.Count; i++)
+        {
+            Assert.Equal(accounts[i].GetSubaddresses().Count, accountsAfter[i].GetSubaddresses().Count);
+            for (uint j = 0; j < accounts[i].GetSubaddresses().Count; j++)
+            {
+                MoneroSubaddress subaddressBefore = accounts[i].GetSubaddresses()[(int)j];
+                MoneroSubaddress subaddressAfter = accountsAfter[i].GetSubaddresses()[(int)j];
+                if (i == srcAccount.GetIndex() && fromSubaddressIndices.Contains(j))
+                {
+                    if (((ulong)subaddressAfter.GetUnlockedBalance()).CompareTo(subaddressBefore.GetUnlockedBalance()) < 0) srcUnlockedBalancedDecreased = true;
+                }
+                else
+                {
+                    Assert.True(((ulong)subaddressAfter.GetUnlockedBalance()).CompareTo(subaddressBefore.GetUnlockedBalance()) == 0, "Subaddress [" + i + "," + j + "] unlocked balance should not have changed");
+                }
+            }
+        }
+        Assert.True(srcUnlockedBalancedDecreased, "Subaddress unlocked balances should have decreased");
+
+        // test context
+        TxContext ctx = new TxContext();
+        ctx.Config = config;
+        ctx.Wallet = wallet;
+        ctx.IsSendResponse = true;
+
+        // test each transaction
+        Assert.True(txs.Count > 0);
+        ulong outgoingSum = 0;
+        foreach (MoneroTxWallet tx in txs)
+        {
+            TestTxWallet(tx, ctx);
+            outgoingSum = outgoingSum + ((ulong)tx.GetOutgoingAmount());
+            if (tx.GetOutgoingTransfer() != null && tx.GetOutgoingTransfer().GetDestinations() != null)
+            {
+                ulong destinationSum = 0;
+                foreach (MoneroDestination destination in tx.GetOutgoingTransfer().GetDestinations())
+                {
+                    TestDestination(destination);
+                    Assert.Equal(address, destination.GetAddress());
+                    destinationSum = destinationSum + ((ulong)destination.GetAmount());
+                }
+                Assert.True(tx.GetOutgoingAmount().Equals(destinationSum));  // Assert. that transfers sum up to tx amount
+            }
+        }
+
+        // Assert. that tx amounts sum up the amount sent within a small margin
+        if (sendAmount >= outgoingSum && (sendAmount - outgoingSum) > SEND_MAX_DIFF)
+        { // send amounts may be slightly different
+            throw new Exception("Tx amounts are too different: " + sendAmount + " - " + outgoingSum + " = " + (sendAmount - (outgoingSum)));
+        }
+    }
+
+    private void TestSendToSingle(MoneroTxConfig config)
+    {
+        TestUtils.WALLET_TX_TRACKER.WaitForWalletTxsToClearPool(wallet);
+        if (config == null) config = new MoneroTxConfig();
+
+        // find a non-primary subaddress to send from
+        bool sufficientBalance = false;
+        MoneroAccount fromAccount = null;
+        MoneroSubaddress fromSubaddress = null;
+        List<MoneroAccount> accounts = wallet.GetAccounts(true);
+        foreach (MoneroAccount account in accounts)
+        {
+            List<MoneroSubaddress> subaddresses = account.GetSubaddresses();
+            for (int i = 1; i < subaddresses.Count; i++)
+            {
+                if (((ulong)subaddresses[i].GetBalance()).CompareTo(TestUtils.MAX_FEE) > 0) sufficientBalance = true;
+                if (((ulong)subaddresses[i].GetUnlockedBalance()).CompareTo(TestUtils.MAX_FEE) > 0)
+                {
+                    fromAccount = account;
+                    fromSubaddress = subaddresses[i];
+                    break;
+                }
+            }
+            if (fromAccount != null) break;
+        }
+        Assert.True(sufficientBalance, "No non-primary subaddress found with sufficient balance");
+        Assert.True(fromSubaddress != null, "Wallet is waiting on unlocked funds");
+
+        // get balance before send
+        ulong balanceBefore = (ulong)fromSubaddress.GetBalance();
+        ulong unlockedBalanceBefore = (ulong)fromSubaddress.GetUnlockedBalance();
+
+        // init tx config
+        ulong sendAmount = (unlockedBalanceBefore - TestUtils.MAX_FEE) / SEND_DIVISOR;
+        string address = wallet.GetPrimaryAddress();
+        config.SetDestinations([new MoneroDestination(address, sendAmount)]);
+        config.SetAccountIndex(fromAccount.GetIndex());
+        config.SetSubaddressIndices([(uint)fromSubaddress.GetIndex()]);
+        MoneroTxConfig configCopy = config.Clone();
+
+        // test sending to invalid address
+        try
+        {
+            config.SetAddress("my invalid address");
+            if (config.GetCanSplit() != false) wallet.CreateTxs(config);
+            else wallet.CreateTx(config);
+            Assert.Fail("Should have thrown error creating tx with invalid address");
+        }
+        catch (MoneroError e)
+        {
+            Assert.Equal("Invalid destination address", e.Message);
+            config.SetAddress(address);
+        }
+
+        // send to self
+        List<MoneroTxWallet> txs = wallet.CreateTxs(config);
+        if (config.GetCanSplit() != false) Assert.Single(txs);  // must have exactly one tx if no split
+
+        // test that config is unchanged
+        Assert.True(configCopy != config);
+        Assert.Equal(configCopy, config);
+
+        // test common tx set among txs
+        TestCommonTxSets(txs, false, false, false);
+
+        // handle non-relayed transaction
+        if (config.GetRelay() != true)
+        {
+
+            // build test context
+            TxContext ctx2 = new TxContext();
+            ctx2.Wallet = wallet;
+            ctx2.Config = config;
+            ctx2.IsSendResponse = true;
+
+            // test transactions
+            foreach (MoneroTxWallet tx in txs)
+            {
+                TestTxWallet(tx, ctx2);
+            }
+
+            // txs are not in the pool
+            foreach (MoneroTxWallet txCreated in txs)
+            {
+                foreach (MoneroTx txPool in daemon.GetTxPool())
+                {
+                    Assert.False(txPool.GetHash().Equals(txCreated.GetHash()), "Created tx should not be in the pool");
+                }
+            }
+
+            // relay txs
+            List<string> txHashes = null;
+            if (config.GetCanSplit() != true) txHashes = [wallet.RelayTx(txs[0])]; // test relayTx() with single transaction
+            else
+            {
+                List<string> txMetadatas = new List<string>();
+                foreach (MoneroTxWallet tx in txs) txMetadatas.Add(tx.GetMetadata());
+                txHashes = wallet.RelayTxs(txMetadatas); // test relayTxs() with potentially multiple transactions
+            }
+            foreach (string txHash in txHashes) Assert.Equal(64, txHash.Length);
+
+            // fetch txs for testing
+            txs = wallet.GetTxs(new MoneroTxQuery().SetHashes(txHashes));
+        }
+
+        // test that balance and unlocked balance decreased
+        // TODO: test that other balances did not decrease
+        MoneroSubaddress subaddress = wallet.GetSubaddress((uint)fromAccount.GetIndex(), (uint)fromSubaddress.GetIndex());
+        Assert.True(((ulong)subaddress.GetBalance()).CompareTo(balanceBefore) < 0);
+        Assert.True(((ulong)subaddress.GetUnlockedBalance()).CompareTo(unlockedBalanceBefore) < 0);
+
+        // query locked txs
+        List<MoneroTxWallet> lockedTxs = GetAndTestTxs(wallet, new MoneroTxQuery().SetIsLocked(true), null, true);
+        foreach (MoneroTxWallet lockedTx in lockedTxs) Assert.Equal(true, lockedTx.IsLocked());
+
+        // build test context
+        TxContext ctx = new TxContext();
+        ctx.Wallet = wallet;
+        ctx.Config = config;
+        ctx.IsSendResponse = config.GetRelay() == true;
+
+        // test transactions
+        Assert.True(txs.Count > 0);
+        foreach (MoneroTxWallet tx in txs)
+        {
+            TestTxWallet(tx, ctx);
+            Assert.Equal(fromAccount.GetIndex(), tx.GetOutgoingTransfer().GetAccountIndex());
+            Assert.Single(tx.GetOutgoingTransfer().GetSubaddressIndices());
+            Assert.Equal(fromSubaddress.GetIndex(), tx.GetOutgoingTransfer().GetSubaddressIndices()[0]);
+            Assert.True(sendAmount.Equals(tx.GetOutgoingAmount()));
+            if (config.GetPaymentId() != null) Assert.Equal(config.GetPaymentId(), tx.GetPaymentId());
+
+            // test outgoing destinations
+            if (tx.GetOutgoingTransfer() != null && tx.GetOutgoingTransfer().GetDestinations() != null)
+            {
+                Assert.Single(tx.GetOutgoingTransfer().GetDestinations());
+                foreach (MoneroDestination destination in tx.GetOutgoingTransfer().GetDestinations())
+                {
+                    TestDestination(destination);
+                    Assert.Equal(destination.GetAddress(), address);
+                    Assert.True(sendAmount.Equals(destination.GetAmount()));
+                }
+            }
+
+            // tx is among locked txs
+            bool found = false;
+            foreach (MoneroTxWallet locked in lockedTxs)
+            {
+                if (locked.GetHash().Equals(tx.GetHash()))
+                {
+                    found = true;
+                    break;
+                }
+            }
+            Assert.True(found, "Created txs should be among locked txs");
+        }
+
+        // if tx was relayed in separate step, all wallets will need to wait for tx to confirm in order to reliably sync
+        if (config.GetRelay() != true)
+        {
+            TestUtils.WALLET_TX_TRACKER.Reset(); // TODO: resetExcept(wallet), or does this test wallet also need to be waited on?
+        }
+    }
+
+    private void SendToMultiple(uint numAccounts, uint numSubaddressesPerAccount, bool canSplit, ulong? sendAmountPerSubaddress = null, bool subtractFeeFromDestinations = false)
+    {
+        TestUtils.WALLET_TX_TRACKER.WaitForWalletTxsToClearPool(wallet);
+
+        // compute the minimum account unlocked balance needed in order to fulfill the config
+        ulong? minAccountAmount = null;
+        uint totalSubaddresses = numAccounts * numSubaddressesPerAccount;
+        if (sendAmountPerSubaddress != null) minAccountAmount = (totalSubaddresses * sendAmountPerSubaddress) + TestUtils.MAX_FEE; // min account amount must cover the total amount being sent plus the tx fee = numAddresses * (amtPerSubaddress + fee)
+        else minAccountAmount = (TestUtils.MAX_FEE * totalSubaddresses * SEND_DIVISOR) + TestUtils.MAX_FEE; // account balance must be more than fee * numAddresses * divisor + fee so each destination amount is at least a fee's worth (so dust is not sent)
+
+        // send funds from first account with sufficient unlocked funds
+        MoneroAccount srcAccount = null;
+        bool hasBalance = false;
+        foreach (MoneroAccount walletAccount in wallet.GetAccounts())
+        {
+            if (walletAccount.GetBalance()! > minAccountAmount) hasBalance = true;
+            if (walletAccount.GetUnlockedBalance()! > minAccountAmount)
+            {
+                srcAccount = walletAccount;
+                break;
+            }
+        }
+        Assert.True(hasBalance, "Wallet does not have enough balance; load '" + TestUtils.WALLET_NAME + "' with XMR in order to test sending");
+        if (srcAccount == null) throw new Exception("Wallet is waiting on unlocked funds");
+        ulong balance = (ulong)srcAccount.GetBalance()!;
+        ulong unlockedBalance = (ulong)srcAccount.GetUnlockedBalance()!;
+
+        // get amount to send total and per subaddress
+        ulong? sendAmount = null;
+        if (sendAmountPerSubaddress == null)
+        {
+            sendAmount = TestUtils.MAX_FEE * 5 * totalSubaddresses;
+            sendAmountPerSubaddress = (ulong)(sendAmount / ((ulong)totalSubaddresses));
+        }
+        else
+        {
+            sendAmount = sendAmountPerSubaddress * totalSubaddresses;
+        }
+
+        // create minimum number of accounts
+        List<MoneroAccount> accounts = wallet.GetAccounts();
+        for (int i = 0; i < numAccounts - accounts.Count; i++)
+        {
+            wallet.CreateAccount();
+        }
+
+        // create minimum number of subaddresses per account and collect destination addresses
+        List<string> destinationAddresses = new List<string>();
+        for (uint i = 0; i < numAccounts; i++)
+        {
+            List<MoneroSubaddress> subaddresses = wallet.GetSubaddresses(i);
+            for (int j = 0; j < numSubaddressesPerAccount - subaddresses.Count; j++) wallet.CreateSubaddress(i);
+            subaddresses = wallet.GetSubaddresses(i);
+            Assert.True(subaddresses.Count >= numSubaddressesPerAccount);
+            for (int j = 0; j < numSubaddressesPerAccount; j++) destinationAddresses.Add(subaddresses[j].GetAddress());
+        }
+
+        // build tx config
+        MoneroTxConfig config = new MoneroTxConfig();
+        config.SetAccountIndex(srcAccount.GetIndex());
+        config.SetSubaddressIndices(null); // test assigning null
+        config.SetDestinations(new List<MoneroDestination>());
+        config.SetRelay(true);
+        config.SetCanSplit(canSplit);
+        config.SetPriority(MoneroTxPriority.NORMAL);
+        List<uint> subtractFeeFrom = new List<uint>();
+        for (uint i = 0; i < destinationAddresses.Count; i++)
+        {
+            config.GetDestinations().Add(new MoneroDestination(destinationAddresses[(int)i], sendAmountPerSubaddress));
+            subtractFeeFrom.Add(i);
+        }
+        if (subtractFeeFromDestinations) config.SetSubtractFeeFrom(subtractFeeFrom);
+
+        MoneroTxConfig configCopy = config.Clone();
+
+        // send tx(s) with config
+        List<MoneroTxWallet> txs = null;
+        try
+        {
+            txs = wallet.CreateTxs(config);
+        }
+        catch (MoneroError e)
+        {
+
+            // test error applying subtractFromFee with split txs
+            if (subtractFeeFromDestinations && txs == null)
+            {
+                if (!e.Message.Equals("subtractfeefrom transfers cannot be split over multiple transactions yet")) throw;
+                return;
+            }
+
+            throw;
+        }
+        if (!canSplit) Assert.Single(txs);
+
+        // test that config is unchanged
+        Assert.True(configCopy != config);
+        Assert.Equal(configCopy, config);
+
+        // test that wallet balance decreased
+        MoneroAccount account = wallet.GetAccount((uint)srcAccount.GetIndex());
+        Assert.True(account.GetBalance()! < balance);
+        Assert.True(account.GetUnlockedBalance()! < unlockedBalance);
+
+        // build test context
+        config.SetCanSplit(canSplit);
+        TxContext ctx = new TxContext();
+        ctx.Wallet = wallet;
+        ctx.Config = config;
+        ctx.IsSendResponse = true;
+
+        // test each transaction
+        Assert.True(txs.Count > 0);
+        ulong feeSum = 0;
+        ulong outgoingSum = 0;
+        TestTxsWallet(txs, ctx);
+        foreach (MoneroTxWallet tx in txs)
+        {
+            feeSum = feeSum + ((ulong)tx.GetFee());
+            outgoingSum = outgoingSum + ((ulong)tx.GetOutgoingAmount());
+            if (tx.GetOutgoingTransfer() != null && tx.GetOutgoingTransfer().GetDestinations() != null)
+            {
+                ulong destinationSum = 0;
+                foreach (MoneroDestination destination in tx.GetOutgoingTransfer().GetDestinations())
+                {
+                    TestDestination(destination);
+                    Assert.Contains(destination.GetAddress(), destinationAddresses);
+                    destinationSum = destinationSum + ((ulong)destination.GetAmount());
+                }
+                Assert.True(tx.GetOutgoingAmount().Equals(destinationSum));  // Assert. that transfers sum up to tx amount
+            }
+        }
+
+        // Assert. that outgoing amounts sum up to the amount sent within a small margin
+        if (sendAmount - (subtractFeeFromDestinations ? feeSum : 0) - outgoingSum > SEND_MAX_DIFF)
+        { // send amounts may be slightly different
+            Assert.Fail("Actual send amount is too different from requested send amount: " + sendAmount + " - " + (subtractFeeFromDestinations ? feeSum : 0) + " - " + outgoingSum + " = " + (sendAmount - (subtractFeeFromDestinations ? feeSum : 0) - outgoingSum));
+        }
+    }
+
+    private void TestSendAndUpdateTxs(MoneroTxConfig config)
+    {
+
+        // wait for txs to confirm and for sufficient unlocked balance
+        TestUtils.WALLET_TX_TRACKER.WaitForWalletTxsToClearPool(wallet);
+        Assert.Null(config.GetSubaddressIndices());
+        TestUtils.WALLET_TX_TRACKER.WaitForUnlockedBalance(wallet, config.GetAccountIndex(), null, TestUtils.MAX_FEE * 2);
+
+        // this test starts and stops mining, so it's wrapped in order to stop mining if anything fails
+        try
+        {
+
+            // send transactions
+            List<MoneroTxWallet> sentTxs = wallet.CreateTxs(config);
+
+            // build test context
+            TxContext ctx = new TxContext();
+            ctx.Wallet = wallet;
+            ctx.Config = config;
+            ctx.IsSendResponse = true;
+
+            // test sent transactions
+            foreach (MoneroTxWallet tx in sentTxs)
+            {
+                TestTxWallet(tx, ctx);
+                Assert.Equal(false, tx.IsConfirmed());
+                Assert.Equal(true, tx.InTxPool());
+            }
+
+            // track resulting outgoing and incoming txs as blocks are added to the chain
+            List<MoneroTxWallet> updatedTxs = null;
+
+            // attempt to start mining to push the network along
+            bool startedMining = false;
+            MoneroMiningStatus miningStatus = daemon.GetMiningStatus();
+            if (miningStatus.IsActive() != true)
+            {
+                try
+                {
+                    StartMining.Start();
+                    startedMining = true;
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine("Warning: could not start mining: " + e.Message); // not fatal
+                }
+            }
+
+            // loop to update txs through confirmations
+            ulong numConfirmations = 0;
+            ulong numConfirmationsTotal = 2; // number of confirmations to test
+            while (numConfirmations < numConfirmationsTotal)
+            {
+                Console.WriteLine(numConfirmations + " < " + numConfirmationsTotal + " needed confirmations");
+
+                // wait for a block
+                MoneroBlockHeader header = daemon.WaitForNextBlockHeader();
+                Console.WriteLine("*** Block " + header.GetHeight() + " added to chain ***");
+
+                // give wallet time to catch up, otherwise incoming tx may not appear
+                // TODO: this lets new block slip, okay?
+                try
+                {
+                    GenUtils.WaitFor(TestUtils.SYNC_PERIOD_IN_MS);
+                }
+                catch (ThreadInterruptedException e)
+                {
+                    throw new Exception("Thread was interrupted", e);
+                }
+
+                // get incoming/outgoing txs with sent hashes
+                List<string> txHashes = new List<string>();
+                foreach (MoneroTxWallet sentTx in sentTxs) txHashes.Add(sentTx.GetHash());
+                MoneroTxQuery txQuery = new MoneroTxQuery().SetHashes(txHashes);
+                List<MoneroTxWallet> fetchedTxs = GetAndTestTxs(wallet, txQuery, null, true);
+                Assert.False(fetchedTxs.Count == 0);
+
+                // test fetched txs
+                TestOutInPairs(wallet, fetchedTxs, config, false);
+
+                // merge fetched txs into updated txs and original sent txs
+                foreach (MoneroTxWallet fetchedTx in fetchedTxs)
+                {
+
+                    // merge with updated txs
+                    if (updatedTxs == null) updatedTxs = fetchedTxs;
+                    else
+                    {
+                        foreach (MoneroTxWallet updatedTx in updatedTxs)
+                        {
+                            if (!fetchedTx.GetHash().Equals(updatedTx.GetHash())) continue;
+                            if (fetchedTx.IsOutgoing() != updatedTx.IsOutgoing()) continue; // skip if directions are different
+                            updatedTx.Merge(fetchedTx.Clone());
+                            if (updatedTx.GetBlock() == null && fetchedTx.GetBlock() != null) updatedTx.SetBlock(fetchedTx.GetBlock().Clone().SetTxs([updatedTx]));  // copy block for testing
+                        }
+                    }
+
+                    // merge with original sent txs
+                    foreach (MoneroTxWallet sentTx in sentTxs)
+                    {
+                        if (!fetchedTx.GetHash().Equals(sentTx.GetHash())) continue;
+                        if (fetchedTx.IsOutgoing() != sentTx.IsOutgoing()) continue; // skip if directions are different
+                        sentTx.Merge(fetchedTx.Clone());  // TODO: it's mergeable but tests don't account for extra info from send (e.g. hex) so not tested; could specify in test config
+                    }
+                }
+
+                // test updated txs
+                TestOutInPairs(wallet, updatedTxs, config, false);
+
+                // update confirmations in order to exit loop
+                numConfirmations = (ulong)fetchedTxs[0].GetNumConfirmations();
+            }
+
+            // stop mining if it was started by this test
+            if (startedMining) wallet.StopMining();
+
+        }
+        catch (MoneroError e)
+        {
+            throw;
+        }
+        finally
+        {
+
+            // stop mining at end of test
+            try { daemon.StopMining(); }
+            catch (MoneroError e) { }
+        }
+    }
+
+    private void TestOutInPairs(MoneroWallet wallet, List<MoneroTxWallet> txs, MoneroTxConfig config, bool isSendResponse)
+    {
+        // for each out tx
+        foreach (MoneroTxWallet tx in txs)
+        {
+            TestUnlockTx(wallet, tx, config, isSendResponse);
+            if (tx.GetOutgoingTransfer() != null) continue;
+            MoneroTxWallet txOut = tx;
+
+            // find incoming counterpart
+            MoneroTxWallet txIn = null;
+            foreach (MoneroTxWallet tx2 in txs)
+            {
+                if (tx2.IsIncoming() == true && tx.GetHash().Equals(tx2.GetHash()))
+                {
+                    txIn = tx2;
+                    break;
+                }
+            }
+
+            // test out / in pair
+            // TODO monero-wallet-rpc: incoming txs occluded by their outgoing counterpart #4500
+            if (txIn == null)
+            {
+                Console.WriteLine("WARNING: outgoing tx " + txOut.GetHash() + " missing incoming counterpart (issue #4500)");
+            }
+            else
+            {
+                TestOutInPair(txOut, txIn);
+            }
+        }
+    }
+
+    private void TestOutInPair(MoneroTxWallet txOut, MoneroTxWallet txIn)
+    {
+        Assert.Equal(txOut.IsConfirmed(), txIn.IsConfirmed());
+        Assert.Equal(txIn.GetIncomingAmount(), txOut.GetOutgoingAmount());
+    }
+
+    private void TestUnlockTx(MoneroWallet wallet, MoneroTxWallet tx, MoneroTxConfig config, bool isSendResponse)
+    {
+        TxContext ctx = new TxContext();
+        ctx.Wallet = wallet;
+        ctx.Config = config;
+        ctx.IsSendResponse = isSendResponse;
+        try
+        {
+            TestTxWallet(tx, ctx);
+        }
+        catch (MoneroError e)
+        {
+            Console.WriteLine(tx.ToString());
+            throw;
+        }
+    }
+
+    #endregion
+
+    #endregion
+
+    #region Reset Tests
+
+    // Can sweep subaddresses
+    [Fact]
+    public virtual void TestSweepSubaddresses()
+    {
+        Assert.True(TEST_RESETS, "Reset tests disabled");
+        TestUtils.WALLET_TX_TRACKER.WaitForWalletTxsToClearPool(wallet);
+
+        const int NUM_SUBADDRESSES_TO_SWEEP = 2;
+
+        // collect subaddresses with balance and unlocked balance
+        List<MoneroSubaddress> subaddresses = new List<MoneroSubaddress>();
+        List<MoneroSubaddress> subaddressesBalance = new List<MoneroSubaddress>();
+        List<MoneroSubaddress> subaddressesUnlocked = new List<MoneroSubaddress>();
+        foreach (MoneroAccount account in wallet.GetAccounts(true))
+        {
+            if (account.GetIndex() == 0) continue;  // skip default account
+            foreach (MoneroSubaddress subaddress in account.GetSubaddresses())
+            {
+                subaddresses.Add(subaddress);
+                if (((ulong)subaddress.GetBalance()).CompareTo(TestUtils.MAX_FEE) > 0) subaddressesBalance.Add(subaddress);
+                if (((ulong)subaddress.GetUnlockedBalance()).CompareTo(TestUtils.MAX_FEE) > 0) subaddressesUnlocked.Add(subaddress);
+            }
+        }
+
+        // test requires at least one more subaddresses than the number being swept to verify it does not change
+        Assert.True(subaddressesBalance.Count >= NUM_SUBADDRESSES_TO_SWEEP + 1, "Test requires balance in at least " + (NUM_SUBADDRESSES_TO_SWEEP + 1) + " subaddresses from non-default acccount; run send-to-multiple tests");
+        Assert.True(subaddressesUnlocked.Count >= NUM_SUBADDRESSES_TO_SWEEP + 1, "Wallet is waiting on unlocked funds");
+
+        // sweep from first unlocked subaddresses
+        for (int i = 0; i < NUM_SUBADDRESSES_TO_SWEEP; i++)
+        {
+
+            // sweep unlocked account
+            MoneroSubaddress unlockedSubaddress = subaddressesUnlocked[i];
+            MoneroTxConfig config = new MoneroTxConfig()
+                    .SetAddress(wallet.GetPrimaryAddress())
+                    .SetAccountIndex(unlockedSubaddress.GetAccountIndex())
+                    .SetSubaddressIndices([(uint)unlockedSubaddress.GetIndex()])
+                    .SetRelay(true);
+            List<MoneroTxWallet> txs = wallet.SweepUnlocked(config);
+
+            // test transactions
+            Assert.True(txs.Count > 0);
+            foreach (MoneroTxWallet tx in txs)
+            {
+                Assert.Contains(tx, tx.GetTxSet().GetTxs());
+                TxContext ctx = new TxContext();
+                ctx.Wallet = wallet;
+                ctx.Config = config;
+                ctx.IsSendResponse = true;
+                ctx.IsSweepResponse = true;
+                TestTxWallet(tx, ctx);
+            }
+
+            // Assert. unlocked balance is less than max fee
+            MoneroSubaddress subaddress = wallet.GetSubaddress(((uint)unlockedSubaddress.GetAccountIndex()), ((uint)unlockedSubaddress.GetIndex()));
+            Assert.True(((ulong)subaddress.GetUnlockedBalance()).CompareTo(TestUtils.MAX_FEE) < 0);
+        }
+
+        // test subaddresses after sweeping
+        List<MoneroSubaddress> subaddressesAfter = new List<MoneroSubaddress>();
+        foreach (MoneroAccount account in wallet.GetAccounts(true))
+        {
+            if (account.GetIndex() == 0) continue;  // skip default account
+            foreach (MoneroSubaddress subaddress in account.GetSubaddresses())
+            {
+                subaddressesAfter.Add(subaddress);
+            }
+        }
+        Assert.Equal(subaddresses.Count, subaddressesAfter.Count);
+        for (int i = 0; i < subaddresses.Count; i++)
+        {
+            MoneroSubaddress subaddressBefore = subaddresses[i];
+            MoneroSubaddress subaddressAfter = subaddressesAfter[i];
+
+            // determine if subaddress was swept
+            bool swept = false;
+            for (int j = 0; j < NUM_SUBADDRESSES_TO_SWEEP; j++)
+            {
+                if (subaddressesUnlocked[j].GetAccountIndex().Equals(subaddressBefore.GetAccountIndex()) && subaddressesUnlocked[j].GetIndex().Equals(subaddressBefore.GetIndex()))
+                {
+                    swept = true;
+                    break;
+                }
+            }
+
+            // Assert. unlocked balance is less than max fee if swept, unchanged otherwise
+            if (swept)
+            {
+                Assert.True(((ulong)subaddressAfter.GetUnlockedBalance()).CompareTo(TestUtils.MAX_FEE) < 0);
+            }
+            else
+            {
+                Assert.True(((ulong)subaddressBefore.GetUnlockedBalance()).CompareTo(subaddressAfter.GetUnlockedBalance()) == 0);
+            }
+        }
+    }
+
+    // Can sweep accounts
+    [Fact]
+    public virtual void TestSweepAccounts()
+    {
+        Assert.True(TEST_RESETS, "Reset tests disabled");
+        TestUtils.WALLET_TX_TRACKER.WaitForWalletTxsToClearPool(wallet);
+
+        const int NUM_ACCOUNTS_TO_SWEEP = 1;
+
+        // collect accounts with sufficient balance and unlocked balance to cover the fee
+        List<MoneroAccount> accounts = wallet.GetAccounts(true);
+        List<MoneroAccount> accountsBalance = new List<MoneroAccount>();
+        List<MoneroAccount> accountsUnlocked = new List<MoneroAccount>();
+        foreach (MoneroAccount account in accounts)
+        {
+            if (account.GetIndex() == 0) continue;  // skip default account
+            if (account.GetBalance() > TestUtils.MAX_FEE) accountsBalance.Add(account);
+            if (account.GetUnlockedBalance() > TestUtils.MAX_FEE) accountsUnlocked.Add(account);
+        }
+
+        // test requires at least one more accounts than the number being swept to verify it does not change
+        Assert.True(accountsBalance.Count >= NUM_ACCOUNTS_TO_SWEEP + 1, "Test requires balance greater than the fee in at least " + (NUM_ACCOUNTS_TO_SWEEP + 1) + " non-default accounts; run send-to-multiple tests");
+        Assert.True(accountsUnlocked.Count >= NUM_ACCOUNTS_TO_SWEEP + 1, "Wallet is waiting on unlocked funds");
+
+        // sweep from first unlocked accounts
+        for (int i = 0; i < NUM_ACCOUNTS_TO_SWEEP; i++)
+        {
+
+            // sweep unlocked account
+            MoneroAccount unlockedAccount = accountsUnlocked[i];
+            MoneroTxConfig config = new MoneroTxConfig().SetAddress(wallet.GetPrimaryAddress()).SetAccountIndex(unlockedAccount.GetIndex()).SetRelay(true);
+            List<MoneroTxWallet> txs = wallet.SweepUnlocked(config);
+
+            // test transactions
+            Assert.True(txs.Count > 0);
+            foreach (MoneroTxWallet tx in txs)
+            {
+                TxContext ctx = new TxContext();
+                ctx.Wallet = wallet;
+                ctx.Config = config;
+                ctx.IsSendResponse = true;
+                ctx.IsSweepResponse = true;
+                TestTxWallet(tx, ctx);
+                Assert.NotNull(tx.GetTxSet());
+                Assert.Contains(tx, tx.GetTxSet().GetTxs());
+            }
+
+            // Assert. unlocked account balance less than max fee
+            MoneroAccount account = wallet.GetAccount((uint)unlockedAccount.GetIndex());
+            Assert.True(account.GetUnlockedBalance()! < TestUtils.MAX_FEE);
+        }
+
+        // test accounts after sweeping
+        List<MoneroAccount> accountsAfter = wallet.GetAccounts(true);
+        Assert.Equal(accounts.Count, accountsAfter.Count);
+        for (int i = 0; i < accounts.Count; i++)
+        {
+            MoneroAccount accountBefore = accounts[i];
+            MoneroAccount accountAfter = accountsAfter[i];
+
+            // determine if account was swept
+            bool swept = false;
+            for (int j = 0; j < NUM_ACCOUNTS_TO_SWEEP; j++)
+            {
+                if (accountsUnlocked[j].GetIndex().Equals(accountBefore.GetIndex()))
+                {
+                    swept = true;
+                    break;
+                }
+            }
+
+            // Assert. unlocked balance is less than max fee if swept, unchanged otherwise
+            if (swept)
+            {
+                Assert.True(accountAfter.GetUnlockedBalance()! < TestUtils.MAX_FEE);
+            }
+            else
+            {
+                Assert.True(accountBefore.GetUnlockedBalance() == accountAfter.GetUnlockedBalance());
+            }
+        }
+    }
+
+    // Can sweep the whole wallet by accounts
+    [Fact(Skip = "Disabled so tests don't sweep the whole wallet")]
+    public virtual void TestSweepWalletByAccounts()
+    {
+        Assert.True(TEST_RESETS, "Reset tests disabled");
+        TestSweepWallet(null);
+    }
+
+    // Can sweep the whole wallet by subaddresses
+    [Fact(Skip = "Disabled so tests don't sweep the whole wallet")]
+    public virtual void TestSweepWalletBySubaddresses()
+    {
+        Assert.True(TEST_RESETS, "Reset tests disabled");
+        TestSweepWallet(true);
+    }
+
+    private void TestSweepWallet(bool? sweepEachSubaddress)
+    {
+        TestUtils.WALLET_TX_TRACKER.WaitForWalletTxsToClearPool(wallet);
+
+        // verify 2 subaddresses with enough unlocked balance to cover the fee
+        List<MoneroSubaddress> subaddressesBalance = new List<MoneroSubaddress>();
+        List<MoneroSubaddress> subaddressesUnlocked = new List<MoneroSubaddress>();
+        foreach (MoneroAccount account in wallet.GetAccounts(true))
+        {
+            foreach (MoneroSubaddress subaddress in account.GetSubaddresses())
+            {
+                if (((ulong)subaddress.GetBalance()).CompareTo(TestUtils.MAX_FEE) > 0) subaddressesBalance.Add(subaddress);
+                if (((ulong)subaddress.GetUnlockedBalance()).CompareTo(TestUtils.MAX_FEE) > 0) subaddressesUnlocked.Add(subaddress);
+            }
+        }
+        Assert.True(subaddressesBalance.Count >= 2, "Test requires multiple accounts with a balance greater than the fee; run send to multiple first");
+        Assert.True(subaddressesUnlocked.Count >= 2, "Wallet is waiting on unlocked funds");
+
+        // sweep
+        string destination = wallet.GetPrimaryAddress();
+        MoneroTxConfig config = new MoneroTxConfig().SetAddress(destination).SetSweepEachSubaddress(sweepEachSubaddress).SetRelay(true);
+        MoneroTxConfig copy = config.Clone();
+        List<MoneroTxWallet> txs = wallet.SweepUnlocked(config);
+        Assert.Equal(copy, config);  // config is unchanged
+        foreach (MoneroTxWallet tx in txs)
+        {
+            Assert.Contains(tx, tx.GetTxSet().GetTxs());
+            Assert.Null(tx.GetTxSet().GetMultisigTxHex());
+            Assert.Null(tx.GetTxSet().GetSignedTxHex());
+            Assert.Null(tx.GetTxSet().GetUnsignedTxHex());
+        }
+        Assert.True(txs.Count > 0);
+        foreach (MoneroTxWallet tx in txs)
+        {
+            config = new MoneroTxConfig()
+                    .SetAddress(destination)
+                    .SetAccountIndex(tx.GetOutgoingTransfer().GetAccountIndex())
+                    .SetSweepEachSubaddress(sweepEachSubaddress)
+                    .SetRelay(true);
+            TxContext ctx = new TxContext();
+            ctx.Wallet = wallet;
+            ctx.Config = config;
+            ctx.IsSendResponse = true;
+            ctx.IsSweepResponse = true;
+            TestTxWallet(tx, ctx);
+        }
+
+        // all unspent, unlocked outputs must be less than fee
+        List<MoneroOutputWallet> spendableOutputs = wallet.GetOutputs(new MoneroOutputQuery().SetIsSpent(false).SetTxQuery(new MoneroTxQuery().SetIsLocked(false)));
+        foreach (MoneroOutputWallet spendableOutput in spendableOutputs)
+        {
+            Assert.True(((ulong)spendableOutput.GetAmount()).CompareTo(TestUtils.MAX_FEE) < 0, "Unspent output should have been swept\n" + spendableOutput.ToString());
+        }
+
+        // all subaddress unlocked balances must be less than fee
+        subaddressesBalance.Clear();
+        subaddressesUnlocked.Clear();
+        foreach (MoneroAccount account in wallet.GetAccounts(true))
+        {
+            foreach (MoneroSubaddress subaddress in account.GetSubaddresses())
+            {
+                Assert.True(((ulong)subaddress.GetUnlockedBalance()).CompareTo(TestUtils.MAX_FEE) < 0, "No subaddress should have more unlocked than the fee");
+            }
+        }
+    }
+
+    // Can scan transactions by id
+    [Fact]
+    public virtual void TestScanTxs()
+    {
+
+        // get a few tx hashes
+        List<string> txHashes = [];
+        List<MoneroTxWallet> txs = wallet.GetTxs();
+        if (txs.Count < 3) Assert.Fail("Not enough txs to scan");
+        for (int i = 0; i < 3; i++) txHashes.Add(txs[i].GetHash());
+
+        // start wallet without scanning
+        MoneroWallet scanWallet = CreateWallet(new MoneroWalletConfig().SetSeed(wallet.GetSeed()).SetRestoreHeight(0));
+        scanWallet.StopSyncing(); // TODO: create wallet without daemon connection (offline does not reconnect, default connects to localhost, offline then online causes confirmed txs to disappear)
+        Assert.True(scanWallet.IsConnectedToDaemon());
+
+        // scan txs
+        scanWallet.ScanTxs(txHashes);
+
+        // TODO: scanning txs causes merge problems reconciling 0 fee, isMinerTx with test txs
+
+        //    // txs are scanned
+        //    Assert.Equal(txHashes.Count, scanWallet.GetTxs().Count);
+        //    for (int i = 0; i < txHashes.Count; i++) {
+        //      Assert.Equal(wallet.GetTx(txHashes[i]), scanWallet.GetTx(txHashes[i]));
+        //    }
+        //    List<MoneroTxWallet> scannedTxs = scanWallet.GetTxs(txHashes);
+        //    Assert.Equal(txHashes.Count, scannedTxs.Count);
+
+        // close wallet
+        CloseWallet(scanWallet, false);
+    }
+
+    // Can rescan the blockchain
+    [Fact(Skip = "Disabled so tests don't delete local cache")]
+    public virtual void TestRescanBlockchain()
+    {
+        Assert.True(TEST_RESETS, "Reset tests disabled");
+        wallet.RescanBlockchain();
+        foreach (MoneroTxWallet tx in wallet.GetTxs())
+        {
+            TestTxWallet(tx, null);
+        }
+    }
+
+    #endregion
+
+    #region Notification Tests
+
+    // Can generate notifications sending to different wallet
+    [Fact]
+    public virtual void TestNotificationsDifferentWallet()
+    {
+        TestWalletNotifications("TestNotificationsDifferentWallet", false, false, false, false, 0);
+    }
+
+    // Can generate notifications sending to different wallet when relayed
+    [Fact]
+    public virtual void TestNotificationsDifferentWalletWhenRelayed()
+    {
+        TestWalletNotifications("TestNotificationsDifferentWalletWhenRelayed", false, false, false, true, 3);
+    }
+
+    // Can generate notifications sending to different account
+    [Fact]
+    public virtual void TestNotificationsDifferentAccounts()
+    {
+        TestWalletNotifications("TestNotificationsDifferentAccounts", true, false, false, false, 0);
+    }
+
+    // Can generate notifications sending to same account
+    [Fact]
+    public virtual void TestNotificationsSameAccount()
+    {
+        TestWalletNotifications("TestNotificationsSameAccount", true, true, false, false, 0);
+    }
+
+    // Can generate notifications sweeping output to different account
+    [Fact]
+    public virtual void TestNotificationsDifferentAccountSweepOutput()
+    {
+        TestWalletNotifications("TestNotificationsDifferentAccountSweepOutput", true, false, true, false, 0);
+    }
+
+    // Can generate notifications sweeping output to same account when relayed
+    [Fact]
+    public virtual void TestNotificationsSameAccountSweepOutputWhenRelayed()
+    {
+        TestWalletNotifications("TestNotificationsSameAccountSweepOutputWhenRelayed", true, true, true, true, 0);
+    }
+
+    // Can stop listening
+    [Fact]
+    public virtual void TestStopListening()
+    {
+        // create wallet and start background synchronizing
+        MoneroWallet wallet = CreateWallet(new MoneroWalletConfig());
+
+        // add listener
+        WalletNotificationCollector listener = new WalletNotificationCollector();
+        wallet.AddListener(listener);
+        try { GenUtils.WaitFor(1000); }
+        catch (Exception e) { throw new Exception("An error occurred while sleeping", e); }
+
+        // remove listener and close
+        wallet.RemoveListener(listener);
+        CloseWallet(wallet);
+    }
+
+    // Can be created and receive funds
+    [Fact]
+    public virtual void TestCreateAndReceive()
+    {
+        Assert.True(TEST_NOTIFICATIONS);
+
+        // create random wallet
+        MoneroWallet receiver = CreateWallet(new MoneroWalletConfig());
+        try
+        {
+
+            // listen for received outputs
+            WalletNotificationCollector myListener = new WalletNotificationCollector();
+            receiver.AddListener(myListener);
+
+            // wait for txs to confirm and for sufficient unlocked balance
+            TestUtils.WALLET_TX_TRACKER.WaitForWalletTxsToClearPool(wallet);
+            TestUtils.WALLET_TX_TRACKER.WaitForUnlockedBalance(wallet, 0, null, TestUtils.MAX_FEE);
+
+            // send funds to the receiver
+            MoneroTxWallet sentTx = wallet.CreateTx(new MoneroTxConfig().SetAccountIndex(0).SetAddress(receiver.GetPrimaryAddress()).SetAmount(TestUtils.MAX_FEE).SetRelay(true));
+
+            // wait for funds to confirm
+            try { StartMining.Start(); } catch (Exception e) { }
+            while ((wallet.GetTx(sentTx.GetHash())).IsConfirmed() != true)
+            {
+                if (wallet.GetTx(sentTx.GetHash()).IsFailed() == true) throw new MoneroError("Tx failed in mempool: " + sentTx.GetHash());
+                daemon.WaitForNextBlockHeader();
+            }
+
+            // receiver should have notified listeners of received outputs
+            try { GenUtils.WaitFor(1000); } catch (ThreadInterruptedException e) { throw new Exception("Thread was interrupted", e); } // zmq notifications received within 1 second
+            Assert.False(myListener.GetOutputsReceived().Count == 0);
+        }
+        finally
+        {
+            CloseWallet(receiver);
+            try { daemon.StopMining(); } catch (Exception e) { }
+        }
+    }
+
+    // Can freeze and thaw outputs
+    [Fact]
+    public virtual void TestFreezeOutputs()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // get an available output
+        List<MoneroOutputWallet> outputs = wallet.GetOutputs(new MoneroOutputQuery().SetIsSpent(false).SetIsFrozen(false).SetTxQuery(new MoneroTxQuery().SetIsLocked(false)));
+        foreach (MoneroOutputWallet _out in outputs) Assert.False(_out.IsFrozen());
+        Assert.True(outputs.Count > 0);
+        MoneroOutputWallet output = outputs[0];
+        Assert.False(output.GetTx().IsLocked());
+        Assert.False(output.IsSpent());
+        Assert.False(output.IsFrozen());
+        Assert.False(wallet.IsOutputFrozen(output.GetKeyImage().GetHex()));
+
+        // freeze output by key image
+        int numFrozenBefore = wallet.GetOutputs(new MoneroOutputQuery().SetIsFrozen(true)).Count;
+        wallet.FreezeOutput(output.GetKeyImage().GetHex());
+        Assert.True(wallet.IsOutputFrozen(output.GetKeyImage().GetHex()));
+
+        // test querying
+        Assert.Equal(numFrozenBefore + 1, wallet.GetOutputs(new MoneroOutputQuery().SetIsFrozen(true)).Count);
+        outputs = wallet.GetOutputs(new MoneroOutputQuery().SetKeyImage(new MoneroKeyImage().SetHex(output.GetKeyImage().GetHex())).SetIsFrozen(true));
+        Assert.Single(outputs);
+        MoneroOutputWallet outputFrozen = outputs[0];
+        Assert.True(outputFrozen.IsFrozen());
+        Assert.Equal(output.GetKeyImage().GetHex(), outputFrozen.GetKeyImage().GetHex());
+
+        // try to sweep frozen output
+        try
+        {
+            wallet.SweepOutput(new MoneroTxConfig().SetAddress(wallet.GetPrimaryAddress()).SetKeyImage(output.GetKeyImage().GetHex()));
+            Assert.Fail("Should have thrown error");
+        }
+        catch (MoneroError e)
+        {
+            Assert.Equal("No outputs found", e.Message);
+        }
+
+        // try to freeze null key image
+        try
+        {
+            wallet.FreezeOutput(null);
+            Assert.Fail("Should have thrown error");
+        }
+        catch (MoneroError e)
+        {
+            Assert.Equal("Must specify key image to freeze", e.Message);
+        }
+
+        // try to freeze empty key image
+        try
+        {
+            wallet.FreezeOutput("");
+            Assert.Fail("Should have thrown error");
+        }
+        catch (MoneroError e)
+        {
+            Assert.Equal("Must specify key image to freeze", e.Message);
+        }
+
+        // try to freeze bad key image
+        try
+        {
+            wallet.FreezeOutput("123");
+            Assert.Fail("Should have thrown error");
+        }
+        catch (MoneroError e)
+        {
+            //Assert.Equal("Bad key image", e.Message);
+        }
+
+        // thaw output by key image
+        wallet.ThawOutput(output.GetKeyImage().GetHex());
+        Assert.False(wallet.IsOutputFrozen(output.GetKeyImage().GetHex()));
+
+        // test querying
+        Assert.Equal(numFrozenBefore, wallet.GetOutputs(new MoneroOutputQuery().SetIsFrozen(true)).Count);
+        outputs = wallet.GetOutputs(new MoneroOutputQuery().SetKeyImage(new MoneroKeyImage().SetHex(output.GetKeyImage().GetHex())).SetIsFrozen(true));
+        Assert.Empty(outputs);
+        outputs = wallet.GetOutputs(new MoneroOutputQuery().SetKeyImage(new MoneroKeyImage().SetHex(output.GetKeyImage().GetHex())).SetIsFrozen(false));
+        Assert.Single(outputs);
+        MoneroOutputWallet outputThawed = outputs[0];
+        Assert.False(outputThawed.IsFrozen());
+        Assert.Equal(output.GetKeyImage().GetHex(), outputThawed.GetKeyImage().GetHex());
+    }
+
+    // Provides key images of spent outputs
+    [Fact]
+    public virtual void TestInputKeyImages()
+    {
+        uint accountIndex = 0;
+        uint subaddressIndex = (wallet.GetSubaddresses(0).Count > 1) ? (uint)1 : 0; // TODO: avoid subaddress 0 which is more likely to fail transaction sanity check
+
+        // test unrelayed single transaction
+        TestSpendTx(wallet.CreateTx(new MoneroTxConfig().AddDestination(wallet.GetPrimaryAddress(), TestUtils.MAX_FEE).SetAccountIndex(accountIndex)));
+
+        // test unrelayed split transactions
+        foreach (MoneroTxWallet tx in wallet.CreateTxs(new MoneroTxConfig().AddDestination(wallet.GetPrimaryAddress(), TestUtils.MAX_FEE).SetAccountIndex(accountIndex)))
+        {
+            TestSpendTx(tx);
+        }
+
+        // test unrelayed sweep dust
+        List<string> dustKeyImages = new List<string>();
+        foreach (MoneroTxWallet tx in wallet.SweepDust(false))
+        {
+            TestSpendTx(tx);
+            foreach (MoneroOutput input in tx.GetInputs()) dustKeyImages.Add(input.GetKeyImage().GetHex());
+        }
+
+        // get available outputs above min amount
+        List<MoneroOutputWallet> outputs = wallet.GetOutputs(new MoneroOutputQuery().SetAccountIndex(accountIndex).SetSubaddressIndex(subaddressIndex).SetIsSpent(false).SetIsFrozen(false).SetTxQuery(new MoneroTxQuery().SetIsLocked(false)).SetMinAmount(TestUtils.MAX_FEE));
+
+        // filter dust outputs
+        List<MoneroOutputWallet> dustOutputs = new List<MoneroOutputWallet>();
+        foreach (MoneroOutputWallet output in outputs)
+        {
+            if (dustKeyImages.Contains(output.GetKeyImage().GetHex())) dustOutputs.Add(output);
+        }
+
+        foreach (var dustOutput in dustOutputs) outputs.Remove(dustOutput);
+
+        // test unrelayed sweep output
+        TestSpendTx(wallet.SweepOutput(new MoneroTxConfig().SetAddress(wallet.GetPrimaryAddress()).SetKeyImage(outputs[0].GetKeyImage().GetHex())));
+
+        // test unrelayed sweep wallet ensuring all non-dust outputs are spent
+        HashSet<string> availableKeyImages = new HashSet<string>();
+        foreach (MoneroOutputWallet output in outputs) availableKeyImages.Add(output.GetKeyImage().GetHex());
+        HashSet<string> sweptKeyImages = new HashSet<string>();
+        List<MoneroTxWallet> txs = wallet.SweepUnlocked(new MoneroTxConfig().SetAccountIndex(accountIndex).SetSubaddressIndex(subaddressIndex).SetAddress(wallet.GetPrimaryAddress()));
+        foreach (MoneroTxWallet tx in txs)
+        {
+            TestSpendTx(tx);
+            foreach (MoneroOutput input in tx.GetInputs()) sweptKeyImages.Add(input.GetKeyImage().GetHex());
+        }
+        Assert.True(sweptKeyImages.Count > 0);
+
+        // max skipped output is less than max fee amount
+        MoneroOutputWallet maxSkippedOutput = null;
+        foreach (MoneroOutputWallet output in outputs)
+        {
+            if (!sweptKeyImages.Contains(output.GetKeyImage().GetHex()))
+            {
+                if (maxSkippedOutput == null || ((ulong)maxSkippedOutput.GetAmount()).CompareTo(output.GetAmount()) < 0)
+                {
+                    maxSkippedOutput = output;
+                }
+            }
+        }
+        Assert.True(maxSkippedOutput == null || ((ulong)maxSkippedOutput.GetAmount()).CompareTo(TestUtils.MAX_FEE) < 0);
+    }
+
+    // Can prove unrelayed
+    [Fact]
+    public virtual void TestProveUnrelayedTxs()
+    {
+        // create unrelayed tx to verify
+        string address1 = TestUtils.GetExternalWalletAddress();
+        string address2 = wallet.GetAddress(0, 0);
+        string address3 = wallet.GetAddress(1, 0);
+        MoneroTxWallet tx = wallet.CreateTx(new MoneroTxConfig()
+                .SetAccountIndex(0)
+                .AddDestination(address1, TestUtils.MAX_FEE)
+                .AddDestination(address2, TestUtils.MAX_FEE * 2)
+                .AddDestination(address3, TestUtils.MAX_FEE * 2));
+
+        // submit tx to daemon but do not relay
+        MoneroSubmitTxResult result = daemon.SubmitTxHex(tx.GetFullHex(), true);
+        Assert.True(result.IsGood());
+
+        // create random wallet to verify transfers
+        MoneroWallet verifyingWallet = CreateWallet(new MoneroWalletConfig());
+
+        // verify transfer 1
+        MoneroCheckTx check = verifyingWallet.CheckTxKey(tx.GetHash(), tx.GetKey(), address1);
+        Assert.True(check.IsGood());
+        Assert.True(check.InTxPool());
+        Assert.True(0 == check.GetNumConfirmations());
+        Assert.Equal(TestUtils.MAX_FEE, check.GetReceivedAmount());
+
+        // verify transfer 2
+        check = verifyingWallet.CheckTxKey(tx.GetHash(), tx.GetKey(), address2);
+        Assert.True(check.IsGood());
+        Assert.True(check.InTxPool());
+        Assert.True(0 == check.GetNumConfirmations());
+        Assert.True(((ulong)check.GetReceivedAmount()).CompareTo(TestUtils.MAX_FEE * 2) >= 0); // + change amount
+
+        // verify transfer 3
+        check = verifyingWallet.CheckTxKey(tx.GetHash(), tx.GetKey(), address3);
+        Assert.True(check.IsGood());
+        Assert.True(check.InTxPool());
+        Assert.True(0 == check.GetNumConfirmations());
+        Assert.Equal(TestUtils.MAX_FEE * 3, check.GetReceivedAmount());
+
+        // cleanup
+        daemon.FlushTxPool(tx.GetHash());
+        CloseWallet(verifyingWallet);
+    }
+
+    // Can get the default fee priority
+    [Fact]
+    public virtual void TestGetDefaultFeePriority()
+    {
+        MoneroTxPriority defaultPriority = wallet.GetDefaultFeePriority();
+        Assert.True(defaultPriority > 0);
+    }
+
+    #region Notification Utils
+
+    private void TestWalletNotifications(string testName, bool sameWallet, bool sameAccount, bool sweepOutput, bool createThenRelay, ulong unlockDelay)
+    {
+        Assert.True(TEST_NOTIFICATIONS);
+        List<string> issues = TestWalletNotificationsAux(sameWallet, sameAccount, sweepOutput, createThenRelay, unlockDelay);
+        if (issues.Count == 0) return;
+        string msg = testName + "(" + sameWallet + ", " + sameAccount + ", " + sweepOutput + ", " + createThenRelay + ") generated " + issues.Count + " issues:\n" + IssuesToStr(issues);
+        Console.WriteLine(msg);
+        if (msg.Contains("ERROR:")) Assert.Fail(msg);
+    }
+
+    private List<string> TestWalletNotificationsAux(bool sameWallet, bool sameAccount, bool sweepOutput, bool createThenRelay, ulong unlockDelay)
+    {
+        ulong MAX_POLL_TIME = 5000l; // maximum time granted for wallet to poll
+
+        // collect issues as test runs
+        List<string> issues = new List<string>();
+
+        // set sender and receiver
+        MoneroWallet sender = wallet;
+        MoneroWallet receiver = sameWallet ? sender : CreateWallet(new MoneroWalletConfig());
+
+        // create receiver accounts if necessary
+        int numAccounts = receiver.GetAccounts().Count;
+        for (int i = 0; i < 4 - numAccounts; i++) receiver.CreateAccount();
+
+        // wait for unlocked funds in source account
+        TestUtils.WALLET_TX_TRACKER.WaitForWalletTxsToClearPool(sender);
+        TestUtils.WALLET_TX_TRACKER.WaitForUnlockedBalance(sender, 0, null, TestUtils.MAX_FEE * 10);
+
+        // get balances to compare after sending
+        ulong senderBalanceBefore = sender.GetBalance();
+        ulong senderUnlockedBalanceBefore = sender.GetUnlockedBalance();
+        ulong receiverBalanceBefore = receiver.GetBalance();
+        ulong receiverUnlockedBalanceBefore = receiver.GetUnlockedBalance();
+        ulong lastHeight = daemon.GetHeight();
+
+        // start collecting notifications from sender and receiver
+        WalletNotificationCollector senderNotificationCollector = new WalletNotificationCollector();
+        WalletNotificationCollector receiverNotificationCollector = new WalletNotificationCollector();
+        sender.AddListener(senderNotificationCollector);
+        GenUtils.WaitFor(TestUtils.SYNC_PERIOD_IN_MS / 2);
+        receiver.AddListener(receiverNotificationCollector);
+
+        // send funds
+        TxContext ctx = new TxContext();
+        ctx.Wallet = wallet;
+        ctx.IsSendResponse = true;
+        MoneroTxWallet? senderTx = null;
+        List<uint> destinationAccounts = sameAccount ? (sweepOutput ? [0] : [0, 1, 2]) : (sweepOutput ? [1] : [1, 2, 3]);
+        List<MoneroOutputWallet> expectedOutputs = new List<MoneroOutputWallet>();
+        if (sweepOutput)
+        {
+            ctx.IsSweepResponse = true;
+            ctx.IsSweepOutputResponse = true;
+            List<MoneroOutputWallet> outputs = sender.GetOutputs(new MoneroOutputQuery().SetIsSpent(false).SetTxQuery(new MoneroTxQuery().SetIsLocked(false)).SetAccountIndex(0).SetMinAmount(TestUtils.MAX_FEE * 5));
+            if (outputs.Count == 0)
+            {
+                issues.Add("ERROR: No outputs available to sweep from account 0");
+                return issues;
+            }
+            MoneroTxConfig config = new MoneroTxConfig().SetAddress(receiver.GetAddress(destinationAccounts[0], 0)).SetKeyImage(outputs[0].GetKeyImage().GetHex()).SetRelay(!createThenRelay);
+            senderTx = sender.SweepOutput(config);
+            expectedOutputs.Add(new MoneroOutputWallet().SetAmount(senderTx.GetOutgoingTransfer().GetDestinations()[0].GetAmount()).SetAccountIndex(destinationAccounts[0]).SetSubaddressIndex(0));
+            ctx.Config = config;
+        }
+        else
+        {
+            MoneroTxConfig config = new MoneroTxConfig().SetAccountIndex(0).SetRelay(!createThenRelay);
+            foreach (uint destinationAccount in destinationAccounts)
+            {
+                config.AddDestination(receiver.GetAddress(destinationAccount, 0), TestUtils.MAX_FEE); // TODO: send and check random amounts?
+                expectedOutputs.Add(new MoneroOutputWallet().SetAmount(TestUtils.MAX_FEE).SetAccountIndex(destinationAccount).SetSubaddressIndex(0));
+            }
+            senderTx = sender.CreateTx(config);
+            ctx.Config = config;
+        }
+        if (createThenRelay) sender.RelayTx(senderTx);
+
+        // start timer to measure end of sync period
+        ulong startTime = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+        // test send tx
+        TestTxWallet(senderTx, ctx);
+
+        // test sender after sending
+        MoneroOutputQuery outputQuery = new MoneroOutputQuery().SetTxQuery(new MoneroTxQuery().SetHash(senderTx.GetHash())); // query for outputs from sender tx
+        if (sameWallet)
+        {
+            if (senderTx.GetIncomingAmount() == null) issues.Add("WARNING: sender tx incoming amount is null when sent to same wallet");
+            else if (senderTx.GetIncomingAmount().Equals(0)) issues.Add("WARNING: sender tx incoming amount is 0 when sent to same wallet");
+            else if (((ulong)senderTx.GetIncomingAmount()).CompareTo(senderTx.GetOutgoingAmount() - (senderTx.GetFee())) != 0) issues.Add("WARNING: sender tx incoming amount != outgoing amount - fee when sent to same wallet");
+        }
+        else
+        {
+            if (senderTx.GetIncomingAmount() != null) issues.Add("ERROR: tx incoming amount should be null"); // TODO: should be 0? then can remove null checks in this method
+        }
+        senderTx = sender.GetTxs(new MoneroTxQuery().SetHash(senderTx.GetHash()).SetIncludeOutputs(true))[0];
+        if (!sender.GetBalance().Equals(senderBalanceBefore - senderTx.GetFee() - senderTx.GetOutgoingAmount() + senderTx.GetIncomingAmount() == null ? 0 : senderTx.GetIncomingAmount())) issues.Add("ERROR: sender balance after send != balance before - tx fee - outgoing amount + incoming amount (" + sender.GetBalance() + " != " + senderBalanceBefore + " - " + senderTx.GetFee() + " - " + senderTx.GetOutgoingAmount() + " + " + senderTx.GetIncomingAmount() + ")");
+        if (((ulong)sender.GetUnlockedBalance()).CompareTo(senderUnlockedBalanceBefore) >= 0) issues.Add("ERROR: sender unlocked balance should have decreased after sending");
+        if (senderNotificationCollector.GetBalanceNotifications().Count == 0) issues.Add("ERROR: sender did not notify balance change after sending");
+        else
+        {
+            if (!sender.GetBalance().Equals(senderNotificationCollector.GetBalanceNotifications().Last().Key)) issues.Add("ERROR: sender balance != last notified balance after sending (" + sender.GetBalance() + " != " + senderNotificationCollector.GetBalanceNotifications().Last().Key + ")");
+            if (!sender.GetUnlockedBalance().Equals(senderNotificationCollector.GetBalanceNotifications().Last().Value)) issues.Add("ERROR: sender unlocked balance != last notified unlocked balance after sending (" + sender.GetUnlockedBalance() + " != " + senderNotificationCollector.GetBalanceNotifications().Last().Value + ")");
+        }
+        if (senderNotificationCollector.GetOutputsSpent(outputQuery).Count == 0) issues.Add("ERROR: sender did not announce unconfirmed spent output");
+
+        // test receiver after 2 sync periods
+        GenUtils.WaitFor(TestUtils.SYNC_PERIOD_IN_MS_ULONG - (((ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()) - startTime));
+        startTime = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(); // reset timer
+        MoneroTxWallet receiverTx = receiver.GetTx(senderTx.GetHash());
+        if (!senderTx.GetOutgoingAmount().Equals(receiverTx.GetIncomingAmount()))
+        {
+            if (sameAccount) issues.Add("WARNING: sender tx outgoing amount != receiver tx incoming amount when sent to same account (" + senderTx.GetOutgoingAmount() + " != " + receiverTx.GetIncomingAmount() + ")");
+            else if (sameAccount) issues.Add("ERROR: sender tx outgoing amount != receiver tx incoming amount (" + senderTx.GetOutgoingAmount() + " != " + receiverTx.GetIncomingAmount() + ")");
+        }
+        if (!receiver.GetBalance().Equals(receiverBalanceBefore + (receiverTx.GetIncomingAmount() == null ? 0 : receiverTx.GetIncomingAmount()) - (receiverTx.GetOutgoingAmount() == null ? 0 : receiverTx.GetOutgoingAmount()) - (sameWallet ? receiverTx.GetFee() : 0)))
+        {
+            if (sameAccount) issues.Add("WARNING: after sending, receiver balance != balance before + incoming amount - outgoing amount - tx fee when sent to same account (" + receiver.GetBalance() + " != " + receiverBalanceBefore + " + " + receiverTx.GetIncomingAmount() + " - " + receiverTx.GetOutgoingAmount() + " - " + (sameWallet ? receiverTx.GetFee() : 0) + ")");
+            else issues.Add("ERROR: after sending, receiver balance != balance before + incoming amount - outgoing amount - tx fee (" + receiver.GetBalance() + " != " + receiverBalanceBefore + " + " + receiverTx.GetIncomingAmount() + " - " + receiverTx.GetOutgoingAmount() + " - " + (sameWallet ? receiverTx.GetFee() : 0) + ")");
+        }
+        if (!sameWallet && !receiver.GetUnlockedBalance().Equals(receiverUnlockedBalanceBefore)) issues.Add("ERROR: receiver unlocked balance should not have changed after sending");
+        if (receiverNotificationCollector.GetBalanceNotifications().Count == 0) issues.Add("ERROR: receiver did not notify balance change when funds received");
+        else
+        {
+            if (!receiver.GetBalance().Equals(receiverNotificationCollector.GetBalanceNotifications().Last().Key)) issues.Add("ERROR: receiver balance != last notified balance after funds received");
+            if (!receiver.GetUnlockedBalance().Equals(receiverNotificationCollector.GetBalanceNotifications().Last().Value)) issues.Add("ERROR: receiver unlocked balance != last notified unlocked balance after funds received");
+        }
+        if (receiverNotificationCollector.GetOutputsReceived(outputQuery).Count == 0) issues.Add("ERROR: receiver did not announce unconfirmed received output");
+        else
+        {
+            foreach (MoneroOutputWallet output in GetMissingOutputs(expectedOutputs, receiverNotificationCollector.GetOutputsReceived(outputQuery), true))
+            {
+                issues.Add("ERROR: receiver did not announce received output for amount " + output.GetAmount() + " to subaddress [" + output.GetAccountIndex() + ", " + output.GetSubaddressIndex() + "]");
+            }
+        }
+
+        // mine until test completes
+        StartMining.Start();
+
+        // loop every sync period until unlock tested
+        List<Thread> threads = new List<Thread>();
+        ulong expectedUnlockTime = lastHeight + unlockDelay;
+        ulong? confirmHeight = null;
+        while (true)
+        {
+
+            // test height notifications
+            ulong height = daemon.GetHeight();
+            if (height > lastHeight)
+            {
+                ulong testStartHeight = lastHeight;
+                lastHeight = height;
+                Thread thread = new Thread(() =>
+                {
+                    // Aspetta 2 periodi di sync + poll time per notifiche
+                    GenUtils.WaitFor(TestUtils.SYNC_PERIOD_IN_MS_ULONG * 2 + MAX_POLL_TIME);
+
+                    List<ulong> senderBlockNotifications = senderNotificationCollector.GetBlockNotifications();
+                    List<ulong> receiverBlockNotifications = receiverNotificationCollector.GetBlockNotifications();
+
+                    for (ulong i = testStartHeight; i < height; i++)
+                    {
+                        if (!senderBlockNotifications.Contains(i))
+                            issues.Add($"ERROR: sender did not announce block {i}");
+
+                        if (!receiverBlockNotifications.Contains(i))
+                            issues.Add($"ERROR: receiver did not announce block {i}");
+                    }
+                });
+                threads.Add(thread);
+                thread.Start();
+            }
+
+            // check if tx confirmed
+            if (confirmHeight == null)
+            {
+
+                // get updated tx
+                MoneroTxWallet tx = receiver.GetTx(senderTx.GetHash());
+
+                // break if tx fails
+                if (tx.IsFailed() == true)
+                {
+                    issues.Add("ERROR: tx failed in tx pool");
+                    break;
+                }
+
+                // test confirm notifications
+                if (tx.IsConfirmed() == true && confirmHeight == null)
+                {
+                    confirmHeight = tx.GetHeight();
+                    expectedUnlockTime = Math.Max(((ulong)confirmHeight) + NUM_BLOCKS_LOCKED, expectedUnlockTime); // exact unlock time known
+                    Thread thread = new Thread(() =>
+                    {
+                        // Aspetta 2 periodi di sync + poll time per notifiche
+                        GenUtils.WaitFor(TestUtils.SYNC_PERIOD_IN_MS_ULONG * 2 + MAX_POLL_TIME);
+
+                        // Prepara query confermata
+                        MoneroOutputQuery confirmedQuery = outputQuery.GetTxQuery()
+                            .Clone()
+                            .SetIsConfirmed(true)
+                            .SetIsLocked(true)
+                            .GetOutputQuery();
+
+                        // Controlli sugli output
+                        if (senderNotificationCollector.GetOutputsSpent(confirmedQuery).Count == 0)
+                            issues.Add("ERROR: sender did not announce confirmed spent output"); // TODO: test amount
+
+                        if (receiverNotificationCollector.GetOutputsReceived(confirmedQuery).Count == 0)
+                        {
+                            issues.Add("ERROR: receiver did not announce confirmed received output");
+                        }
+                        else
+                        {
+                            foreach (MoneroOutputWallet output in GetMissingOutputs(expectedOutputs, receiverNotificationCollector.GetOutputsReceived(confirmedQuery), true))
+                            {
+                                issues.Add($"ERROR: receiver did not announce confirmed received output for amount {output.GetAmount()} " +
+                                            $"to subaddress [{output.GetAccountIndex()}, {output.GetSubaddressIndex()}]");
+                            }
+                        }
+
+                        // Se stesso wallet → il net amount speso deve essere uguale alla tx fee
+                        if (sameWallet)
+                        {
+                            ulong netAmount = 0;
+
+                            foreach (MoneroOutputWallet outputSpent in senderNotificationCollector.GetOutputsSpent(confirmedQuery))
+                                netAmount += (ulong)outputSpent.GetAmount();
+
+                            foreach (MoneroOutputWallet outputReceived in senderNotificationCollector.GetOutputsReceived(confirmedQuery))
+                                netAmount -= (ulong)outputReceived.GetAmount();
+
+                            if (((ulong)tx.GetFee()).CompareTo(netAmount) != 0)
+                            {
+                                if (sameAccount)
+                                {
+                                    issues.Add($"WARNING: net output amount != tx fee when funds sent to same account: {netAmount} vs {tx.GetFee()}");
+                                }
+                                else if (sender is MoneroWalletRpc)
+                                {
+                                    issues.Add($"WARNING: net output amount != tx fee when funds sent to same wallet because monero-wallet-rpc does not provide tx inputs: {netAmount} vs {tx.GetFee()}");
+                                }
+                                else
+                                {
+                                    issues.Add($"ERROR: net output amount must equal tx fee when funds sent to same wallet: {netAmount} vs {tx.GetFee()}");
+                                }
+                            }
+                        }
+                    });
+                    threads.Add(thread);
+                    thread.Start();
+                }
+            }
+
+            // otherwise test unlock notifications
+            else if (height >= expectedUnlockTime)
+            {
+                Thread thread = new Thread(() =>
+                {
+                    // Aspetta 2 periodi di sync + poll time per notifiche
+                    GenUtils.WaitFor(TestUtils.SYNC_PERIOD_IN_MS_ULONG * 2 + MAX_POLL_TIME);
+
+                    // Prepara query sbloccata
+                    MoneroOutputQuery unlockedQuery = outputQuery.GetTxQuery()
+                        .Clone()
+                        .SetIsLocked(false)
+                        .GetOutputQuery();
+
+                    // Controlli sugli output
+                    if (senderNotificationCollector.GetOutputsSpent(unlockedQuery).Count == 0)
+                        issues.Add("ERROR: sender did not announce unlocked spent output"); // TODO: test amount?
+
+                    foreach (MoneroOutputWallet output in GetMissingOutputs(expectedOutputs, receiverNotificationCollector.GetOutputsReceived(unlockedQuery), true))
+                    {
+                        issues.Add($"ERROR: receiver did not announce unlocked received output for amount {output.GetAmount()} " +
+                                    $"to subaddress [{output.GetAccountIndex()}, {output.GetSubaddressIndex()}]");
+                    }
+
+                    // Controllo bilanci del receiver
+                    if (!sameWallet && !receiver.GetBalance().Equals(receiver.GetUnlockedBalance()))
+                        issues.Add("ERROR: receiver balance != unlocked balance after funds unlocked");
+
+                    // Controllo notifiche balance del sender
+                    if (senderNotificationCollector.GetBalanceNotifications().Count == 0)
+                    {
+                        issues.Add("ERROR: sender did not announce any balance notifications");
+                    }
+                    else
+                    {
+                        var lastNotification = senderNotificationCollector.GetBalanceNotifications()[^1]; // ultimo elemento
+                        if (!sender.GetBalance().Equals(lastNotification.Key))
+                            issues.Add("ERROR: sender balance != last notified balance after funds unlocked");
+                        if (!sender.GetUnlockedBalance().Equals(lastNotification.Value))
+                            issues.Add("ERROR: sender unlocked balance != last notified unlocked balance after funds unlocked");
+                    }
+
+                    // Controllo notifiche balance del receiver
+                    if (receiverNotificationCollector.GetBalanceNotifications().Count == 0)
+                    {
+                        issues.Add("ERROR: receiver did not announce any balance notifications");
+                    }
+                    else
+                    {
+                        var lastNotification = receiverNotificationCollector.GetBalanceNotifications()[^1]; // ultimo elemento
+                        if (!receiver.GetBalance().Equals(lastNotification.Key))
+                            issues.Add("ERROR: receiver balance != last notified balance after funds unlocked");
+                        if (!receiver.GetUnlockedBalance().Equals(lastNotification.Value))
+                            issues.Add("ERROR: receiver unlocked balance != last notified unlocked balance after funds unlocked");
+                    }
+                });
+                threads.Add(thread);
+                thread.Start();
+                break;
+            }
+
+            // wait for end of sync period
+            GenUtils.WaitFor(TestUtils.SYNC_PERIOD_IN_MS_ULONG - (((ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()) - startTime));
+            startTime = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(); // reset timer
+        }
+
+        // wait for test threads
+        try
+        {
+            foreach (Thread thread in threads) thread.Join();
+        }
+        catch (ThreadInterruptedException e)
+        {
+            throw new Exception("Thread was interrupted", e);
+        }
+
+        // test notified outputs
+        foreach (MoneroOutputWallet output in senderNotificationCollector.GetOutputsSpent(outputQuery)) TestNotifiedOutput(output, true, issues);
+        foreach (MoneroOutputWallet output in senderNotificationCollector.GetOutputsReceived(outputQuery)) TestNotifiedOutput(output, false, issues);
+        foreach (MoneroOutputWallet output in receiverNotificationCollector.GetOutputsSpent(outputQuery)) TestNotifiedOutput(output, true, issues);
+        foreach (MoneroOutputWallet output in receiverNotificationCollector.GetOutputsReceived(outputQuery)) TestNotifiedOutput(output, false, issues);
+
+        // clean up
+        if (daemon.GetMiningStatus().IsActive() == true) daemon.StopMining();
+        sender.RemoveListener(senderNotificationCollector);
+        senderNotificationCollector.SetListening(false);
+        receiver.RemoveListener(receiverNotificationCollector);
+        receiverNotificationCollector.SetListening(false);
+        if (sender != receiver) CloseWallet(receiver);
+        return issues;
+    }
+
+    private static List<MoneroOutputWallet> GetMissingOutputs(List<MoneroOutputWallet> expectedOutputs, List<MoneroOutputWallet> actualOutputs, bool matchSubaddress)
+    {
+        List<MoneroOutputWallet> missing = [];
+        List<MoneroOutputWallet> used = [];
+        foreach (MoneroOutputWallet expectedOutput in expectedOutputs)
+        {
+            bool found = false;
+            foreach (MoneroOutputWallet actualOutput in actualOutputs)
+            {
+                if (used.Contains(actualOutput)) continue;
+                if (actualOutput.GetAmount().Equals(expectedOutput.GetAmount()) && (!matchSubaddress || (actualOutput.GetAccountIndex() == expectedOutput.GetAccountIndex() && actualOutput.GetSubaddressIndex() == expectedOutput.GetSubaddressIndex())))
+                {
+                    used.Add(actualOutput);
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) missing.Add(expectedOutput);
+        }
+        return missing;
+    }
+
+    private static string IssuesToStr(List<string> issues)
+    {
+        var sb = new StringBuilder();
+        for (int i = 0; i < issues.Count; i++)
+        {
+            sb.Append((i + 1) + ": " + issues[i]);
+            if (i < issues.Count - 1)
+                sb.Append('\n');
+        }
+        return sb.ToString();
+    }
+
+    private static void TestNotifiedOutput(MoneroOutputWallet output, bool isTxInput, List<string> issues)
+    {
+        // test tx link
+        Assert.NotNull(output.GetTx());
+        if (isTxInput) Assert.Contains(output, output.GetTx().GetInputs());
+        else Assert.Contains(output, output.GetTx().GetOutputs());
+
+        // test output values
+        TestUtils.TestUnsignedBigInteger(output.GetAmount());
+        if (output.GetAccountIndex() != null) Assert.True(output.GetAccountIndex() >= 0);
+        else
+        {
+            if (isTxInput) issues.Add("WARNING: notification of " + GetOutputState(output) + " spent output missing account index"); // TODO (monero-project): account index not provided when output swept by key image.  could retrieve it but slows tx creation significantly
+            else issues.Add("ERROR: notification of " + GetOutputState(output) + " received output missing account index");
+        }
+        if (output.GetSubaddressIndex() != null) Assert.True(output.GetSubaddressIndex() >= 0);
+        else
+        {
+            if (isTxInput) issues.Add("WARNING: notification of " + GetOutputState(output) + " spent output missing subaddress index"); // TODO (monero-project): because inputs are not provided, creating fake input from outgoing transfer, which can be sourced from multiple subaddress indices, whereas an output can only come from one subaddress index; need to provide tx inputs to resolve this
+            else issues.Add("ERROR: notification of " + GetOutputState(output) + " received output missing subaddress index");
+        }
+    }
+
+    private static string GetOutputState(MoneroOutputWallet output)
+    {
+        if (output.GetTx().IsLocked() == false) return "unlocked";
+        if (output.GetTx().IsConfirmed() == true) return "confirmed";
+        if (output.GetTx().IsConfirmed() == false) return "unconfirmed";
+        throw new Exception("Unknown output state: " + output.ToString());
+    }
+
+    private static void TestSpendTx(MoneroTxWallet spendTx)
+    {
+        Assert.NotNull(spendTx.GetInputs());
+        Assert.True(spendTx.GetInputs().Count > 0);
+        foreach (MoneroOutput input in spendTx.GetInputs()) Assert.NotNull(input.GetKeyImage().GetHex());
+    }
+
+    #endregion
+
+    #endregion
+
+    #region Helpers
+
+    protected virtual void CheckViewOnlyAndOfflineWallets(MoneroWallet viewOnlyWallet, MoneroWallet offlineWallet)
+    {
+        // wait for txs to confirm and for sufficient unlocked balance
+        TestUtils.WALLET_TX_TRACKER.WaitForWalletTxsToClearPool(wallet);
+        TestUtils.WALLET_TX_TRACKER.WaitForUnlockedBalance(wallet, 0, null, TestUtils.MAX_FEE * 4);
+
+        // test getting txs, transfers, and outputs from view-only wallet
+        Assert.False(viewOnlyWallet.GetTxs().Count == 0);
+        Assert.False(viewOnlyWallet.GetTransfers().Count == 0);
+        Assert.False(viewOnlyWallet.GetOutputs().Count == 0);
+
+        // collect info from main test wallet
+        string primaryAddress = wallet.GetPrimaryAddress();
+        string privateViewKey = wallet.GetPrivateViewKey();
+
+        // test and sync view-only wallet
+        Assert.Equal(primaryAddress, viewOnlyWallet.GetPrimaryAddress());
+        Assert.Equal(privateViewKey, viewOnlyWallet.GetPrivateViewKey());
+        Assert.True(viewOnlyWallet.IsViewOnly());
+        string errMsg = "Should have failed";
+        try
+        {
+            viewOnlyWallet.GetSeed();
+            throw new Exception(errMsg);
+        }
+        catch (Exception e)
+        {
+            Assert.NotEqual(errMsg, e.Message);
+        }
+        try
+        {
+            viewOnlyWallet.GetSeedLanguage();
+            throw new Exception(errMsg);
+        }
+        catch (Exception e)
+        {
+            Assert.NotEqual(errMsg, e.Message);
+        }
+        try
+        {
+            viewOnlyWallet.GetPrivateSpendKey();
+            throw new Exception(errMsg);
+        }
+        catch (Exception e)
+        {
+            Assert.NotEqual(errMsg, e.Message);
+        }
+        Assert.True(viewOnlyWallet.IsConnectedToDaemon());  // TODO: this fails with monero-wallet-rpc and monerod with authentication
+        viewOnlyWallet.Sync();
+        Assert.True(viewOnlyWallet.GetTxs().Count > 0);
+
+        // export outputs from view-only wallet
+        string outputsHex = viewOnlyWallet.ExportOutputs();
+
+        // test offline wallet
+        Assert.False(offlineWallet.IsConnectedToDaemon());
+        Assert.False(offlineWallet.IsViewOnly());
+        if (!(offlineWallet is MoneroWalletRpc)) Assert.Equal(TestUtils.SEED, offlineWallet.GetSeed()); // TODO monero-project: cannot get seed from offline wallet rpc
+        Assert.Empty(offlineWallet.GetTxs(new MoneroTxQuery().SetInTxPool(false)));
+
+        // import outputs to offline wallet
+        int numOutputsImported = offlineWallet.ImportOutputs(outputsHex);
+        Assert.True(numOutputsImported > 0, "No outputs imported");
+
+        // export key images from offline wallet
+        List<MoneroKeyImage> keyImages = offlineWallet.ExportKeyImages();
+
+        // import key images to view-only wallet
+        Assert.True(viewOnlyWallet.IsConnectedToDaemon());
+        viewOnlyWallet.ImportKeyImages(keyImages);
+        Assert.Equal(wallet.GetBalance(), viewOnlyWallet.GetBalance());
+
+        // create unsigned tx using view-only wallet
+        MoneroTxWallet unsignedTx = viewOnlyWallet.CreateTx(new MoneroTxConfig().SetAccountIndex(0).SetAddress(primaryAddress).SetAmount(TestUtils.MAX_FEE * 3));
+        Assert.NotNull(unsignedTx.GetTxSet().GetUnsignedTxHex());
+
+        // sign tx using offline wallet
+        MoneroTxSet signedTxSet = offlineWallet.SignTxs(unsignedTx.GetTxSet().GetUnsignedTxHex());
+        Assert.False(signedTxSet.GetSignedTxHex().Length == 0);
+        Assert.Single(signedTxSet.GetTxs());
+        Assert.False(signedTxSet.GetTxs()[0].GetHash().Length == 0);
+
+        // parse or "describe" unsigned tx set
+        MoneroTxSet describedTxSet = offlineWallet.DescribeUnsignedTxSet(unsignedTx.GetTxSet().GetUnsignedTxHex());
+        TestDescribedTxSet(describedTxSet);
+
+        // submit signed tx using view-only wallet
+        if (TEST_RELAYS)
+        {
+            List<string> txHashes = viewOnlyWallet.SubmitTxs(signedTxSet.GetSignedTxHex());
+            Assert.Single(txHashes);
+            Assert.Equal(64, txHashes[0].Length);
+            TestUtils.WALLET_TX_TRACKER.WaitForWalletTxsToClearPool(viewOnlyWallet); // wait for confirmation for other tests
+        }
+    }
+
+    private List<MoneroTxWallet> GetAndTestTxs(MoneroWallet wallet, MoneroTxQuery? query, TxContext ctx, bool? isExpected)
+    {
+        MoneroTxQuery copy = null;
+        if (query != null) copy = query.Clone();
+        List<MoneroTxWallet> txs = wallet.GetTxs(query);
+        Assert.NotNull(txs);
+        if (isExpected == false) Assert.True(txs.Count == 0);
+        if (isExpected == true) Assert.False(txs.Count == 0);
+        foreach (MoneroTxWallet tx in txs) TestTxWallet(tx, ctx);
+
+        TestGetTxsStructure(txs, query);
+
+        if (query != null) Assert.True(copy.Equals(query));
+        return txs;
+    }
+
+    private List<MoneroTransfer> GetAndTestTransfers(MoneroWallet wallet, MoneroTransferQuery? query, TxContext ctx, bool? isExpected)
+    {
+        MoneroTransferQuery copy = null;
+        if (query != null) copy = query.Clone();
+        List<MoneroTransfer> transfers = wallet.GetTransfers(query);
+        if (isExpected == false) Assert.Empty(transfers);
+        if (isExpected == true) Assert.True(transfers.Count > 0, "Transfers were expected but not found; run send tests?");
+        if (ctx == null) ctx = new TxContext();
+        ctx.Wallet = wallet;
+        foreach (MoneroTransfer transfer in transfers) TestTxWallet(transfer.GetTx(), ctx);
+        if (query != null) Assert.True(copy.Equals(query));
+        return transfers;
+    }
+
+    private static List<MoneroOutputWallet> GetAndTestOutputs(MoneroWallet wallet, MoneroOutputQuery? query, bool? isExpected)
+    {
+        MoneroOutputQuery? copy = null;
+        if (query != null) copy = query.Clone();
+        List<MoneroOutputWallet> outputs = wallet.GetOutputs(query);
+
+        if (query != null)
+        {
+            Assert.True(query.Equals(copy));
+        }
+
+        if (isExpected == false) Assert.True(outputs.Count == 0);
+        if (isExpected == true) Assert.True(outputs.Count > 0, "Outputs were expected but not found; run send tests");
+        foreach (MoneroOutputWallet output in outputs) TestOutputWallet(output);
+
+        if (query != null)
+        {
+            Assert.True(query.Equals(copy));
+        }
+
+        return outputs;
+    }
+
+    protected virtual void TestInvalidAddressError(MoneroError e)
+    {
+        Assert.Equal("Invalid address", e.Message);
+    }
+
+    protected virtual void TestInvalidTxHashError(MoneroError e)
+    {
+        Assert.Equal("TX hash has invalid format", e.Message);
+    }
+
+    protected virtual void TestInvalidTxKeyError(MoneroError e)
+    {
+        Assert.Equal("Tx key has invalid format", e.Message);
+    }
+
+    protected virtual void TestInvalidSignatureError(MoneroError e)
+    {
+        Assert.Equal("Signature size mismatch with additional _tx pubkeys", e.Message);
+    }
+
+    protected virtual void TestNoSubaddressError(MoneroError e)
+    {
+        Assert.Equal("Address must not be a subaddress", e.Message);
+    }
+
+    protected virtual void TestSignatureHeaderCheckError(MoneroError e)
+    {
+        Assert.Equal("Signature header check error", e.Message);
+    }
+
+    private static void TestAccount(MoneroAccount account)
+    {
+        // test account
+        Assert.NotNull(account);
+        Assert.True(account.GetIndex() >= 0);
+        MoneroUtils.ValidateAddress(account.GetPrimaryAddress(), TestUtils.NETWORK_TYPE);
+        TestUtils.TestUnsignedBigInteger(account.GetBalance());
+        TestUtils.TestUnsignedBigInteger(account.GetUnlockedBalance());
+
+        // if given, test subaddresses and that their balances add up to account balances
+        if (account.GetSubaddresses() != null)
+        {
+            ulong balance = 0;
+            ulong unlockedBalance = 0;
+            for (int i = 0; i < account.GetSubaddresses().Count; i++)
+            {
+                TestSubaddress(account.GetSubaddresses()[i]);
+                Assert.Equal(account.GetIndex(), account.GetSubaddresses()[i].GetAccountIndex());
+                Assert.Equal(i, (int)account.GetSubaddresses()[i].GetIndex());
+                balance += account.GetSubaddresses()[i].GetBalance() ?? 0;
+                unlockedBalance += account.GetSubaddresses()[i].GetUnlockedBalance() ?? 0;
+            }
+            Assert.True(account.GetBalance().Equals(balance), "Subaddress balances " + balance + " != account " + account.GetIndex() + " balance " + account.GetBalance());
+            Assert.True(account.GetUnlockedBalance().Equals(unlockedBalance), "Subaddress unlocked balances " + unlockedBalance + " != account " + account.GetIndex() + " unlocked balance " + account.GetUnlockedBalance());
+        }
+
+        // tag must be undefined or non-empty
+        string? tag = account.GetTag();
+        Assert.True(tag == null || tag.Length > 0);
+    }
+
+    private static void TestSubaddress(MoneroSubaddress subaddress)
+    {
+        Assert.True(subaddress.GetAccountIndex() >= 0);
+        Assert.True(subaddress.GetIndex() >= 0);
+        Assert.NotNull(subaddress.GetAddress());
+        Assert.True(subaddress.GetLabel() == null || subaddress.GetLabel().Length != 0);
+        TestUtils.TestUnsignedBigInteger(subaddress.GetBalance());
+        TestUtils.TestUnsignedBigInteger(subaddress.GetUnlockedBalance());
+        Assert.True(subaddress.GetNumUnspentOutputs() >= 0);
+        Assert.NotNull(subaddress.IsUsed());
+        if (subaddress.GetBalance() > 0) Assert.True(subaddress.IsUsed());
+        Assert.True(subaddress.GetNumBlocksToUnlock() >= 0);
+    }
+
+    protected virtual void TestTxsWallet(List<MoneroTxWallet> txs, TxContext ctx)
+    {
+        // test each transaction
+        Assert.True(txs.Count > 0);
+        foreach (MoneroTxWallet tx in txs) TestTxWallet(tx, ctx);
+
+        // test destinations across transactions
+        if (ctx.Config != null && ctx.Config.GetDestinations() != null)
+        {
+            int destinationIdx = 0;
+            bool subtractFeeFromDestinations = ctx.Config.GetSubtractFeeFrom() != null && ctx.Config.GetSubtractFeeFrom().Count > 0;
+            foreach (MoneroTxWallet tx in txs)
+            {
+                // TODO: remove this after >18.3.1 when amounts_by_dest_list is official
+                if (tx.GetOutgoingTransfer().GetDestinations() == null)
+                {
+                    Console.WriteLine("Tx missing destinations");
+                    return;
+                }
+
+                ulong amountDiff = 0;
+                foreach (MoneroDestination destination in tx.GetOutgoingTransfer().GetDestinations())
+                {
+                    MoneroDestination ctxDestination = ctx.Config.GetDestinations()[destinationIdx];
+                    Assert.Equal(ctxDestination.GetAddress(), destination.GetAddress());
+                    if (subtractFeeFromDestinations) amountDiff += ctxDestination.GetAmount() - destination.GetAmount() ?? 0;
+                    else Assert.Equal(ctxDestination.GetAmount(), destination.GetAmount());
+                    destinationIdx++;
+                }
+                if (subtractFeeFromDestinations) Assert.Equal(amountDiff, tx.GetFee());
+            }
+
+            Assert.Equal(destinationIdx, ctx.Config.GetDestinations().Count);
+        }
+    }
+
+    protected virtual void TestTxWallet(MoneroTxWallet tx, TxContext? ctx = null)
+    {
+
+        // validate / sanitize inputs
+        ctx = new TxContext(ctx);
+        ctx.Wallet = null;  // TODO: re-enable
+        Assert.NotNull(tx);
+        if (ctx.IsSendResponse == null || ctx.Config == null)
+        {
+            if (ctx.IsSendResponse != null) throw new Exception("if either sendRequest or isSendResponse is defined, they must both be defined");
+            if (ctx.Config != null) throw new Exception("if either sendRequest or isSendResponse is defined, they must both be defined");
+        }
+
+        // test common field types
+        Assert.NotNull(tx.GetHash());
+        Assert.NotNull(tx.IsConfirmed());
+        Assert.NotNull(tx.IsMinerTx());
+        Assert.NotNull(tx.IsFailed());
+        Assert.NotNull(tx.IsRelayed());
+        Assert.NotNull(tx.InTxPool());
+        Assert.NotNull(tx.IsLocked());
+        TestUtils.TestUnsignedBigInteger(tx.GetFee());
+        if (tx.GetPaymentId() != null) Assert.NotEqual(MoneroTx.DEFAULT_PAYMENT_ID, tx.GetPaymentId()); // default payment id converted to null
+        if (tx.GetNote() != null) Assert.True(tx.GetNote().Length > 0);  // empty notes converted to undefined
+        Assert.True(tx.GetUnlockTime() >= 0);
+        Assert.Null(tx.GetSize());   // TODO monero-wallet-rpc: add tx_size to get_transfers and get_transfer_by_txid
+        Assert.Null(tx.GetReceivedTimestamp());  // TODO monero-wallet-rpc: return received timestamp (asked to file issue if wanted)
+
+        // test send _tx
+        if (ctx.IsSendResponse == true)
+        {
+            Assert.True(tx.GetWeight() > 0);
+            Assert.NotNull(tx.GetInputs());
+            Assert.True(tx.GetInputs().Count > 0);
+            foreach (MoneroOutput input in tx.GetInputs()) Assert.True(input.GetTx() == tx);
+        }
+        else
+        {
+            Assert.Null(tx.GetWeight());
+            Assert.Null(tx.GetInputs());
+        }
+
+        // test confirmed
+        if (tx.IsConfirmed() == true)
+        {
+            Assert.NotNull(tx.GetBlock());
+            Assert.Contains(tx, tx.GetBlock().GetTxs());
+            Assert.True(tx.GetBlock().GetHeight() > 0);
+            Assert.True(tx.GetBlock().GetTimestamp() > 0);
+            Assert.Equal(true, tx.GetRelay());
+            Assert.Equal(true, tx.IsRelayed());
+            Assert.Equal(false, tx.IsFailed());
+            Assert.Equal(false, tx.InTxPool());
+            Assert.Equal(false, tx.IsDoubleSpendSeen());
+            Assert.True(tx.GetNumConfirmations() > 0);
+        }
+        else
+        {
+            Assert.Null(tx.GetBlock());
+            Assert.True(tx.GetNumConfirmations() == 0);
+        }
+
+        // test in _tx pool
+        if (tx.InTxPool() == true)
+        {
+            Assert.Equal(false, tx.IsConfirmed());
+            Assert.Equal(true, tx.GetRelay());
+            Assert.Equal(true, tx.IsRelayed());
+            Assert.Equal(false, tx.IsDoubleSpendSeen()); // TODO: test double spend attempt
+            Assert.Equal(true, tx.IsLocked());
+
+            // these should be initialized unless a response from sending
+            if (ctx.IsSendResponse != true)
+            {
+                //Assert.True(_tx.GetReceivedTimestamp() > 0);  // TODO: re-enable when received timestamp returned in wallet rpc
+            }
+        }
+        else
+        {
+            Assert.Null(tx.GetLastRelayedTimestamp());
+        }
+
+        // test miner _tx
+        if (tx.IsMinerTx() == true)
+        {
+            Assert.True(tx.GetFee() == 0);
+            Assert.True(tx.GetIncomingTransfers().Count > 0);
+        }
+
+        // test failed  // TODO: what else to test associated with failed
+        if (tx.IsFailed() == true)
+        {
+            Assert.True(tx.GetOutgoingTransfer() is MoneroTransfer);
+            //Assert.True(_tx.GetReceivedTimestamp() > 0);  // TODO: re-enable when received timestamp returned in wallet rpc
+        }
+        else
+        {
+            if (tx.IsRelayed() == true) Assert.Equal(tx.IsDoubleSpendSeen(), false);
+            else
+            {
+                Assert.Equal(false, tx.GetRelay());
+                Assert.Equal(false, tx.IsRelayed());
+                Assert.Null(tx.IsDoubleSpendSeen());
+            }
+        }
+        Assert.Null(tx.GetLastFailedHeight());
+        Assert.Null(tx.GetLastFailedHash());
+
+        // received time only for _tx pool or failed txs
+        if (tx.GetReceivedTimestamp() != null)
+        {
+            Assert.True(tx.InTxPool() == true || tx.IsFailed() == true);
+        }
+
+        // test relayed _tx
+        if (tx.IsRelayed() == true) Assert.Equal(tx.GetRelay(), true);
+        if (!tx.GetRelay() == true) Assert.True(!tx.IsRelayed());
+
+        // test outgoing transfer per configuration
+        if (ctx.HasOutgoingTransfer == false) Assert.Null(tx.GetOutgoingTransfer());
+        if (ctx.HasDestinations == true) Assert.True(tx.GetOutgoingTransfer().GetDestinations().Count > 0);
+
+        // test outgoing transfer
+        if (tx.GetOutgoingTransfer() != null)
+        {
+            Assert.True(tx.IsOutgoing());
+            TestTransfer(tx.GetOutgoingTransfer(), ctx);
+            if (ctx.IsSweepResponse == true) Assert.Single(tx.GetOutgoingTransfer().GetDestinations());
+
+            // TODO: handle special cases
+        }
+        else
+        {
+            Assert.True(tx.GetIncomingTransfers().Count > 0);
+            Assert.Null(tx.GetOutgoingAmount());
+            Assert.Null(tx.GetOutgoingTransfer());
+            Assert.Null(tx.GetRingSize());
+            Assert.Null(tx.GetFullHex());
+            Assert.Null(tx.GetMetadata());
+            Assert.Null(tx.GetKey());
+        }
+
+        // test incoming transfers
+        if (tx.GetIncomingTransfers() != null)
+        {
+            Assert.True(tx.IsIncoming());
+            Assert.True(tx.GetIncomingTransfers().Count > 0);
+            TestUtils.TestUnsignedBigInteger(tx.GetIncomingAmount());
+            Assert.Equal(tx.IsFailed(), false);
+
+            // test each transfer and collect transfer sum
+            ulong transferSum = 0;
+            foreach (MoneroIncomingTransfer transfer in tx.GetIncomingTransfers())
+            {
+                TestTransfer(transfer, ctx);
+                transferSum += transfer.GetAmount() ?? 0;
+                if (ctx.Wallet != null) Assert.Equal(ctx.Wallet.GetAddress((uint)transfer.GetAccountIndex(), (uint)transfer.GetSubaddressIndex()), transfer.GetAddress());
+
+                // TODO special case: transfer amount of 0
+            }
+
+            // incoming transfers add up to incoming _tx amount
+            Assert.Equal(tx.GetIncomingAmount(), transferSum);
+        }
+        else
+        {
+            Assert.NotNull(tx.GetOutgoingTransfer());
+            Assert.Null(tx.GetIncomingAmount());
+            Assert.Null(tx.GetIncomingTransfers());
+        }
+
+        // test _tx results from send or relay
+        if (ctx.IsSendResponse == true)
+        {
+
+            // test _tx set
+            Assert.NotNull(tx.GetTxSet());
+            bool found = false;
+            foreach (MoneroTxWallet aTx in tx.GetTxSet().GetTxs())
+            {
+                if (aTx == tx)
+                {
+                    found = true;
+                    break;
+                }
+            }
+            if (ctx.IsCopy == true) Assert.False(found); // copy will not have back reference from _tx set
+            else Assert.True(found);
+
+            // test common attributes
+            MoneroTxConfig config = ctx.Config;
+            Assert.Equal(false, tx.IsConfirmed());
+            TestTransfer(tx.GetOutgoingTransfer(), ctx);
+            Assert.Equal(MoneroUtils.RING_SIZE, (uint)tx.GetRingSize());
+            Assert.True(0 == tx.GetUnlockTime());
+            Assert.Null(tx.GetBlock());
+            Assert.True(tx.GetKey().Length > 0);
+            Assert.NotNull(tx.GetFullHex());
+            Assert.True(tx.GetFullHex().Length > 0);
+            Assert.NotNull(tx.GetMetadata());
+            Assert.Null(tx.GetReceivedTimestamp());
+            Assert.True(tx.IsLocked());
+
+            // test locked state
+            if (tx.GetUnlockTime() == 0) Assert.Equal(tx.IsConfirmed(), !tx.IsLocked());
+            else Assert.Equal(true, tx.IsLocked());
+            foreach (MoneroOutputWallet output in tx.GetOutputsWallet())
+            {
+                Assert.Equal(tx.IsLocked(), output.IsLocked());
+            }
+
+            // test destinations of sent _tx
+            if (tx.GetOutgoingTransfer().GetDestinations() == null)
+            {
+                Assert.True(config.GetCanSplit());
+                Console.WriteLine("Destinations not returned from split transactions"); // TODO: remove this after >18.3.1 when amounts_by_dest_list official
+            }
+            else
+            {
+                Assert.NotNull(tx.GetOutgoingTransfer().GetDestinations());
+                Assert.True(tx.GetOutgoingTransfer().GetDestinations().Count > 0);
+                bool subtractFeeFromDestinations = ctx.Config.GetSubtractFeeFrom() != null && ctx.Config.GetSubtractFeeFrom().Count > 0;
+                if (ctx.IsSweepResponse == true)
+                {
+                    Assert.True(1 == config.GetDestinations().Count);
+                    Assert.Null(config.GetDestinations()[0].GetAmount());
+                    if (!subtractFeeFromDestinations)
+                    {
+                        Assert.Equal(tx.GetOutgoingTransfer().GetAmount().ToString(), tx.GetOutgoingTransfer().GetDestinations()[0].GetAmount().ToString());
+                    }
+                }
+            }
+
+
+            // test relayed txs
+            if (config.GetRelay() == true)
+            {
+                Assert.Equal(true, tx.InTxPool());
+                Assert.Equal(true, tx.GetRelay());
+                Assert.Equal(true, tx.IsRelayed());
+                Assert.True(tx.GetLastRelayedTimestamp() > 0);
+                Assert.Equal(false, tx.IsDoubleSpendSeen());
+            }
+
+            // test non-relayed txs
+            else
+            {
+                Assert.Equal(false, tx.InTxPool());
+                Assert.Equal(false, tx.GetRelay());
+                Assert.Equal(false, tx.IsRelayed());
+                Assert.Null(tx.GetLastRelayedTimestamp());
+                Assert.Null(tx.IsDoubleSpendSeen());
+            }
+        }
+
+        // test _tx result query
+        else
+        {
+            Assert.Null(tx.GetTxSet());  // _tx set only initialized on send responses
+            Assert.Null(tx.GetRingSize());
+            Assert.Null(tx.GetKey());
+            Assert.Null(tx.GetFullHex());
+            Assert.Null(tx.GetMetadata());
+            Assert.Null(tx.GetLastRelayedTimestamp());
+        }
+
+        // test inputs
+        if (tx.IsOutgoing() == true && ctx.IsSendResponse == true)
+        {
+            Assert.NotNull(tx.GetInputs());
+            Assert.True(tx.GetInputs().Count > 0);
+        }
+        if (tx.GetInputs() != null) foreach (MoneroOutputWallet input in tx.GetInputsWallet()) TestInputWallet(input);
+
+        // test outputs
+        if (tx.IsIncoming() == true && ctx.IncludeOutputs == true)
+        {
+            if (tx.IsConfirmed() == true)
+            {
+                Assert.NotNull(tx.GetOutputs());
+                Assert.True(tx.GetOutputs().Count > 0);
+            }
+            else
+            {
+                Assert.Null(tx.GetOutputs());
+            }
+        }
+        if (tx.GetOutputs() != null) foreach (MoneroOutputWallet output in tx.GetOutputsWallet()) TestOutputWallet(output);
+
+        // test deep copy
+        if (ctx.IsCopy != true) TestTxWalletCopy(tx, ctx);
+    }
+
+    private void TestTxWalletCopy(MoneroTxWallet tx, TxContext ctx)
+    {
+        // copy _tx and Assert. deep equality
+        MoneroTxWallet copy = tx.Clone();
+        Assert.True(copy is MoneroTxWallet);
+        Assert.True(copy.Equals(tx));
+
+        // test different references
+        if (tx.GetOutgoingTransfer() != null)
+        {
+            Assert.True(tx.GetOutgoingTransfer() != copy.GetOutgoingTransfer());
+            Assert.True(tx.GetOutgoingTransfer().GetTx() != copy.GetOutgoingTransfer().GetTx());
+            if (tx.GetOutgoingTransfer().GetDestinations() != null)
+            {
+                Assert.True(tx.GetOutgoingTransfer()!.GetDestinations() != copy.GetOutgoingTransfer()!.GetDestinations());
+                for (int i = 0; i < tx.GetOutgoingTransfer()!.GetDestinations()!.Count; i++)
+                {
+                    Assert.True(copy.GetOutgoingTransfer()!.GetDestinations()![i].Equals(tx.GetOutgoingTransfer()!.GetDestinations()![i]));
+                    Assert.True(tx.GetOutgoingTransfer()!.GetDestinations()![i] != copy.GetOutgoingTransfer()!.GetDestinations()![i]);
+                }
+            }
+        }
+        if (tx.GetIncomingTransfers() != null)
+        {
+            for (int i = 0; i < tx.GetIncomingTransfers()!.Count; i++)
+            {
+                Assert.True(copy.GetIncomingTransfers()![i].Equals(tx.GetIncomingTransfers()![i]));
+                Assert.True(tx.GetIncomingTransfers()![i] != copy.GetIncomingTransfers()![i]);
+            }
+        }
+        if (tx.GetInputs() != null)
+        {
+            for (int i = 0; i < tx.GetInputs()!.Count; i++)
+            {
+                Assert.True(copy.GetInputs()![i].Equals(tx.GetInputs()![i]));
+                Assert.True(tx.GetInputs()![i] != copy.GetInputs()![i]);
+            }
+        }
+        if (tx.GetOutputs() != null)
+        {
+            for (int i = 0; i < tx.GetOutputs()!.Count; i++)
+            {
+                Assert.True(copy.GetOutputs()![i].Equals(tx.GetOutputs()![i]));
+                Assert.True(tx.GetOutputs()![i] != copy.GetOutputs()![i]);
+            }
+        }
+
+        // test copied _tx
+        ctx = new TxContext(ctx);
+        ctx.IsCopy = true;
+        if (tx.GetBlock() != null) copy.SetBlock(tx.GetBlock().Clone().SetTxs([copy])); // copy block for testing
+        TestTxWallet(copy, ctx);
+
+        // test merging with copy
+        MoneroTxWallet merged = copy.Merge(copy.Clone());
+        Assert.Equal(merged.ToString(), tx.ToString());
+    }
+
+    private static void TestTransfer(MoneroTransfer transfer, TxContext? ctx)
+    {
+        if (ctx == null) ctx = new TxContext();
+        Assert.NotNull(transfer);
+        TestUtils.TestUnsignedBigInteger(transfer.GetAmount());
+        if (ctx.IsSweepOutputResponse != true) Assert.True(transfer.GetAccountIndex() >= 0);
+        if (transfer.IsIncoming() == true) TestIncomingTransfer((MoneroIncomingTransfer)transfer);
+        else TestOutgoingTransfer((MoneroOutgoingTransfer)transfer, ctx);
+
+        // transfer and _tx reference each other
+        Assert.NotNull(transfer.GetTx());
+        if (!transfer.Equals(transfer.GetTx().GetOutgoingTransfer()))
+        {
+            Assert.NotNull(transfer.GetTx().GetIncomingTransfers());
+            Assert.True(transfer.GetTx().GetIncomingTransfers().Contains(transfer), "Transaction does not reference given transfer");
+        }
+    }
+
+    private static void TestIncomingTransfer(MoneroIncomingTransfer transfer)
+    {
+        Assert.True(transfer.IsIncoming());
+        Assert.False(transfer.IsOutgoing());
+        Assert.NotNull(transfer.GetAddress());
+        Assert.True(transfer.GetSubaddressIndex() >= 0);
+        Assert.True(transfer.GetNumSuggestedConfirmations() > 0);
+    }
+
+    private static void TestOutgoingTransfer(MoneroOutgoingTransfer transfer, TxContext ctx)
+    {
+        Assert.False(transfer.IsIncoming());
+        Assert.True(transfer.IsOutgoing());
+        if (ctx.IsSendResponse != true) Assert.NotNull(transfer.GetSubaddressIndices());
+        if (transfer.GetSubaddressIndices() != null)
+        {
+            Assert.True(transfer.GetSubaddressIndices().Count >= 1);
+            foreach (uint subaddressIdx in transfer.GetSubaddressIndices()) Assert.True(subaddressIdx >= 0);
+        }
+        if (transfer.GetAddresses() != null)
+        {
+            Assert.Equal(transfer.GetSubaddressIndices().Count, transfer.GetAddresses().Count);
+            foreach (string address in transfer.GetAddresses()) Assert.NotNull(address);
+        }
+
+        // test destinations sum to outgoing amount
+        if (transfer.GetDestinations() != null)
+        {
+            Assert.True(transfer.GetDestinations().Count > 0);
+            ulong sum = 0;
+            foreach (MoneroDestination destination in transfer.GetDestinations())
+            {
+                TestDestination(destination);
+                sum += destination.GetAmount() ?? 0;
+            }
+            if (!transfer.GetAmount().Equals(sum)) Console.WriteLine(transfer.GetTx().GetTxSet() == null ? transfer.GetTx().ToString() : transfer.GetTx().GetTxSet().ToString());
+            Assert.Equal(sum, transfer.GetAmount());
+        }
+    }
+
+    private static void TestDestination(MoneroDestination destination)
+    {
+        MoneroUtils.ValidateAddress(destination.GetAddress(), TestUtils.NETWORK_TYPE);
+        TestUtils.TestUnsignedBigInteger(destination.GetAmount(), true);
+    }
+
+    private static void TestInputWallet(MoneroOutputWallet? input)
+    {
+        Assert.NotNull(input);
+        Assert.NotNull(input.GetKeyImage());
+        Assert.NotNull(input.GetKeyImage().GetHex());
+        Assert.True(input.GetKeyImage().GetHex().Length > 0);
+        Assert.Null(input.GetAmount()); // must get info separately
+    }
+
+    private static void TestOutputWallet(MoneroOutputWallet? output)
+    {
+        Assert.NotNull(output);
+        Assert.True(output.GetAccountIndex() >= 0);
+        Assert.True(output.GetSubaddressIndex() >= 0);
+        Assert.True(output.GetIndex() >= 0);
+        Assert.NotNull(output.IsSpent());
+        Assert.NotNull(output.IsLocked());
+        Assert.NotNull(output.IsFrozen());
+        Assert.NotNull(output.GetKeyImage());
+        Assert.True(output.GetKeyImage().GetHex().Length > 0);
+        TestUtils.TestUnsignedBigInteger(output.GetAmount(), true);
+
+        // output has circular reference to its transaction which has some initialized fields
+        MoneroTxWallet tx = output.GetTx();
+        Assert.NotNull(tx);
+        Assert.Contains(output, tx.GetOutputs());
+        Assert.NotNull(tx.GetHash());
+        Assert.NotNull(tx.IsLocked());
+        Assert.Equal(true, tx.IsConfirmed());  // TODO monero-wallet-rpc: possible to get unconfirmed outputs?
+        Assert.Equal(true, tx.IsRelayed());
+        Assert.Equal(false, tx.IsFailed());
+        Assert.True(tx.GetHeight() > 0);
+
+        // test copying
+        MoneroOutputWallet copy = output.Clone();
+        Assert.True(copy != output);
+        Assert.Equal(output.ToString(), copy.ToString());
+        Assert.Null(copy.GetTx());  // TODO: should output copy do deep copy of _tx so models are graph instead of tree?  Would need to work out circular references
+    }
+
+    private static List<MoneroTxWallet> GetRandomTransactions(MoneroWallet wallet, MoneroTxQuery txQuery, int? minTxs, int? maxTxs)
+    {
+        List<MoneroTxWallet> txs = wallet.GetTxs(txQuery);
+        if (minTxs != null) Assert.True(txs.Count >= minTxs, txs.Count + "/" + minTxs + " transactions found with the query");
+        txs.Shuffle();
+        if (maxTxs == null) return txs;
+        else return txs.GetRange(0, Math.Min((int)maxTxs, txs.Count));
+    }
+
+    private static void TestCommonTxSets(List<MoneroTxWallet> txs, bool hasSigned, bool hasUnsigned, bool hasMultisig)
+    {
+        Assert.True(txs.Count > 0);
+
+        // Assert. that all sets are same reference
+        MoneroTxSet? set = null;
+        for (int i = 0; i < txs.Count; i++)
+        {
+            Assert.True(txs[i] is MoneroTxWallet);
+            if (i == 0) set = txs[i].GetTxSet();
+            else Assert.True(txs[i].GetTxSet() == set);
+        }
+
+        // test expected set
+        Assert.NotNull(set);
+        if (hasSigned)
+        {
+            Assert.NotNull(set.GetSignedTxHex());
+            Assert.True(set.GetSignedTxHex().Length > 0);
+        }
+        if (hasUnsigned)
+        {
+            Assert.NotNull(set.GetUnsignedTxHex());
+            Assert.True(set.GetUnsignedTxHex().Length > 0);
+        }
+        if (hasMultisig)
+        {
+            Assert.NotNull(set.GetMultisigTxHex());
+            Assert.True(set.GetMultisigTxHex().Length > 0);
+        }
+    }
+
+    private static void TestCheckTx(MoneroTxWallet tx, MoneroCheckTx check)
+    {
+        if (check.IsGood() == true)
+        {
+            Assert.True(check.GetNumConfirmations() >= 0);
+            TestUtils.TestUnsignedBigInteger(check.GetReceivedAmount());
+            if (check.InTxPool() == true) Assert.True(0 == check.GetNumConfirmations());
+            else Assert.True(check.GetNumConfirmations() > 0); // TODO (monero-wall-rpc) this fails (confirmations is 0) for (at least one) transaction that has 1 confirmation on testCheckTxKey()
+        }
+        else
+        {
+        }
+    }
+
+    private static void TestCheckReserve(MoneroCheckReserve check)
+    {
+        if (check.IsGood() == true)
+        {
+            TestUtils.TestUnsignedBigInteger(check.GetTotalAmount());
+            Assert.True(check.GetTotalAmount() >= 0);
+            TestUtils.TestUnsignedBigInteger(check.GetUnconfirmedSpentAmount());
+            Assert.True(check.GetUnconfirmedSpentAmount() >= 0);
+        }
+        else
+        {
+        }
+    }
+
+    private static void TestDescribedTxSet(MoneroTxSet describedTxSet)
+    {
+        Assert.NotNull(describedTxSet.GetTxs());
+        Assert.False(describedTxSet.GetTxs().Count == 0);
+        Assert.Null(describedTxSet.GetSignedTxHex());
+        Assert.Null(describedTxSet.GetUnsignedTxHex());
+
+        // test each transaction
+        // TODO: use common _tx wallet test?
+        Assert.Null(describedTxSet.GetMultisigTxHex());
+        foreach (MoneroTxWallet parsedTx in describedTxSet.GetTxs())
+        {
+            Assert.True(parsedTx.GetTxSet() == describedTxSet);
+            TestUtils.TestUnsignedBigInteger(parsedTx.GetInputSum(), true);
+            TestUtils.TestUnsignedBigInteger(parsedTx.GetOutputSum(), true);
+            TestUtils.TestUnsignedBigInteger(parsedTx.GetFee());
+            TestUtils.TestUnsignedBigInteger(parsedTx.GetChangeAmount());
+            if (parsedTx.GetChangeAmount().Equals(0)) Assert.Null(parsedTx.GetChangeAddress());
+            else MoneroUtils.ValidateAddress(parsedTx.GetChangeAddress(), TestUtils.NETWORK_TYPE);
+            Assert.True(parsedTx.GetRingSize() > 1);
+            Assert.True(parsedTx.GetUnlockTime() >= 0);
+            Assert.True(parsedTx.GetNumDummyOutputs() >= 0);
+            Assert.False(parsedTx.GetExtraHex().Length == 0);
+            Assert.True(parsedTx.GetPaymentId() == null || parsedTx.GetPaymentId().Length != 0);
+            Assert.True(parsedTx.IsOutgoing());
+            Assert.NotNull(parsedTx.GetOutgoingTransfer());
+            Assert.NotNull(parsedTx.GetOutgoingTransfer().GetDestinations());
+            Assert.False(parsedTx.GetOutgoingTransfer().GetDestinations().Count == 0);
+            Assert.Null(parsedTx.IsIncoming());
+            foreach (MoneroDestination destination in parsedTx.GetOutgoingTransfer().GetDestinations())
+            {
+                TestDestination(destination);
+            }
+        }
+    }
+
+    private static void TestAddressBookEntry(MoneroAddressBookEntry entry)
+    {
+        Assert.True(entry.GetIndex() >= 0);
+        MoneroUtils.ValidateAddress(entry.GetAddress(), TestUtils.NETWORK_TYPE);
+        Assert.NotNull(entry.GetDescription());
+    }
+
+    private void TestGetTxsStructure(List<MoneroTxWallet> txs, MoneroTxQuery? query)
+    {
+        if (query == null) query = new MoneroTxQuery();
+
+        // collect unique blocks in order (using set and list instead of TreeSet for direct portability to other languages)
+        HashSet<MoneroBlock> seenBlocks = [];
+        List<MoneroBlock> blocks = [];
+        List<MoneroTxWallet> unconfirmedTxs = [];
+        foreach (MoneroTxWallet tx in txs)
+        {
+            if (tx.GetBlock() == null) unconfirmedTxs.Add(tx);
+            else
+            {
+                Assert.Contains(tx, tx.GetBlock().GetTxs());
+                if (!seenBlocks.Contains(tx.GetBlock()))
+                {
+                    seenBlocks.Add(tx.GetBlock());
+                    blocks.Add(tx.GetBlock());
+                }
+            }
+        }
+
+        // _tx hashes must be in order if requested
+        if (query.GetHashes() != null)
+        {
+            Assert.Equal(txs.Count, query.GetHashes().Count);
+            for (int i = 0; i < query.GetHashes().Count; i++)
+            {
+                Assert.Equal(query.GetHashes()[i], txs[i].GetHash());
+            }
+        }
+
+        // test that txs and blocks reference each other and blocks are in ascending order unless specific _tx hashes queried
+        int index = 0;
+        ulong? prevBlockHeight = null;
+        foreach (MoneroBlock block in blocks)
+        {
+            if (prevBlockHeight == null) prevBlockHeight = block.GetHeight();
+            else if (query.GetHashes() == null) Assert.True(block.GetHeight() > prevBlockHeight, "Blocks are not in order of heights: " + prevBlockHeight + " vs " + block.GetHeight());
+            foreach (MoneroTx tx in block.GetTxs())
+            {
+                Assert.True(tx.GetBlock() == block);
+                if (query.GetHashes() == null)
+                {
+                    Assert.Equal(txs[index].GetHash(), tx.GetHash()); // verify _tx order is self-consistent with blocks unless txs manually re-ordered by querying by hash
+                    Assert.True(txs[index] == tx);
+                }
+                index++;
+            }
+        }
+        Assert.Equal(txs.Count, index + unconfirmedTxs.Count);
+
+        // test that incoming transfers are in order of ascending accounts and subaddresses
+        foreach (MoneroTxWallet tx in txs)
+        {
+            uint? prevAccountIdx = null;
+            uint? prevSubaddressIdx = null;
+            if (tx.GetIncomingTransfers() == null) continue;
+            foreach (MoneroIncomingTransfer transfer in tx.GetIncomingTransfers())
+            {
+                if (prevAccountIdx == null) prevAccountIdx = transfer.GetAccountIndex();
+                else
+                {
+                    Assert.True(prevAccountIdx <= transfer.GetAccountIndex());
+                    if (prevAccountIdx < transfer.GetAccountIndex())
+                    {
+                        prevSubaddressIdx = null;
+                        prevAccountIdx = transfer.GetAccountIndex();
+                    }
+                    if (prevSubaddressIdx == null) prevSubaddressIdx = transfer.GetSubaddressIndex();
+                    else Assert.True(prevSubaddressIdx < transfer.GetSubaddressIndex());
+                }
+            }
+        }
+
+        // test that outputs are in order of ascending accounts and subaddresses
+        foreach (MoneroTxWallet tx in txs)
+        {
+            uint? prevAccountIdx = null;
+            uint? prevSubaddressIdx = null;
+            if (tx.GetOutputs() == null) continue;
+            foreach (MoneroOutputWallet output in tx.GetOutputsWallet())
+            {
+                if (prevAccountIdx == null) prevAccountIdx = output.GetAccountIndex();
+                else
+                {
+                    Assert.True(prevAccountIdx <= output.GetAccountIndex());
+                    if (prevAccountIdx < output.GetAccountIndex())
+                    {
+                        prevSubaddressIdx = null;
+                        prevAccountIdx = output.GetAccountIndex();
+                    }
+                    if (prevSubaddressIdx == null) prevSubaddressIdx = output.GetSubaddressIndex();
+                    else Assert.True(prevSubaddressIdx <= output.GetSubaddressIndex(), output.GetKeyImage().ToString() + " " + prevSubaddressIdx + " > " + output.GetSubaddressIndex()); // TODO: this does not test that index < other index if subaddresses are equal
+                }
+            }
+        }
+
+    }
+
+    private static Dictionary<ulong, uint> CountNumInstances(List<ulong> instances)
+    {
+        Dictionary<ulong, uint> heightCounts = [];
+        foreach (ulong instance in instances)
+        {
+            uint count = heightCounts.GetValueOrDefault(instance, (uint)0);
+            heightCounts.Add(instance, count + 1);
+        }
+        return heightCounts;
+    }
+
+    private static HashSet<ulong> GetModes(Dictionary<ulong, uint> counts)
+    {
+        HashSet<ulong> modes = new HashSet<ulong>();
+        uint? maxCount = null;
+        foreach (uint count in counts.Values)
+        {
+            if (maxCount == null || count > maxCount) maxCount = count;
+        }
+        foreach (var entry in counts)
+        {
+            if (entry.Value == maxCount) modes.Add(entry.Key);
+        }
+        return modes;
+    }
+
+    #endregion
+}
+
+
+public class TxContext
+{
+    public MoneroWallet? Wallet;
+    public MoneroTxConfig? Config;
+    public bool? HasOutgoingTransfer;
+    public bool? HasIncomingTransfers;
+    public bool? HasDestinations;
+    public bool? IsCopy;                 // indicates if a copy is being tested which means back references won't be the same
+    public bool? IncludeOutputs;
+    public bool? IsSendResponse;
+    public bool? IsSweepResponse;
+    public bool? IsSweepOutputResponse;  // TODO monero-wallet-rpc: this only necessary because sweep_output does not return account index
+
+    public TxContext() { }
+
+    public TxContext(TxContext ctx)
+    {
+        if (ctx == null) return;
+        Wallet = ctx.Wallet;
+        Config = ctx.Config;
+        HasOutgoingTransfer = ctx.HasOutgoingTransfer;
+        HasIncomingTransfers = ctx.HasIncomingTransfers;
+        HasDestinations = ctx.HasDestinations;
+        IsCopy = ctx.IsCopy;
+        IncludeOutputs = ctx.IncludeOutputs;
+        IsSendResponse = ctx.IsSendResponse;
+        IsSweepResponse = ctx.IsSweepResponse;
+        IsSweepOutputResponse = ctx.IsSweepOutputResponse;
+    }
 }

--- a/Monero.Test/TestMoneroWalletLight.cs
+++ b/Monero.Test/TestMoneroWalletLight.cs
@@ -1,10 +1,28 @@
-﻿using Monero.Wallet;
+﻿using Monero.Daemon;
+using Monero.Wallet;
 using Monero.Wallet.Common;
 
 namespace Monero.Test;
 
-public class TestMoneroWalletLight : TestMoneroWalletCommon
+public class MoneroWalletLightFixture : MoneroWalletCommonFixture
 {
+    public new MoneroWalletLight _wallet;
+    public MoneroDaemonLws _lws;
+
+    public MoneroWalletLightFixture(MoneroWalletLight wallet, MoneroDaemonRpc daemon, MoneroDaemonLws lws) : base(wallet, daemon)
+    {
+        // Before All
+        _wallet = wallet;
+        _lws = lws;
+    }
+}
+
+public class TestMoneroWalletLight : TestMoneroWalletCommon, IClassFixture<MoneroWalletLightFixture>
+{
+    public TestMoneroWalletLight(MoneroWalletLightFixture walletLightFixture) : base(walletLightFixture)
+    {
+
+    }
 
     protected override void CloseWallet(MoneroWallet wallet, bool save)
     {

--- a/Monero.Test/TestMoneroWalletRpc.cs
+++ b/Monero.Test/TestMoneroWalletRpc.cs
@@ -5,22 +5,72 @@ using Monero.Wallet.Common;
 
 namespace Monero.Test;
 
-public class TestMoneroWalletRpc : TestMoneroWalletCommon
+public class MoneroWalletRpcFixture : MoneroWalletCommonFixture
 {
+    public MoneroWalletRpc walletRpc;
+
+    public MoneroWalletRpcFixture() : base(TestUtils.GetWalletRpc(), TestUtils.GetDaemonRpc())
+    {
+        // Before All
+        walletRpc = (MoneroWalletRpc)wallet;
+    }
+}
+
+public class TestMoneroWalletRpc : TestMoneroWalletCommon, IClassFixture<MoneroWalletRpcFixture>
+{
+    public TestMoneroWalletRpc(MoneroWalletRpcFixture walletRpcFixture) : base(walletRpcFixture)
+    {
+
+    }
+
+    #region Base Method Overrides
 
     protected override void CloseWallet(MoneroWallet wallet, bool save)
     {
-        throw new NotImplementedException();
+        MoneroWalletRpc walletRpc = (MoneroWalletRpc)wallet;
+        walletRpc.Close(save);
+        try
+        {
+            TestUtils.StopWalletRpcProcess(walletRpc);
+        }
+        catch (Exception e)
+        {
+            throw new Exception("An error occurred while stopping monero wallet rpc process", e);
+        }
     }
 
-    protected override MoneroWallet CreateWallet(MoneroWalletConfig config)
+    protected override MoneroWalletRpc CreateWallet(MoneroWalletConfig config)
     {
-        throw new NotImplementedException();
+        // assign defaults
+        if (config == null) config = new MoneroWalletConfig();
+        bool random = config.GetSeed() == null && config.GetPrimaryAddress() == null;
+        if (config.GetPath() == null) config.SetPath(GenUtils.GetGuid());
+        if (config.GetPassword() == null) config.SetPassword(TestUtils.WALLET_PASSWORD);
+        if (config.GetRestoreHeight() == null && !random) config.SetRestoreHeight(0l);
+        if (config.GetServer() == null && config.GetConnectionManager() == null) config.SetServer(daemon.GetRpcConnection());
+
+        // create client connected to internal monero-wallet-rpc process
+        bool offline = MoneroUtils.ParseUri(TestUtils.OFFLINE_SERVER_URI).ToString().Equals(config.GetServerUri());
+        MoneroWalletRpc wallet = TestUtils.StartWalletRpcProcess(offline);
+
+        // create wallet
+        try
+        {
+            wallet.CreateWallet(config);
+            wallet.SetDaemonConnection(wallet.GetDaemonConnection(), true, null); // set daemon as trusted
+            if (wallet.IsConnectedToDaemon()) wallet.StartSyncing(TestUtils.SYNC_PERIOD_IN_MS_ULONG);
+            return wallet;
+        }
+        catch (MoneroError e)
+        {
+            try { TestUtils.StopWalletRpcProcess(wallet); } catch (Exception e2) { throw new Exception("An error occurred while stopping monero wallet rpc process", e2); }
+            throw;
+        }
     }
 
     protected override List<string> GetSeedLanguages()
     {
-        throw new NotImplementedException();
+        return ((MoneroWalletRpc)wallet).GetSeedLanguages();
     }
 
     protected override MoneroWallet GetTestWallet()
@@ -53,4 +103,391 @@ public class TestMoneroWalletRpc : TestMoneroWalletCommon
             throw;
         }
     }
+
+    protected override void DisposeInternal()
+    {
+        base.DisposeInternal();
+
+        foreach (MoneroWalletRpc walletRpc in TestUtils.WALLET_PORT_OFFSETS.Keys)
+        {
+            try
+            {
+                TestUtils.StopWalletRpcProcess(walletRpc);
+            }
+            catch (Exception e)
+            {
+                throw new Exception("An error occurred while stopping monero wallet rpc process", e);
+            }
+        }
+
+    }
+
+    #endregion
+
+    #region Tests
+
+    // Can create a wallet with a randomly generated seed
+    [Fact]
+    public void TestCreateWalletRandomRpc()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // Create random wallet with defaults
+        string path = GenUtils.GetGuid();
+        MoneroWallet newWallet = CreateWallet(new MoneroWalletConfig().SetPath(path));
+        string seed = newWallet.GetSeed();
+        MoneroUtils.ValidateMnemonic(seed);
+        Assert.NotEqual(TestUtils.SEED, seed);
+        MoneroUtils.ValidateAddress(newWallet.GetPrimaryAddress(), TestUtils.NETWORK_TYPE);
+        newWallet.Sync();  // very quick because restore height is chain height
+        CloseWallet(newWallet);
+
+        // Create random wallet with non defaults
+        path = GenUtils.GetGuid();
+        newWallet = CreateWallet(new MoneroWalletConfig().SetPath(path).SetLanguage("Spanish"));
+        MoneroUtils.ValidateMnemonic(newWallet.GetSeed());
+        Assert.NotEqual(seed, newWallet.GetSeed());
+        seed = newWallet.GetSeed();
+        MoneroUtils.ValidateAddress(newWallet.GetPrimaryAddress(), TestUtils.NETWORK_TYPE);
+
+        // attempt to Create wallet which already exists
+        try
+        {
+            CreateWallet(new MoneroWalletConfig().SetPath(path).SetLanguage("Spanish"));
+        }
+        catch (MoneroError e)
+        {
+            Assert.Equal(e.Message, "Wallet already exists: " + path);
+            Assert.Equal(-21, (int)e.GetCode());
+            Assert.Equal(seed, newWallet.GetSeed());
+        }
+        CloseWallet(newWallet);
+    }
+
+    // Can create a RPC wallet from a seed
+    [Fact]
+    public void TestCreateWalletFromSeedRpc()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // Create wallet with seed and defaults
+        string path = GenUtils.GetGuid();
+        MoneroWallet wallet = CreateWallet(new MoneroWalletConfig().SetPath(path).SetSeed(TestUtils.SEED).SetRestoreHeight(TestUtils.FIRST_RECEIVE_HEIGHT));
+        Assert.Equal(TestUtils.SEED, wallet.GetSeed());
+        Assert.Equal(TestUtils.ADDRESS, wallet.GetPrimaryAddress());
+        wallet.Sync();
+        Assert.Equal(daemon.GetHeight(), wallet.GetHeight());
+        List<MoneroTxWallet> txs = wallet.GetTxs();
+        Assert.False(txs.Count == 0); // wallet is used
+        Assert.Equal(TestUtils.FIRST_RECEIVE_HEIGHT, (ulong)txs[0].GetHeight());
+        CloseWallet(wallet); // TODO: monero-wallet-rpc: if wallet is not closed, primary address will not change
+
+        // Create wallet with non-defaults
+        path = GenUtils.GetGuid();
+        wallet = CreateWallet(new MoneroWalletConfig().SetPath(path).SetSeed(TestUtils.SEED).SetRestoreHeight(TestUtils.FIRST_RECEIVE_HEIGHT).SetLanguage("German").SetSeedOffset("my offset!").SetSaveCurrent(false));
+        MoneroUtils.ValidateMnemonic(wallet.GetSeed());
+        Assert.NotEqual(TestUtils.SEED, wallet.GetSeed()); // seed is different because of offset
+        Assert.NotEqual(TestUtils.ADDRESS, wallet.GetPrimaryAddress());
+        wallet.Sync();
+        Assert.Equal(daemon.GetHeight(), wallet.GetHeight());
+        Assert.True(wallet.GetTxs().Count == 0);  // wallet is not used
+        CloseWallet(wallet);
+    }
+
+    // Can open wallets
+    [Fact]
+    public void TestOpenWallet()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // create names of test wallets
+        int numTestWallets = 3;
+        List<string> names = new List<string>();
+        for (int i = 0; i < numTestWallets; i++) names.Add(GenUtils.GetGuid());
+
+        // create test wallets
+        List<string> seeds = new List<string>();
+        foreach (string name in names)
+        {
+            MoneroWalletRpc wallet = CreateWallet(new MoneroWalletConfig().SetPath(name));
+            seeds.Add(wallet.GetSeed());
+            CloseWallet(wallet, true);
+        }
+
+        // open test wallets
+        List<MoneroWallet> wallets = new List<MoneroWallet>();
+        for (int i = 0; i < numTestWallets; i++)
+        {
+            MoneroWallet wallet = OpenWallet(new MoneroWalletConfig().SetPath(names[i]).SetPassword(TestUtils.WALLET_PASSWORD));
+            Assert.Equal(seeds[i], wallet.GetSeed());
+            wallets.Add(wallet);
+        }
+
+        // attempt to re-open already opened wallet
+        try
+        {
+            OpenWallet(new MoneroWalletConfig().SetPath(names[numTestWallets - 1]).SetPassword(TestUtils.WALLET_PASSWORD));
+            Assert.Fail("Cannot open wallet which is already open");
+        }
+        catch (MoneroError e)
+        {
+            Assert.Equal(-1, (int)e.GetCode()); // -1 indicates wallet does not exist (or is open by another app)
+        }
+
+        // attempt to open non-existent
+        try
+        {
+            OpenWallet(new MoneroWalletConfig().SetPath("btc_integrity").SetPassword(TestUtils.WALLET_PASSWORD));
+            Assert.Fail("Cannot open non-existent wallet");
+        }
+        catch (MoneroError e)
+        {
+            Assert.Equal(-1, (int)e.GetCode());
+        }
+
+        // Close wallets
+        foreach (MoneroWallet wallet in wallets) CloseWallet(wallet);
+    }
+
+    // Can indicate if multisig import is needed for correct balance information
+    [Fact]
+    public void TestIsMultisigNeeded()
+    {
+        Assert.True(TEST_NON_RELAYS);
+        Assert.False(wallet.IsMultisigImportNeeded()); // TODO: test with multisig wallet
+    }
+
+    // Can tag accounts and query accounts by tag
+    [Fact]
+    public void TestAccountTags()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // get accounts
+        List<MoneroAccount> accounts = wallet.GetAccounts();
+        Assert.True(accounts.Count >= 3, "Not enough accounts to test; run create account test");
+
+        // tag some of the accounts
+        MoneroAccountTag tag = new MoneroAccountTag("my_tag_" + GenUtils.GetGuid(), "my tag label", [0, 1]);
+        wallet.TagAccounts(tag.GetTag(), tag.GetAccountIndices());
+
+        // query accounts by tag
+        List<MoneroAccount> taggedAccounts = wallet.GetAccounts(false, tag.GetTag());
+        Assert.Equal(2, taggedAccounts.Count);
+        Assert.Equal(0, (int)taggedAccounts[0].GetIndex());
+        Assert.Equal(tag.GetTag(), taggedAccounts[0].GetTag());
+        Assert.Equal(1, (int)taggedAccounts[1].GetIndex());
+        Assert.Equal(tag.GetTag(), taggedAccounts[1].GetTag());
+
+        // set tag label
+        wallet.SetAccountTagLabel(tag.GetTag(), tag.GetLabel());
+
+        // fetch tags and ensure new tag is contained
+        List<MoneroAccountTag> tags = wallet.GetAccountTags();
+        Assert.NotNull(tags.Find(x => x.Equals(tag)));
+
+        // re-tag an account
+        MoneroAccountTag tag2 = new MoneroAccountTag("my_tag_" + GenUtils.GetGuid(), "my tag label 2", [1]);
+        wallet.TagAccounts(tag2.GetTag(), tag2.GetAccountIndices());
+        List<MoneroAccount> taggedAccounts2 = wallet.GetAccounts(false, tag2.GetTag());
+        Assert.Single(taggedAccounts2);
+        Assert.True(1 == taggedAccounts2[0].GetIndex());
+        Assert.Equal(tag2.GetTag(), taggedAccounts2[0].GetTag());
+
+        // re-query original tag which only applies to one account now
+        taggedAccounts = wallet.GetAccounts(false, tag.GetTag());
+        Assert.Single(taggedAccounts);
+        Assert.Equal(0, (int)taggedAccounts[0].GetIndex());
+        Assert.Equal(tag.GetTag(), taggedAccounts[0].GetTag());
+
+        // untag and query accounts
+        wallet.UntagAccounts([0, 1]);
+        Assert.Empty(wallet.GetAccountTags());
+        try
+        {
+            wallet.GetAccounts(false, tag.GetTag());
+            Assert.Fail("Should have thrown exception with unregistered tag");
+        }
+        catch (MoneroError e)
+        {
+            Assert.Equal(-1, (int)e.GetCode());
+        }
+
+        // test that non-existing tag returns no accounts
+        try
+        {
+            wallet.GetAccounts(false, "non_existing_tag");
+            Assert.Fail("Should have thrown exception with unregistered tag");
+        }
+        catch (MoneroError e)
+        {
+            Assert.Equal(-1, (int)e.GetCode());
+        }
+    }
+
+    // Can get addresses out of range of used accounts and subaddresses
+    [Fact]
+    public override void TestGetSubaddressAddressOutOfRange()
+    {
+        Assert.True(TEST_NON_RELAYS);
+        List<MoneroAccount> accounts = wallet.GetAccounts(true);
+        int accountIdx = accounts.Count - 1;
+        int subaddressIdx = accounts[accountIdx].GetSubaddresses().Count;
+        string address = wallet.GetAddress((uint)accountIdx, (uint)subaddressIdx);
+        Assert.Null(address);
+    }
+
+    // Can save the wallet
+    [Fact]
+    public void TestSave()
+    {
+        Assert.True(TEST_NON_RELAYS);
+        wallet.Save();
+    }
+
+    // Can close a wallet
+    [Fact]
+    public void TestClose()
+    {
+        Assert.True(TEST_NON_RELAYS);
+
+        // create a test wallet
+        string path = GenUtils.GetGuid();
+        MoneroWalletRpc wallet = CreateWallet(new MoneroWalletConfig().SetPath(path));
+        wallet.Sync();
+
+        // close the wallet
+        wallet.Close();
+
+        // attempt to interact with the wallet
+        try
+        {
+            wallet.GetHeight();
+        }
+        catch (MoneroError e)
+        {
+            Assert.Equal(-13, (int)e.GetCode());
+            Assert.Equal("No wallet file", e.Message);
+        }
+        try
+        {
+            wallet.GetSeed();
+        }
+        catch (MoneroError e)
+        {
+            Assert.Equal(-13, (int)e.GetCode());
+            Assert.Equal("No wallet file", e.Message);
+        }
+        try
+        {
+            wallet.Sync();
+        }
+        catch (MoneroError e)
+        {
+            Assert.Equal(-13, (int)e.GetCode());
+            Assert.Equal("No wallet file", e.Message);
+        }
+
+        // re-open the wallet
+        wallet.OpenWallet(path, TestUtils.WALLET_PASSWORD);
+        wallet.Sync();
+        Assert.Equal(daemon.GetHeight(), wallet.GetHeight());
+
+        // close the wallet
+        CloseWallet(wallet, true);
+    }
+
+    // Can stop the RPC server
+    [Fact(Skip = "Disabled so server not actually stopped")]
+    public void TestStop()
+    {
+        ((MoneroWalletRpc)wallet).Stop();
+    }
+
+    [Fact(Skip = "Disabled because importing key images deletes corresponding incoming transfers: https://github.com/monero-project/monero/issues/5812")]
+    public override void TestImportKeyImages()
+    {
+        base.TestImportKeyImages();
+    }
+
+    [Fact(Skip = "monero-wallet-rpc does not support getting a height by date")]
+    public override void TestGetHeightByDate()
+    {
+        base.TestGetHeightByDate();
+    }
+
+    [Fact(Skip = "monero-wallet-rpc does not support getting seed language")]
+    public override void TestGetSeedLanguage()
+    {
+        base.TestGetSeedLanguage();
+    }
+
+    [Fact(Skip = "monero-wallet-rpc doesn't support getting public view key")]
+    public override void TestGetPublicViewKey()
+    {
+        base.TestGetPublicViewKey();
+    }
+
+    [Fact(Skip = "monero-wallet-rpc doesn't support getting public spend key")]
+    public override void TestGetPublicSpendKey()
+    {
+        base.TestGetPublicSpendKey();
+    }
+
+    [Fact(Skip = "monero-wallet-rpc does not support creating wallets with subaddress lookahead over rpc")]
+    public override void TestSubaddressLookahead()
+    {
+        base.TestSubaddressLookahead();
+    }
+
+    #endregion
+
+    #region RPC Specific Tests
+
+    protected override void TestTxWallet(MoneroTxWallet tx, TxContext? ctx = null)
+    {
+        ctx = new TxContext(ctx);
+
+        // run common tests
+        base.TestTxWallet(tx, ctx);
+    }
+
+    protected override void TestInvalidTxHashError(MoneroError e)
+    {
+        base.TestInvalidTxHashError(e);
+        Assert.Equal(-8, (int)e.GetCode());
+    }
+
+    protected override void TestInvalidTxKeyError(MoneroError e)
+    {
+        base.TestInvalidTxKeyError(e);
+        Assert.Equal(-25, (int)e.GetCode());
+    }
+
+    protected override void TestInvalidAddressError(MoneroError e)
+    {
+        base.TestInvalidAddressError(e);
+        Assert.Equal(-2, (int)e.GetCode());
+    }
+
+    protected override void TestInvalidSignatureError(MoneroError e)
+    {
+        base.TestInvalidSignatureError(e);
+        Assert.Equal(-1, (int)e.GetCode()); // TODO: sometimes comes back bad, sometimes throws exception.  ensure txs come from different addresses?
+    }
+
+    protected override void TestNoSubaddressError(MoneroError e)
+    {
+        base.TestNoSubaddressError(e);
+        Assert.Equal(-1, (int)e.GetCode());
+    }
+
+    protected override void TestSignatureHeaderCheckError(MoneroError e)
+    {
+        base.TestSignatureHeaderCheckError(e);
+        Assert.Equal(-1, (int)e.GetCode());
+    }
+
+    #endregion
+
 }

--- a/Monero.Test/Utils/TestUtils.cs
+++ b/Monero.Test/Utils/TestUtils.cs
@@ -27,7 +27,7 @@ internal abstract class TestUtils
     public static readonly int WALLET_RPC_ZMQ_BIND_PORT_START = 48083;  // TODO: zmq bind port necessary?
     public static readonly string WALLET_RPC_USERNAME = "";
     public static readonly string WALLET_RPC_PASSWORD = "";
-    public static readonly string WALLET_RPC_ZMQ_DOMAIN = "127.0.0.1";
+    public static readonly string WALLET_RPC_ZMQ_DOMAIN = "xmr_wallet";
     public static readonly string WALLET_RPC_DOMAIN = "http://xmr_wallet";
     public static readonly string WALLET_RPC_URI = WALLET_RPC_DOMAIN + ":" + WALLET_RPC_PORT_START;
     public static readonly string WALLET_RPC_ZMQ_URI = "tcp://" + WALLET_RPC_ZMQ_DOMAIN + ":" + WALLET_RPC_ZMQ_PORT_START;
@@ -49,11 +49,14 @@ internal abstract class TestUtils
     public static readonly string ADDRESS = "4B7nn4hBQhaJ2MBWHLpdUHQMoMqgE2BWtZfofNxTDAJoGgckeEGm4f9WaBuFJmCKuwZ7FE3Di7biKbdafqE4JDj19MWPvQ9";
     public static readonly string PRIVATE_VIEW_KEY = "395d05e724f4c08f072895eab08ee4d00b3b2848902cf939fd3c07288454f804";
     public static readonly ulong FIRST_RECEIVE_HEIGHT = 171; // NOTE: this value must be the height of the wallet's first tx for tests
-    public static readonly int SYNC_PERIOD_IN_MS = 5000; // period between wallet syncs in milliseconds
+    public static readonly int SYNC_PERIOD_IN_MS = 5000; // period between wallet syncs in 
+    public static readonly ulong SYNC_PERIOD_IN_MS_ULONG = (ulong)SYNC_PERIOD_IN_MS;
     public static readonly string OFFLINE_SERVER_URI = "offline_server_uri"; // dummy server uri to remain offline because wallet2 connects to default if not given
     public static readonly int AUTO_CONNECT_TIMEOUT_MS = 3000;
 
     public static readonly WalletTxTracker WALLET_TX_TRACKER = new();
+
+    public static Dictionary<MoneroWalletRpc, int> WALLET_PORT_OFFSETS = [];
 
     public static MoneroWalletRpc StartWalletRpcProcess(bool offline = false)
     {

--- a/Monero.Test/Utils/WalletEqualityUtils.cs
+++ b/Monero.Test/Utils/WalletEqualityUtils.cs
@@ -1,0 +1,384 @@
+using Monero.Common;
+using Monero.Wallet;
+using Monero.Wallet.Common;
+
+namespace Monero.Test.Utils;
+
+public class WalletEqualityUtils
+{
+    public static void TestWalletEqualityOnChain(MoneroWallet w1, MoneroWallet w2)
+    {
+        TestUtils.WALLET_TX_TRACKER.Reset(); // all wallets need to wait for txs to confirm to reliably sync
+
+        // wait for relayed txs associated with wallets to clear pool
+        Assert.Equal(w1.IsConnectedToDaemon(), w2.IsConnectedToDaemon());
+        if (w1.IsConnectedToDaemon()) TestUtils.WALLET_TX_TRACKER.WaitForWalletTxsToClearPool([w1, w2]);
+
+        // sync the wallets until same height
+        while (w1.GetHeight() != w2.GetHeight())
+        {
+            w1.Sync();
+            w2.Sync();
+        }
+
+        // test that wallets are equal using only on-chain data
+        Assert.Equal(w1.GetHeight(), w2.GetHeight());
+        Assert.Equal(w1.GetSeed(), w2.GetSeed());
+        Assert.Equal(w1.GetPrimaryAddress(), w2.GetPrimaryAddress());
+        Assert.Equal(w1.GetPrivateViewKey(), w2.GetPrivateViewKey());
+        Assert.Equal(w1.GetPrivateSpendKey(), w2.GetPrivateSpendKey());
+        MoneroTxQuery txQuery = new MoneroTxQuery().SetIsConfirmed(true);
+        TestTxWalletsEqualOnChain(w1.GetTxs(txQuery), w2.GetTxs(txQuery));
+        txQuery.SetIncludeOutputs(true);
+        TestTxWalletsEqualOnChain(w1.GetTxs(txQuery), w2.GetTxs(txQuery));  // fetch and compare outputs
+        TestAccountsEqualOnChain(w1.GetAccounts(true), w2.GetAccounts(true));
+        Assert.Equal(w1.GetBalance(), w2.GetBalance());
+        Assert.Equal(w1.GetUnlockedBalance(), w2.GetUnlockedBalance());
+        MoneroTransferQuery transferQuery = new MoneroTransferQuery().SetTxQuery(new MoneroTxQuery().SetIsConfirmed(true));
+        TestTransfersEqualOnChain(w1.GetTransfers(transferQuery), w2.GetTransfers(transferQuery));
+        MoneroOutputQuery outputQuery = new MoneroOutputQuery().SetTxQuery(new MoneroTxQuery().SetIsConfirmed(true));
+        TestOutputWalletsEqualOnChain(w1.GetOutputs(outputQuery), w2.GetOutputs(outputQuery));
+    }
+
+    private static void TestAccountsEqualOnChain(List<MoneroAccount> accounts1, List<MoneroAccount> accounts2)
+    {
+        for (int i = 0; i < Math.Max(accounts1.Count, accounts2.Count); i++)
+        {
+            if (i < accounts1.Count && i < accounts2.Count)
+            {
+                TestAccountEqualOnChain(accounts1[i], accounts2[i]);
+            }
+            else if (i >= accounts1.Count)
+            {
+                for (int j = i; j < accounts2.Count; j++)
+                {
+                    Assert.Equal((ulong)0, accounts2[j].GetBalance()!);
+                    Assert.True(accounts2[j].GetSubaddresses().Count >= 1);
+                    foreach (MoneroSubaddress subaddress in accounts2[j].GetSubaddresses()) Assert.False(subaddress.IsUsed());
+                }
+                return;
+            }
+            else
+            {
+                for (int j = i; j < accounts1.Count; j++)
+                {
+                    Assert.Equal((ulong)0, accounts1[j].GetBalance()!);
+                    Assert.True(accounts1[j].GetSubaddresses().Count >= 1);
+                    foreach (MoneroSubaddress subaddress in accounts1[j].GetSubaddresses()) Assert.False(subaddress.IsUsed());
+                }
+                return;
+            }
+        }
+    }
+
+    private static void TestAccountEqualOnChain(MoneroAccount account1, MoneroAccount account2)
+    {
+
+        // nullify off-chain data for comparison
+        List<MoneroSubaddress> subaddresses1 = account1.GetSubaddresses();
+        List<MoneroSubaddress> subaddresses2 = account2.GetSubaddresses();
+        account1.SetSubaddresses(null);
+        account2.SetSubaddresses(null);
+        account1.SetTag(null);
+        account2.SetTag(null);
+
+        // test account equality
+        Assert.Equal(account1, account2);
+        TestSubaddressesEqualOnChain(subaddresses1, subaddresses2);
+    }
+
+    private static void TestSubaddressesEqualOnChain(List<MoneroSubaddress> subaddresses1, List<MoneroSubaddress> subaddresses2)
+    {
+        for (int i = 0; i < Math.Max(subaddresses1.Count, subaddresses2.Count); i++)
+        {
+            if (i < subaddresses1.Count && i < subaddresses2.Count)
+            {
+                TestSubaddressesEqualOnChain(subaddresses1[i], subaddresses2[i]);
+            }
+            else if (i >= subaddresses1.Count)
+            {
+                for (int j = i; j < subaddresses2.Count; j++)
+                {
+                    Assert.True(0 == (ulong)subaddresses2[j].GetBalance());
+                    Assert.False(subaddresses2[j].IsUsed());
+                }
+                return;
+            }
+            else
+            {
+                for (int j = i; j < subaddresses1.Count; j++)
+                {
+                    Assert.True(0 == (ulong)subaddresses1[i].GetBalance());
+                    Assert.False(subaddresses1[j].IsUsed());
+                }
+                return;
+            }
+        }
+    }
+
+    private static void TestSubaddressesEqualOnChain(MoneroSubaddress subaddress1, MoneroSubaddress subaddress2)
+    {
+        subaddress1.SetLabel(null); // nullify off-chain data for comparison
+        subaddress2.SetLabel(null);
+        Assert.Equal(subaddress1, subaddress2);
+    }
+
+    private static void TestTxWalletsEqualOnChain(List<MoneroTxWallet> txs1, List<MoneroTxWallet> txs2)
+    {
+
+        // nullify off-chain data for comparison
+        var allTxs = new List<MoneroTxWallet>(txs1);
+
+        allTxs.AddRange(txs2);
+
+        foreach (MoneroTxWallet tx in allTxs)
+        {
+            tx.SetNote(null);
+            if (tx.GetOutgoingTransfer() != null)
+            {
+                tx.GetOutgoingTransfer().SetAddresses(null);
+            }
+        }
+
+        // compare txs
+        Assert.Equal(txs1.Count, txs2.Count);
+        foreach (MoneroTxWallet tx1 in txs1)
+        {
+            bool found = false;
+            foreach (MoneroTxWallet tx2 in txs2)
+            {
+                if (tx1.GetHash().Equals(tx2.GetHash()))
+                {
+
+                    // transfer cached info if known for comparison
+                    if (tx1.GetOutgoingTransfer() != null && tx1.GetOutgoingTransfer().GetDestinations() != null)
+                    {
+                        if (tx2.GetOutgoingTransfer() == null || tx2.GetOutgoingTransfer().GetDestinations() == null) TransferCachedInfo(tx1, tx2);
+                    }
+                    else if (tx2.GetOutgoingTransfer() != null && tx2.GetOutgoingTransfer().GetDestinations() != null)
+                    {
+                        TransferCachedInfo(tx2, tx1);
+                    }
+
+                    // test tx equality by merging
+                    Assert.True(TestUtils.TxsMergeable(tx1, tx2), "Txs are not mergeable");
+                    Assert.Equal(tx1, tx2);
+                    found = true;
+
+                    // test block equality except txs to ignore order
+                    List<MoneroTx> blockTxs1 = tx1.GetBlock().GetTxs();
+                    List<MoneroTx> blockTxs2 = tx2.GetBlock().GetTxs();
+                    tx1.GetBlock().SetTxs(null);
+                    tx2.GetBlock().SetTxs(null);
+                    Assert.Equal(tx1.GetBlock(), tx2.GetBlock());
+                    tx1.GetBlock().SetTxs(blockTxs1);
+                    tx2.GetBlock().SetTxs(blockTxs2);
+                }
+            }
+            Assert.True(found);  // each tx must have one and only one match
+        }
+    }
+
+    private static void TransferCachedInfo(MoneroTxWallet src, MoneroTxWallet tgt)
+    {
+
+        // fill in missing incoming transfers when sending from/to the same account
+        if (src.GetIncomingTransfers() != null)
+        {
+            foreach (MoneroIncomingTransfer inTransfer in src.GetIncomingTransfers())
+            {
+                if (inTransfer.GetAccountIndex() == src.GetOutgoingTransfer().GetAccountIndex())
+                {
+                    tgt.GetIncomingTransfers().Add(inTransfer);
+                }
+            }
+
+            tgt.GetIncomingTransfers().Sort(new MoneroIncomingTransferComparer());
+        }
+
+        // transfer info to outgoing transfer
+        if (tgt.GetOutgoingTransfer() == null) tgt.SetOutgoingTransfer(src.GetOutgoingTransfer());
+        else
+        {
+            tgt.GetOutgoingTransfer().SetDestinations(src.GetOutgoingTransfer().GetDestinations());
+            tgt.GetOutgoingTransfer().SetAmount(src.GetOutgoingTransfer().GetAmount());
+        }
+
+        // transfer payment id if outgoing // TODO: monero-wallet-rpc does not provide payment id for outgoing transfer when cache missing https://github.com/monero-project/monero/issues/8378
+        if (tgt.GetOutgoingTransfer() != null) tgt.SetPaymentId(src.GetPaymentId());
+    }
+
+    private static void TestTransfersEqualOnChain(List<MoneroTransfer> transfers1, List<MoneroTransfer> transfers2)
+    {
+        Assert.Equal(transfers1.Count, transfers2.Count);
+
+        // test and collect transfers per transaction
+        Dictionary<string, List<MoneroTransfer>> txsTransfers1 = new();
+        Dictionary<string, List<MoneroTransfer>> txsTransfers2 = new();
+        ulong? lastHeight = null;
+        MoneroTxWallet lastTx1 = null;
+        MoneroTxWallet lastTx2 = null;
+        for (int i = 0; i < transfers1.Count; i++)
+        {
+            MoneroTransfer transfer1 = transfers1[i];
+            MoneroTransfer transfer2 = transfers2[i];
+
+            // transfers must have same height even if they don't belong to same tx (because tx ordering within blocks is not currently provided by wallet2)
+            Assert.Equal((long)transfer1.GetTx().GetHeight(), (long)transfer2.GetTx().GetHeight());
+
+            // transfers must be in ascending order by height
+            if (lastHeight == null) lastHeight = transfer1.GetTx().GetHeight();
+            else Assert.True(lastHeight <= transfer1.GetTx().GetHeight());
+
+            // transfers must be consecutive per transaction
+            if (lastTx1 != transfer1.GetTx())
+            {
+                Assert.False(txsTransfers1.ContainsKey(transfer1.GetTx().GetHash()));  // cannot be seen before
+                lastTx1 = transfer1.GetTx();
+            }
+            if (lastTx2 != transfer2.GetTx())
+            {
+                Assert.False(txsTransfers2.ContainsKey(transfer2.GetTx().GetHash()));  // cannot be seen before
+                lastTx2 = transfer2.GetTx();
+            }
+
+            // collect tx1 transfer
+            List<MoneroTransfer> txTransfers1 = txsTransfers1.GetValueOrDefault(transfer1.GetTx().GetHash());
+            if (txTransfers1 == null)
+            {
+                txTransfers1 = new List<MoneroTransfer>();
+                txsTransfers1.Add(transfer1.GetTx().GetHash(), txTransfers1);
+            }
+            txTransfers1.Add(transfer1);
+
+            // collect tx2 transfer
+            List<MoneroTransfer> txTransfers2 = txsTransfers2.GetValueOrDefault(transfer2.GetTx().GetHash());
+            if (txTransfers2 == null)
+            {
+                txTransfers2 = new List<MoneroTransfer>();
+                txsTransfers2.Add(transfer2.GetTx().GetHash(), txTransfers2);
+            }
+            txTransfers2.Add(transfer2);
+        }
+
+        // compare collected transfers per tx for equality
+        foreach (string txHash in txsTransfers1.Keys)
+        {
+            List<MoneroTransfer> txTransfers1 = txsTransfers1.GetValueOrDefault(txHash, []);
+            List<MoneroTransfer> txTransfers2 = txsTransfers2.GetValueOrDefault(txHash, []);
+            Assert.Equal(txTransfers1.Count, txTransfers2.Count);
+
+            // normalize and compare transfers
+            for (int i = 0; i < txTransfers1.Count; i++)
+            {
+                MoneroTransfer transfer1 = txTransfers1[i];
+                MoneroTransfer transfer2 = txTransfers2[i];
+
+                // normalize outgoing transfers
+                if (transfer1 is MoneroOutgoingTransfer)
+                {
+                    MoneroOutgoingTransfer ot1 = (MoneroOutgoingTransfer)transfer1;
+                    MoneroOutgoingTransfer ot2 = (MoneroOutgoingTransfer)transfer2;
+
+                    // transfer destination info if known for comparison
+                    if (ot1.GetDestinations() != null)
+                    {
+                        if (ot2.GetDestinations() == null) TransferCachedInfo(ot1.GetTx(), ot2.GetTx());
+                    }
+                    else if (ot2.GetDestinations() != null)
+                    {
+                        TransferCachedInfo(ot2.GetTx(), ot1.GetTx());
+                    }
+
+                    // nullify other local wallet data
+                    ot1.SetAddresses(null);
+                    ot2.SetAddresses(null);
+                }
+
+                // normalize incoming transfers
+                else
+                {
+                    MoneroIncomingTransfer it1 = (MoneroIncomingTransfer)transfer1;
+                    MoneroIncomingTransfer it2 = (MoneroIncomingTransfer)transfer2;
+                    it1.SetAddress(null);
+                    it2.SetAddress(null);
+                }
+
+                // compare transfer equality
+                Assert.Equal(transfer1, transfer2);
+            }
+        }
+    }
+
+    private static void TestOutputWalletsEqualOnChain(List<MoneroOutputWallet> outputs1, List<MoneroOutputWallet> outputs2)
+    {
+        Assert.Equal(outputs1.Count, outputs2.Count);
+
+        // test and collect outputs per transaction
+        Dictionary<string, List<MoneroOutputWallet>> txsOutputs1 = new();
+        Dictionary<string, List<MoneroOutputWallet>> txsOutputs2 = new();
+        ulong? lastHeight = null;
+        MoneroTxWallet lastTx1 = null;
+        MoneroTxWallet lastTx2 = null;
+        for (int i = 0; i < outputs1.Count; i++)
+        {
+            MoneroOutputWallet output1 = outputs1[i];
+            MoneroOutputWallet output2 = outputs2[i];
+
+            // outputs must have same height even if they don't belong to same tx (because tx ordering within blocks is not currently provided by wallet2)
+            Assert.Equal((long)output1.GetTx().GetHeight(), (long)output2.GetTx().GetHeight());
+
+            // outputs must be in ascending order by height
+            if (lastHeight == null) lastHeight = output1.GetTx().GetHeight();
+            else Assert.True(lastHeight <= output1.GetTx().GetHeight());
+
+            // outputs must be consecutive per transaction
+            if (lastTx1 != output1.GetTx())
+            {
+                Assert.False(txsOutputs1.ContainsKey(output1.GetTx().GetHash()));  // cannot be seen before
+                lastTx1 = output1.GetTx();
+            }
+            if (lastTx2 != output2.GetTx())
+            {
+                Assert.False(txsOutputs2.ContainsKey(output2.GetTx().GetHash()));  // cannot be seen before
+                lastTx2 = output2.GetTx();
+            }
+
+            // collect tx1 output
+            List<MoneroOutputWallet> txOutputs1 = txsOutputs1.GetValueOrDefault(output1.GetTx().GetHash(), []);
+            if (txOutputs1 == null)
+            {
+                txOutputs1 = new List<MoneroOutputWallet>();
+                txsOutputs1.Add(output1.GetTx().GetHash(), txOutputs1);
+            }
+            txOutputs1.Add(output1);
+
+            // collect tx2 output
+            List<MoneroOutputWallet> txOutputs2 = txsOutputs2.GetValueOrDefault(output2.GetTx().GetHash(), []);
+            if (txOutputs2 == null)
+            {
+                txOutputs2 = new List<MoneroOutputWallet>();
+                txsOutputs2.Add(output2.GetTx().GetHash(), txOutputs2);
+            }
+            txOutputs2.Add(output2);
+        }
+
+        // compare collected outputs per tx for equality
+        foreach (string txHash in txsOutputs1.Keys)
+        {
+            List<MoneroOutputWallet> txOutputs1 = txsOutputs1.GetValueOrDefault(txHash, []);
+            List<MoneroOutputWallet> txOutputs2 = txsOutputs2.GetValueOrDefault(txHash, []);
+            Assert.Equal(txOutputs1.Count, txOutputs2.Count);
+
+            // normalize and compare outputs
+            for (int i = 0; i < txOutputs1.Count; i++)
+            {
+                MoneroOutput output1 = txOutputs1[i];
+                MoneroOutput output2 = txOutputs2[i];
+                Assert.Equal(output1.GetTx().GetHash(), output2.GetTx().GetHash());
+                Assert.Equal(output1, output2);
+            }
+        }
+    }
+
+}

--- a/Monero.Test/Utils/WalletNotificationCollector.cs
+++ b/Monero.Test/Utils/WalletNotificationCollector.cs
@@ -1,0 +1,96 @@
+using Monero.Wallet;
+using Monero.Wallet.Common;
+
+namespace Monero.Test.Utils;
+
+public class WalletNotificationCollector : MoneroWalletListener
+{
+    private bool _listening;
+    private readonly List<ulong> _blockNotifications = [];
+    private readonly List<KeyValuePair<ulong, ulong>> _balanceNotifications = [];
+    private readonly List<MoneroOutputWallet> _outputsReceived = [];
+    private readonly List<MoneroOutputWallet> _outputsSpent = [];
+
+    public override void OnNewBlock(ulong height)
+    {
+        Assert.True(_listening);
+        if (_blockNotifications.Count > 0)
+        {
+            var last = _blockNotifications.Last();
+            Assert.True(height == last + 1);
+        }
+
+        _blockNotifications.Add(height);
+    }
+
+    public override void OnBalancesChanged(ulong newBalance, ulong newUnlockedBalance)
+    {
+        Assert.True(_listening);
+
+        if (_balanceNotifications.Count != 0)
+        {
+            KeyValuePair<ulong, ulong> lastNotification = _balanceNotifications.Last();
+            Assert.True(!newBalance.Equals(lastNotification.Key) || !newUnlockedBalance.Equals(lastNotification.Value)); // test that balances change
+        }
+
+        _balanceNotifications.Add(new KeyValuePair<ulong, ulong>(newBalance, newUnlockedBalance));
+    }
+
+    public override void OnOutputReceived(MoneroOutputWallet output)
+    {
+        Assert.True(_listening);
+        _outputsReceived.Add(output);
+    }
+
+    public override void OnOutputSpent(MoneroOutputWallet output)
+    {
+        Assert.True(_listening);
+        _outputsSpent.Add(output);
+    }
+
+    public List<ulong> GetBlockNotifications()
+    {
+        return _blockNotifications;
+    }
+
+    public List<KeyValuePair<ulong, ulong>> GetBalanceNotifications()
+    {
+        return _balanceNotifications;
+    }
+
+    public List<MoneroOutputWallet> GetOutputsReceived(MoneroOutputQuery? query = null)
+    {
+        List<MoneroOutputWallet> result = [];
+
+        foreach (var output in _outputsReceived)
+        {
+            if (query == null || query.MeetsCriteria(output))
+            {
+                result.Add(output);
+            }
+        }
+
+        return result;
+    }
+
+    public List<MoneroOutputWallet> GetOutputsSpent(MoneroOutputQuery? query = null)
+    {
+        List<MoneroOutputWallet> result = [];
+
+        foreach (var output in _outputsSpent)
+        {
+            if (query == null || query.MeetsCriteria(output))
+            {
+                result.Add(output);
+            }
+        }
+
+        return result;
+    }
+
+    public void SetListening(bool listening)
+    {
+        _listening = listening;
+    }
+
+}

--- a/Monero/Common/ListExtensions.cs
+++ b/Monero/Common/ListExtensions.cs
@@ -1,0 +1,17 @@
+namespace Monero.Common;
+
+public static class ListExtensions
+{
+    private static readonly Random RNG = new();
+
+    public static void Shuffle<T>(this IList<T> list)
+    {
+        int n = list.Count;
+        while (n > 1)
+        {
+            n--;
+            int k = RNG.Next(n + 1); // random index
+            (list[n], list[k]) = (list[k], list[n]); // swap
+        }
+    }
+}

--- a/Monero/Common/MoneroBlock.cs
+++ b/Monero/Common/MoneroBlock.cs
@@ -182,12 +182,6 @@ public class MoneroBlock : MoneroBlockHeader
         return this;
     }
 
-    public MoneroBlock SetTxs(MoneroTx? tx)
-    {
-        if (tx == null) throw new ArgumentNullException(nameof(tx), "Transaction cannot be null");
-        return SetTxs([tx]);
-    }
-
     public MoneroBlock AddTx(MoneroTx? tx)
     {
         if (tx == null) throw new ArgumentNullException(nameof(tx), "Transaction cannot be null");

--- a/Monero/Common/MoneroOutput.cs
+++ b/Monero/Common/MoneroOutput.cs
@@ -3,12 +3,12 @@ namespace Monero.Common;
 
 public class MoneroOutput
 {
-    private MoneroTx? tx;
-    private MoneroKeyImage? keyImage;
-    private ulong? amount;
-    private ulong? index;
-    private List<ulong>? ringOutputIndices;
-    private string? stealthPublicKey;
+    private MoneroTx? _tx;
+    private MoneroKeyImage? _keyImage;
+    private ulong? _amount;
+    private ulong? _index;
+    private List<ulong>? _ringOutputIndices;
+    private string? _stealthPublicKey;
 
     public MoneroOutput()
     {
@@ -17,11 +17,11 @@ public class MoneroOutput
 
     public MoneroOutput(MoneroOutput output)
     {
-        if (output.keyImage != null) this.keyImage = output.keyImage.Clone();
-        amount = output.amount;
-        index = output.index;
-        if (output.ringOutputIndices != null) ringOutputIndices = new List<ulong>(output.ringOutputIndices);
-        stealthPublicKey = output.stealthPublicKey;
+        if (output._keyImage != null) _keyImage = output._keyImage.Clone();
+        _amount = output._amount;
+        _index = output._index;
+        if (output._ringOutputIndices != null) _ringOutputIndices = new List<ulong>(output._ringOutputIndices);
+        _stealthPublicKey = output._stealthPublicKey;
     }
 
     public virtual MoneroOutput Clone()
@@ -31,67 +31,67 @@ public class MoneroOutput
 
     public virtual MoneroTx? GetTx()
     {
-        return tx;
+        return _tx;
     }
 
     public virtual MoneroOutput SetTx(MoneroTx? tx)
     {
-        this.tx = tx;
+        _tx = tx;
         return this;
     }
 
     public MoneroKeyImage? GetKeyImage()
     {
-        return keyImage;
+        return _keyImage;
     }
 
-    public MoneroOutput SetKeyImage(MoneroKeyImage? keyImage)
+    public virtual MoneroOutput SetKeyImage(MoneroKeyImage? keyImage)
     {
-        this.keyImage = keyImage;
+        _keyImage = keyImage;
         return this;
     }
 
     public ulong? GetAmount()
     {
-        return amount;
+        return _amount;
     }
 
     public virtual MoneroOutput SetAmount(ulong? amount)
     {
-        this.amount = amount;
+        _amount = amount;
         return this;
     }
 
     public ulong? GetIndex()
     {
-        return index;
+        return _index;
     }
 
     public virtual MoneroOutput SetIndex(ulong? index)
     {
-        this.index = index;
+        _index = index;
         return this;
     }
 
     public List<ulong>? GetRingOutputIndices()
     {
-        return ringOutputIndices;
+        return _ringOutputIndices;
     }
 
     public virtual MoneroOutput SetRingOutputIndices(List<ulong>? ringOutputIndices)
     {
-        this.ringOutputIndices = ringOutputIndices;
+        _ringOutputIndices = ringOutputIndices;
         return this;
     }
 
     public string? GetStealthPublicKey()
     {
-        return stealthPublicKey;
+        return _stealthPublicKey;
     }
 
     public virtual MoneroOutput SetStealthPublicKey(string? stealthPublicKey)
     {
-        this.stealthPublicKey = stealthPublicKey;
+        _stealthPublicKey = stealthPublicKey;
         return this;
     }
 
@@ -101,17 +101,49 @@ public class MoneroOutput
         if (this == output) return this;
 
         // merge txs if they're different which comes back to merging outputs
-        if (this.GetTx() != output.GetTx()) this.GetTx().Merge(output.GetTx());
+        if (GetTx() != output.GetTx()) GetTx()!.Merge(output.GetTx()!);
 
         // otherwise merge output fields
         else
         {
-            if (this.GetKeyImage() == null) this.SetKeyImage(output.GetKeyImage());
-            else if (output.GetKeyImage() != null) this.GetKeyImage().Merge(output.GetKeyImage());
-            this.SetAmount(GenUtils.Reconcile(this.GetAmount(), output.GetAmount()));
-            this.SetIndex(GenUtils.Reconcile(this.GetIndex(), output.GetIndex()));
+            if (GetKeyImage() == null) SetKeyImage(output.GetKeyImage());
+            else if (output.GetKeyImage() != null) GetKeyImage()!.Merge(output.GetKeyImage());
+            SetAmount(GenUtils.Reconcile(GetAmount(), output.GetAmount()));
+            SetIndex(GenUtils.Reconcile(GetIndex(), output.GetIndex()));
         }
 
         return this;
+    }
+
+    public bool Equals(MoneroOutput? other)
+    {
+        if (this == other) return true;
+        if (other == null) return false;
+        if (_amount == null)
+        {
+            if (other._amount != null) return false;
+        }
+        else if (_amount != other._amount) return false;
+        if (_index == null)
+        {
+            if (other._index != null) return false;
+        }
+        else if (_index != other._index) return false;
+        if (_keyImage == null)
+        {
+            if (other._keyImage != null) return false;
+        }
+        else if (!_keyImage.Equals(other._keyImage)) return false;
+        if (_ringOutputIndices == null)
+        {
+            if (other._ringOutputIndices != null) return false;
+        }
+        else if (!_ringOutputIndices.Equals(other._ringOutputIndices)) return false;
+        if (_stealthPublicKey == null)
+        {
+            if (other._stealthPublicKey != null) return false;
+        }
+        else if (!_stealthPublicKey.Equals(other._stealthPublicKey)) return false;
+        return true;
     }
 }

--- a/Monero/Common/MoneroTx.cs
+++ b/Monero/Common/MoneroTx.cs
@@ -513,125 +513,218 @@ public class MoneroTx
         return this;
     }
 
-    public MoneroTx Merge(MoneroTx? tx)
+    public virtual MoneroTx Merge(MoneroTx tx)
     {
-        if (tx == null)
-        {
-            throw new MoneroError("Cannot merge null tx");
-        }
         if (this == tx) return this;
+        var block = GetBlock();
 
         // merge blocks if they're different
-        if (this.GetBlock() != tx.GetBlock())
+        if (block != null && !block.Equals(tx.GetBlock()))
         {
-            if (this.GetBlock() == null)
+            if (GetBlock() == null)
             {
-                this.SetBlock(tx.GetBlock());
-                //this.GetBlock().GetTxs().Set(this.GetBlock().GetTxs().IndexOf(tx), this); // update block to point to this tx
+                SetBlock(tx.GetBlock());
+                var blockTxs = GetBlock()!.GetTxs() ?? [];
+                var txIndex = blockTxs.IndexOf(tx);
+                blockTxs[txIndex] = this; // update block to point to this tx
             }
             else if (tx.GetBlock() != null)
             {
-                this.GetBlock().Merge(tx.GetBlock()); // comes back to merging txs
+                GetBlock()!.Merge(tx.GetBlock()); // comes back to merging txs
                 return this;
             }
         }
 
         // otherwise merge tx fields
-        this.SetHash(GenUtils.Reconcile(this.GetHash(), tx.GetHash()));
-        this.SetVersion(GenUtils.Reconcile(this.GetVersion(), tx.GetVersion()));
-        this.SetPaymentId(GenUtils.Reconcile(this.GetPaymentId(), tx.GetPaymentId()));
-        this.SetFee(GenUtils.Reconcile(this.GetFee(), tx.GetFee()));
-        this.SetRingSize(GenUtils.Reconcile(this.GetRingSize(), tx.GetRingSize()));
-        this.SetIsConfirmed(GenUtils.Reconcile(this.IsConfirmed(), tx.IsConfirmed(), null, true, null));  // tx can become confirmed
-        this.SetIsMinerTx(GenUtils.Reconcile(this.IsMinerTx(), tx.IsMinerTx(), null, null, null));
-        this.SetRelay(GenUtils.Reconcile(this.GetRelay(), tx.GetRelay(), null, true, null));        // tx can become relayed
-        this.SetIsRelayed(GenUtils.Reconcile(this.IsRelayed(), tx.IsRelayed(), null, true, null));  // tx can become relayed
-        this.SetIsDoubleSpendSeen(GenUtils.Reconcile(this.IsDoubleSpendSeen(), tx.IsDoubleSpendSeen(), null, true, null)); // double spend can become seen
-        this.SetKey(GenUtils.Reconcile(this.GetKey(), tx.GetKey()));
-        this.SetFullHex(GenUtils.Reconcile(this.GetFullHex(), tx.GetFullHex()));
-        this.SetPrunedHex(GenUtils.Reconcile(this.GetPrunedHex(), tx.GetPrunedHex()));
-        this.SetPrunableHex(GenUtils.Reconcile(this.GetPrunableHex(), tx.GetPrunableHex()));
-        this.SetPrunableHash(GenUtils.Reconcile(this.GetPrunableHash(), tx.GetPrunableHash()));
-        this.SetSize(GenUtils.Reconcile(this.GetSize(), tx.GetSize()));
-        this.SetWeight(GenUtils.Reconcile(this.GetWeight(), tx.GetWeight()));
-        this.SetOutputIndices(GenUtils.Reconcile(this.GetOutputIndices(), tx.GetOutputIndices()));
-        this.SetMetadata(GenUtils.Reconcile(this.GetMetadata(), tx.GetMetadata()));
-        this.SetExtra(GenUtils.ReconcileByteArrays(this.GetExtra(), tx.GetExtra()));
-        this.SetRctSignatures(GenUtils.Reconcile(this.GetRctSignatures(), tx.GetRctSignatures()));
-        this.SetRctSigPrunable(GenUtils.Reconcile(this.GetRctSigPrunable(), tx.GetRctSigPrunable()));
-        this.SetIsKeptByBlock(GenUtils.Reconcile(this.IsKeptByBlock(), tx.IsKeptByBlock()));
-        this.SetIsFailed(GenUtils.Reconcile(this.IsFailed(), tx.IsFailed(), null, true, null));
-        this.SetLastFailedHeight(GenUtils.Reconcile(this.GetLastFailedHeight(), tx.GetLastFailedHeight()));
-        this.SetLastFailedHash(GenUtils.Reconcile(this.GetLastFailedHash(), tx.GetLastFailedHash()));
-        this.SetMaxUsedBlockHeight(GenUtils.Reconcile(this.GetMaxUsedBlockHeight(), tx.GetMaxUsedBlockHeight()));
-        this.SetMaxUsedBlockHash(GenUtils.Reconcile(this.GetMaxUsedBlockHash(), tx.GetMaxUsedBlockHash()));
-        this.SetSignatures(GenUtils.Reconcile(this.GetSignatures(), tx.GetSignatures()));
-        this.SetUnlockTime(GenUtils.Reconcile(this.GetUnlockTime(), tx.GetUnlockTime()));
-        this.SetNumConfirmations(GenUtils.Reconcile(this.GetNumConfirmations(), tx.GetNumConfirmations(), null, null, true)); // num confirmations can increase
+        SetHash(GenUtils.Reconcile(GetHash(), tx.GetHash()));
+        SetVersion(GenUtils.Reconcile(GetVersion(), tx.GetVersion()));
+        SetPaymentId(GenUtils.Reconcile(GetPaymentId(), tx.GetPaymentId()));
+        SetFee(GenUtils.Reconcile(GetFee(), tx.GetFee()));
+        SetRingSize(GenUtils.Reconcile(GetRingSize(), tx.GetRingSize()));
+        SetIsConfirmed(GenUtils.Reconcile(IsConfirmed(), tx.IsConfirmed(), null, true, null));  // tx can become confirmed
+        SetIsMinerTx(GenUtils.Reconcile(IsMinerTx(), tx.IsMinerTx(), null, null, null));
+        SetRelay(GenUtils.Reconcile(GetRelay(), tx.GetRelay(), null, true, null));        // tx can become relayed
+        SetIsRelayed(GenUtils.Reconcile(IsRelayed(), tx.IsRelayed(), null, true, null));  // tx can become relayed
+        SetIsDoubleSpendSeen(GenUtils.Reconcile(IsDoubleSpendSeen(), tx.IsDoubleSpendSeen(), null, true, null)); // double spend can become seen
+        SetKey(GenUtils.Reconcile(GetKey(), tx.GetKey()));
+        SetFullHex(GenUtils.Reconcile(GetFullHex(), tx.GetFullHex()));
+        SetPrunedHex(GenUtils.Reconcile(GetPrunedHex(), tx.GetPrunedHex()));
+        SetPrunableHex(GenUtils.Reconcile(GetPrunableHex(), tx.GetPrunableHex()));
+        SetPrunableHash(GenUtils.Reconcile(GetPrunableHash(), tx.GetPrunableHash()));
+        SetSize(GenUtils.Reconcile(GetSize(), tx.GetSize()));
+        SetWeight(GenUtils.Reconcile(GetWeight(), tx.GetWeight()));
+        SetOutputIndices(GenUtils.Reconcile(GetOutputIndices(), tx.GetOutputIndices()));
+        SetMetadata(GenUtils.Reconcile(GetMetadata(), tx.GetMetadata()));
+        SetExtra(GenUtils.ReconcileByteArrays(GetExtra()!, tx.GetExtra()!));
+        SetRctSignatures(GenUtils.Reconcile(GetRctSignatures(), tx.GetRctSignatures()));
+        SetRctSigPrunable(GenUtils.Reconcile(GetRctSigPrunable(), tx.GetRctSigPrunable()));
+        SetIsKeptByBlock(GenUtils.Reconcile(IsKeptByBlock(), tx.IsKeptByBlock()));
+        SetIsFailed(GenUtils.Reconcile(IsFailed(), tx.IsFailed(), null, true, null));
+        SetLastFailedHeight(GenUtils.Reconcile(GetLastFailedHeight(), tx.GetLastFailedHeight()));
+        SetLastFailedHash(GenUtils.Reconcile(GetLastFailedHash(), tx.GetLastFailedHash()));
+        SetMaxUsedBlockHeight(GenUtils.Reconcile(GetMaxUsedBlockHeight(), tx.GetMaxUsedBlockHeight()));
+        SetMaxUsedBlockHash(GenUtils.Reconcile(GetMaxUsedBlockHash(), tx.GetMaxUsedBlockHash()));
+        SetSignatures(GenUtils.Reconcile(GetSignatures(), tx.GetSignatures()));
+        SetUnlockTime(GenUtils.Reconcile(GetUnlockTime(), tx.GetUnlockTime()));
+        SetNumConfirmations(GenUtils.Reconcile(GetNumConfirmations(), tx.GetNumConfirmations(), null, null, true)); // num confirmations can increase
 
         // merge inputs
         if (tx.GetInputs() != null)
         {
-            foreach (MoneroOutput merger in tx.GetInputs())
+            foreach (MoneroOutput merger in tx.GetInputs()!)
             {
                 bool merged = false;
                 merger.SetTx(this);
-                if (this.GetInputs() == null) this.SetInputs([]);
-                foreach (MoneroOutput mergee in this.GetInputs())
+                if (GetInputs() == null) SetInputs([]);
+                foreach (MoneroOutput mergee in GetInputs()!)
                 {
-                    if (mergee.GetKeyImage().GetHex().Equals(merger.GetKeyImage().GetHex()))
+                    if (mergee.GetKeyImage()!.GetHex()!.Equals(merger.GetKeyImage()!.GetHex()))
                     {
                         mergee.Merge(merger);
                         merged = true;
                         break;
                     }
                 }
-                if (!merged) this.GetInputs().Add(merger);
+                if (!merged) GetInputs()!.Add(merger);
             }
         }
 
         // merge outputs
         if (tx.GetOutputs() != null)
         {
-            foreach (MoneroOutput output in tx.GetOutputs()) output.SetTx(this);
-            if (this.GetOutputs() == null) this.SetOutputs(tx.GetOutputs());
+            foreach (MoneroOutput output in tx.GetOutputs()!) output.SetTx(this);
+            if (GetOutputs() == null) SetOutputs(tx.GetOutputs());
             else
             {
 
                 // merge outputs if key image or stealth public key present, otherwise append
-                foreach (MoneroOutput merger in tx.GetOutputs())
+                foreach (MoneroOutput merger in tx.GetOutputs()!)
                 {
                     bool merged = false;
                     merger.SetTx(this);
-                    foreach (MoneroOutput mergee in this.GetOutputs())
+                    foreach (MoneroOutput mergee in GetOutputs()!)
                     {
-                        if ((merger.GetKeyImage() != null && mergee.GetKeyImage().GetHex().Equals(merger.GetKeyImage().GetHex())) ||
-                            (merger.GetStealthPublicKey() != null && mergee.GetStealthPublicKey().Equals(merger.GetStealthPublicKey())))
+                        if ((merger.GetKeyImage() != null && mergee.GetKeyImage()!.GetHex()!.Equals(merger.GetKeyImage()!.GetHex())) ||
+                            (merger.GetStealthPublicKey() != null && mergee.GetStealthPublicKey()!.Equals(merger.GetStealthPublicKey())))
                         {
                             mergee.Merge(merger);
                             merged = true;
                             break;
                         }
                     }
-                    if (!merged) this.GetOutputs().Add(merger); // append output
+                    if (!merged) GetOutputs()!.Add(merger); // append output
                 }
             }
         }
 
         // handle unrelayed -> relayed -> confirmed
-        if (this.IsConfirmed() == true)
+        if (IsConfirmed() == true)
         {
-            this.SetInTxPool(false);
-            this.SetReceivedTimestamp(null);
-            this.SetLastRelayedTimestamp(null);
+            SetInTxPool(false);
+            SetReceivedTimestamp(null);
+            SetLastRelayedTimestamp(null);
         }
         else
         {
-            this.SetInTxPool(GenUtils.Reconcile(this.InTxPool(), tx.InTxPool(), null, true, null)); // unrelayed -> tx pool
-            this.SetReceivedTimestamp(GenUtils.Reconcile(this.GetReceivedTimestamp(), tx.GetReceivedTimestamp(), null, null, false)); // take earliest receive time
-            this.SetLastRelayedTimestamp(GenUtils.Reconcile(this.GetLastRelayedTimestamp(), tx.GetLastRelayedTimestamp(), null, null, true));  // take latest relay time
+            SetInTxPool(GenUtils.Reconcile(InTxPool(), tx.InTxPool(), null, true, null)); // unrelayed -> tx pool
+            SetReceivedTimestamp(GenUtils.Reconcile(GetReceivedTimestamp(), tx.GetReceivedTimestamp(), null, null, false)); // take earliest receive time
+            SetLastRelayedTimestamp(GenUtils.Reconcile(GetLastRelayedTimestamp(), tx.GetLastRelayedTimestamp(), null, null, true));  // take latest relay time
         }
 
         return this;  // for chaining
+    }
+
+    public virtual bool Equals(MoneroTx other, bool checkInputs = true, bool checkOutputs = true)
+    {
+        if (this == other) return true;
+
+        if (checkInputs)
+        {
+            var inputs = GetInputs() ?? [];
+            var otherInputs = other.GetInputs() ?? [];
+
+            if (inputs.Count != otherInputs.Count) return false;
+            int i = 0;
+            foreach (var input in inputs)
+            {
+                var otherInput = otherInputs[i]!;
+                if (!input.Equals(otherInput)) return false;
+            }
+
+            i++;
+        }
+
+        if (checkOutputs)
+        {
+            var outputs = GetOutputs() ?? [];
+            var otherOutputs = other.GetOutputs() ?? [];
+
+            if (outputs.Count != otherOutputs.Count) return false;
+            int i = 0;
+            foreach (var output in outputs)
+            {
+                var otherOutput = otherOutputs[i]!;
+                if (!output.Equals(otherOutput)) return false;
+                i++;
+            }
+        }
+
+        var signatures = GetSignatures() ?? [];
+        var otherSignatures = other.GetSignatures() ?? [];
+
+        if (signatures.Count != otherSignatures.Count) return false;
+
+        int j = 0;
+
+        foreach (var signature in signatures)
+        {
+            if (signature != otherSignatures[j]) return false;
+            j++;
+        }
+
+        var indices = GetOutputIndices() ?? [];
+        var otherIndices = other.GetOutputIndices() ?? [];
+
+        if (indices.Count != otherIndices.Count) return false;
+
+        int k = 0;
+
+        foreach (var index in indices)
+        {
+            if (index != otherIndices[k]) return false;
+            k++;
+        }
+
+        return GetHash() == other.GetHash() &&
+               GetVersion() == other.GetVersion() &&
+               IsMinerTx() == other.IsMinerTx() &&
+               GetPaymentId() == other.GetPaymentId() &&
+               GetFee() == other.GetFee() &&
+               GetRingSize() == other.GetRingSize() &&
+               GetRelay() == other.GetRelay() &&
+               IsRelayed() == other.IsRelayed() &&
+               IsConfirmed() == other.IsConfirmed() &&
+               InTxPool() == other.InTxPool() &&
+               GetNumConfirmations() == other.GetNumConfirmations() &&
+               GetUnlockTime() == other.GetUnlockTime() &&
+               GetLastRelayedTimestamp() == other.GetLastRelayedTimestamp() &&
+               GetReceivedTimestamp() == other.GetReceivedTimestamp() &&
+               IsDoubleSpendSeen() == other.IsDoubleSpendSeen() &&
+               GetKey() == other.GetKey() &&
+               GetFullHex() == other.GetFullHex() &&
+               GetPrunedHex() == other.GetPrunedHex() &&
+               GetPrunableHash() == other.GetPrunableHash() &&
+               GetSize() == other.GetSize() &&
+               GetWeight() == other.GetWeight() &&
+               GetMetadata() == other.GetMetadata() &&
+               GetExtra() == other.GetExtra() &&
+               GetRctSignatures() == other.GetRctSignatures() &&
+               GetRctSigPrunable() == other.GetRctSigPrunable() &&
+               IsKeptByBlock() == other.IsKeptByBlock() &&
+               IsFailed() == other.IsFailed() &&
+               GetLastFailedHeight() == other.GetLastFailedHeight() &&
+               GetLastFailedHash() == other.GetLastFailedHash() &&
+               GetMaxUsedBlockHeight() == other.GetMaxUsedBlockHeight() &&
+               GetMaxUsedBlockHash() == other.GetMaxUsedBlockHash();
     }
 }

--- a/Monero/Wallet/Common/MoneroAccount.cs
+++ b/Monero/Wallet/Common/MoneroAccount.cs
@@ -4,27 +4,69 @@ public class MoneroAccount
 {
     private uint? index;
     private string? primaryAddress;
-    private ulong balance;
-    private ulong unlockedBalance;
+    private ulong? balance;
+    private ulong? unlockedBalance;
     private string? tag;
-    private List<MoneroSubaddress> subaddresses;
+    private List<MoneroSubaddress>? subaddresses;
 
-    public MoneroAccount(uint? index = null, string? primaryAddress = null)
-    {
-        this.index = index;
-        this.primaryAddress = primaryAddress;
-        subaddresses = [];
-        balance = 0;
-        unlockedBalance = 0;
-    }
-
-    public MoneroAccount(uint index, string primaryAddress, ulong balance, ulong unlockedBalance, List<MoneroSubaddress> subaddresses)
+    public MoneroAccount(uint? index = null, string? primaryAddress = null, ulong? balance = null, ulong? unlockedBalance = null, List<MoneroSubaddress>? subaddresses = null)
     {
         this.index = index;
         this.primaryAddress = primaryAddress;
         this.balance = balance;
         this.unlockedBalance = unlockedBalance;
         this.subaddresses = subaddresses;
+    }
+
+    public MoneroAccount(MoneroAccount other)
+    {
+        index = other.index;
+        primaryAddress = other.primaryAddress;
+        balance = other.balance;
+        unlockedBalance = other.unlockedBalance;
+
+        if (other.subaddresses != null)
+        {
+            subaddresses = [];
+            foreach (var subaddr in other.subaddresses)
+            {
+                subaddresses.Add(subaddr.Clone());
+            }
+        }
+    }
+
+    public bool Equals(MoneroAccount? other)
+    {
+        if (other == null) return false;
+        if (this == other) return false;
+
+        if (subaddresses == null)
+        {
+            if (other.subaddresses != null) return false;
+        }
+        else
+        {
+            if (other.subaddresses == null) return false;
+
+            int i = 0;
+
+            foreach (MoneroSubaddress subaddr in subaddresses)
+            {
+                var otherSubaddr = other.subaddresses[i];
+                if (!subaddr.Equals(otherSubaddr)) return false;
+                i++;
+            }
+        }
+
+        return index == other.index &&
+                primaryAddress == other.primaryAddress &&
+                balance == other.balance &&
+                unlockedBalance == other.unlockedBalance;
+    }
+
+    public MoneroAccount Clone()
+    {
+        return new MoneroAccount(this);
     }
 
     public uint? GetIndex()
@@ -49,23 +91,23 @@ public class MoneroAccount
         return this;
     }
 
-    public ulong GetBalance()
+    public ulong? GetBalance()
     {
         return balance;
     }
 
-    public MoneroAccount SetBalance(ulong balance)
+    public MoneroAccount SetBalance(ulong? balance)
     {
         this.balance = balance;
         return this;
     }
 
-    public ulong GetUnlockedBalance()
+    public ulong? GetUnlockedBalance()
     {
         return unlockedBalance;
     }
 
-    public MoneroAccount SetUnlockedBalance(ulong unlockedBalance)
+    public MoneroAccount SetUnlockedBalance(ulong? unlockedBalance)
     {
         this.unlockedBalance = unlockedBalance;
         return this;
@@ -82,12 +124,12 @@ public class MoneroAccount
         return this;
     }
 
-    public List<MoneroSubaddress> GetSubaddresses()
+    public List<MoneroSubaddress>? GetSubaddresses()
     {
         return subaddresses;
     }
 
-    public MoneroAccount SetSubaddresses(List<MoneroSubaddress> subaddresses)
+    public MoneroAccount SetSubaddresses(List<MoneroSubaddress>? subaddresses)
     {
         this.subaddresses = subaddresses;
         if (subaddresses != null)

--- a/Monero/Wallet/Common/MoneroDestination.cs
+++ b/Monero/Wallet/Common/MoneroDestination.cs
@@ -1,4 +1,7 @@
 ﻿
+using System.Text;
+using Monero.Common;
+
 namespace Monero.Wallet.Common;
 
 public class MoneroDestination
@@ -18,9 +21,17 @@ public class MoneroDestination
         _amount = destination._amount;
     }
 
+    public bool Equals(MoneroDestination? other)
+    {
+        if (other == null) return false;
+        if (this == other) return true;
+
+        return _address == other._address && _amount == other._amount;
+    }
+
     public MoneroDestination Clone() { return new MoneroDestination(this); }
 
-    public string GetAddress()
+    public string? GetAddress()
     {
         return _address;
     }
@@ -40,5 +51,19 @@ public class MoneroDestination
     {
         _amount = amount;
         return this;
+    }
+
+    public override string ToString()
+    {
+        return ToString(0);
+    }
+
+    public string ToString(int indent)
+    {
+        var sb = new StringBuilder();
+        sb.Append(GenUtils.KvLine("Address", GetAddress(), indent));
+        sb.Append(GenUtils.KvLine("Amount", GetAmount() != null ? GetAmount().ToString() : null, indent));
+        string str = sb.ToString();
+        return str.Substring(0, str.Length - 1);
     }
 }

--- a/Monero/Wallet/Common/MoneroIncomingTransfer.cs
+++ b/Monero/Wallet/Common/MoneroIncomingTransfer.cs
@@ -1,15 +1,29 @@
 ﻿
+using System.Text;
+using Monero.Common;
+
 namespace Monero.Wallet.Common;
 
 public class MoneroIncomingTransfer : MoneroTransfer
 {
-    private uint subaddressIndex;
-    private string address;
+    private uint? subaddressIndex;
+    private string? address;
     private ulong numSuggestedConfirmations;
 
     public MoneroIncomingTransfer()
     {
         // nothing to initialize
+    }
+
+    public bool Equals(MoneroIncomingTransfer? other)
+    {
+        if (other == null) return false;
+        if (other == this) return true;
+        if (!base.Equals(other)) return false;
+
+        return subaddressIndex == other.subaddressIndex &&
+                address == other.address &&
+                numSuggestedConfirmations == other.numSuggestedConfirmations;
     }
 
     public MoneroIncomingTransfer(MoneroIncomingTransfer transfer) : base(transfer)
@@ -24,9 +38,9 @@ public class MoneroIncomingTransfer : MoneroTransfer
         return new MoneroIncomingTransfer(this);
     }
 
-    public override MoneroIncomingTransfer SetTx(MoneroTxWallet tx)
+    public override MoneroIncomingTransfer SetTx(MoneroTxWallet? tx)
     {
-        _tx = tx;
+        base.SetTx(tx);
         return this;
     }
 
@@ -35,23 +49,23 @@ public class MoneroIncomingTransfer : MoneroTransfer
         return true;
     }
 
-    public uint GetSubaddressIndex()
+    public uint? GetSubaddressIndex()
     {
         return subaddressIndex;
     }
 
-    public MoneroIncomingTransfer SetSubaddressIndex(uint subaddressIndex)
+    public MoneroIncomingTransfer SetSubaddressIndex(uint? subaddressIndex)
     {
         this.subaddressIndex = subaddressIndex;
         return this;
     }
 
-    public string GetAddress()
+    public string? GetAddress()
     {
         return address;
     }
 
-    public MoneroIncomingTransfer SetAddress(string address)
+    public MoneroIncomingTransfer SetAddress(string? address)
     {
         this.address = address;
         return this;
@@ -66,5 +80,16 @@ public class MoneroIncomingTransfer : MoneroTransfer
     {
         this.numSuggestedConfirmations = numSuggestedConfirmations;
         return this;
+    }
+
+    public override string ToString(int indent)
+    {
+        var sb = new StringBuilder();
+        sb.Append(base.ToString(indent) + "\n");
+        sb.Append(GenUtils.KvLine("Subaddress index", GetSubaddressIndex(), indent));
+        sb.Append(GenUtils.KvLine("Address", GetAddress(), indent));
+        sb.Append(GenUtils.KvLine("Num suggested confirmations", GetNumSuggestedConfirmations(), indent));
+        string str = sb.ToString();
+        return str.Substring(0, str.Length - 1);
     }
 }

--- a/Monero/Wallet/Common/MoneroIncomingTransferComparer.cs
+++ b/Monero/Wallet/Common/MoneroIncomingTransferComparer.cs
@@ -1,19 +1,31 @@
 ﻿
 namespace Monero.Wallet.Common;
 
-internal class MoneroIncomingTransferComparer : Comparer<MoneroIncomingTransfer>
+public class MoneroIncomingTransferComparer : Comparer<MoneroIncomingTransfer>
 {
-    private static readonly MoneroTxHeightComparer TX_HEIGHT_COMPARATOR = new MoneroTxHeightComparer();
+    private static readonly MoneroTxHeightComparer TxHeightComparator = new MoneroTxHeightComparer();
 
     public override int Compare(MoneroIncomingTransfer? t1, MoneroIncomingTransfer? t2)
     {
         // compare by height
-        int heightComparison = TX_HEIGHT_COMPARATOR.Compare(t1.GetTx(), t2.GetTx());
+        if (t1 == null && t2 == null) return 0;
+        if (t1 == null) return -1;
+        if (t2 == null) return 1;
+        int heightComparison = TxHeightComparator.Compare(t1.GetTx(), t2.GetTx());
         if (heightComparison != 0) return heightComparison;
 
         // compare by account and subaddress index
         if (t1.GetAccountIndex() < t2.GetAccountIndex()) return -1;
-        else if (t1.GetAccountIndex() == t2.GetAccountIndex()) return t1.GetSubaddressIndex().CompareTo(t2.GetSubaddressIndex());
+        else if (t1.GetAccountIndex() == t2.GetAccountIndex())
+        {
+            // Gestione dei valori null per subaddressIndex
+            var sub1 = t1.GetSubaddressIndex();
+            var sub2 = t2.GetSubaddressIndex();
+            if (sub1 == null && sub2 == null) return 0;
+            if (sub1 == null) return -1;
+            if (sub2 == null) return 1;
+            return sub1.Value.CompareTo(sub2.Value);
+        }
         return 1;
     }
 }

--- a/Monero/Wallet/Common/MoneroOutgoingTransfer.cs
+++ b/Monero/Wallet/Common/MoneroOutgoingTransfer.cs
@@ -1,27 +1,92 @@
 ﻿
+using System.Text;
+using Monero.Common;
+
 namespace Monero.Wallet.Common;
 
 public class MoneroOutgoingTransfer : MoneroTransfer
 {
-    private List<uint> subaddressIndices;
-    private List<string> addresses;
-    private List<MoneroDestination> destinations;
+    private List<uint>? subaddressIndices;
+    private List<string>? addresses;
+    private List<MoneroDestination>? destinations;
 
     public MoneroOutgoingTransfer()
     {
         // nothing to initialize
     }
 
+    public bool Equals(MoneroOutgoingTransfer? other)
+    {
+        if (other == null) return false;
+        if (other == this) return true;
+
+        if (subaddressIndices == null)
+        {
+            if (other.subaddressIndices != null) return false;
+        }
+        else
+        {
+            if (other.subaddressIndices == null) return false;
+            if (subaddressIndices.Count != other.subaddressIndices.Count) return false;
+            int i = 0;
+
+            foreach (var index in subaddressIndices)
+            {
+                var otherIndex = other.subaddressIndices[i]!;
+                if (index != otherIndex) return false;
+                i++;
+            }
+        }
+
+        if (addresses == null)
+        {
+            if (other.addresses != null) return false;
+        }
+        else
+        {
+            if (other.addresses == null) return false;
+            if (addresses.Count != other.addresses.Count) return false;
+            int i = 0;
+
+            foreach (var address in addresses)
+            {
+                var otherAddress = other.addresses[i]!;
+                if (address != otherAddress) return false;
+                i++;
+            }
+        }
+
+        if (destinations == null)
+        {
+            if (other.destinations != null) return false;
+        }
+        else
+        {
+            if (other.destinations == null) return false;
+            if (destinations.Count != other.destinations.Count) return false;
+
+            int i = 0;
+            foreach (var destination in destinations)
+            {
+                var otherDest = other.destinations[i];
+                if (destination.Equals(otherDest)) return false;
+                i++;
+            }
+        }
+
+        return true;
+    }
+
     public MoneroOutgoingTransfer(MoneroOutgoingTransfer transfer) : base(transfer)
     {
-        if (transfer.subaddressIndices != null) this.subaddressIndices = new List<uint>(transfer.subaddressIndices);
-        if (transfer.addresses != null) this.addresses = new List<string>(transfer.addresses);
+        if (transfer.subaddressIndices != null) subaddressIndices = [.. transfer.subaddressIndices];
+        if (transfer.addresses != null) addresses = [.. transfer.addresses];
         if (transfer.destinations != null)
         {
-            this.destinations = new List<MoneroDestination>();
-            foreach (MoneroDestination destination in transfer.GetDestinations())
+            destinations = new List<MoneroDestination>();
+            foreach (MoneroDestination destination in transfer.GetDestinations()!)
             {
-                this.destinations.Add(destination.Clone());
+                destinations.Add(destination.Clone());
             }
         }
     }
@@ -31,9 +96,9 @@ public class MoneroOutgoingTransfer : MoneroTransfer
         return new MoneroOutgoingTransfer(this);
     }
 
-    public override MoneroOutgoingTransfer SetTx(MoneroTxWallet tx)
+    public override MoneroOutgoingTransfer SetTx(MoneroTxWallet? tx)
     {
-        _tx = tx;
+        base.SetTx(tx);
         return this;
     }
 
@@ -42,37 +107,56 @@ public class MoneroOutgoingTransfer : MoneroTransfer
         return false;
     }
 
-    public List<uint> GetSubaddressIndices()
+    public List<uint>? GetSubaddressIndices()
     {
         return subaddressIndices;
     }
 
-    public MoneroOutgoingTransfer SetSubaddressIndices(List<uint> subaddressIndices)
+    public MoneroOutgoingTransfer SetSubaddressIndices(List<uint>? subaddressIndices)
     {
         this.subaddressIndices = subaddressIndices;
         return this;
     }
 
-    public List<string> GetAddresses()
+    public List<string>? GetAddresses()
     {
         return addresses;
     }
 
-    public MoneroOutgoingTransfer SetAddresses(List<string> addresses)
+    public MoneroOutgoingTransfer SetAddresses(List<string>? addresses)
     {
         this.addresses = addresses;
         return this;
     }
 
-    public List<MoneroDestination> GetDestinations()
+    public List<MoneroDestination>? GetDestinations()
     {
         return destinations;
     }
 
-    public MoneroOutgoingTransfer SetDestinations(List<MoneroDestination> destinations)
+    public MoneroOutgoingTransfer SetDestinations(List<MoneroDestination>? destinations)
     {
         this.destinations = destinations;
         return this;
+    }
+
+    public override string ToString(int indent)
+    {
+        var sb = new StringBuilder();
+        sb.Append(base.ToString(indent) + "\n");
+        sb.Append(GenUtils.KvLine("Subaddress indices", GetSubaddressIndices(), indent));
+        sb.Append(GenUtils.KvLine("Addresses", GetAddresses(), indent));
+        if (GetDestinations() != null)
+        {
+            sb.Append(GenUtils.KvLine("Destinations", "", indent));
+            for (int i = 0; i < GetDestinations()!.Count; i++)
+            {
+                sb.Append(GenUtils.KvLine(i + 1, "", indent + 1));
+                sb.Append(GetDestinations()[i].ToString(indent + 2) + "\n");
+            }
+        }
+        string str = sb.ToString();
+        return str.Substring(0, str.Length - 1);
     }
 
 }

--- a/Monero/Wallet/Common/MoneroOutputWallet.cs
+++ b/Monero/Wallet/Common/MoneroOutputWallet.cs
@@ -6,11 +6,22 @@ public class MoneroOutputWallet : MoneroOutput
 {
     private uint? accountIndex;
     private uint? subaddressIndex;
-    private bool isSpent;
-    private bool isFrozen;
+    private bool? isSpent;
+    private bool? isFrozen;
 
     public MoneroOutputWallet()
     {
+    }
+
+    public bool Equals(MoneroOutputWallet? other)
+    {
+        if (other == null) return false;
+        if (!base.Equals(other)) return false;
+
+        return accountIndex == other.accountIndex &&
+                subaddressIndex == other.subaddressIndex &&
+                isSpent == other.isSpent &&
+                isFrozen == other.isFrozen;
     }
 
     public MoneroOutputWallet(MoneroOutputWallet output) : base(output)
@@ -26,21 +37,20 @@ public class MoneroOutputWallet : MoneroOutput
         return new MoneroOutputWallet(this);
     }
 
-    public override MoneroTxWallet GetTx()
+    public override MoneroTxWallet? GetTx()
     {
-        return (MoneroTxWallet)base.GetTx();
+        return (MoneroTxWallet?)base.GetTx();
     }
 
-
-    public override MoneroOutputWallet SetTx(MoneroTx tx)
+    public override MoneroOutputWallet SetKeyImage(MoneroKeyImage? keyImage)
     {
-        //if (tx != null && !(tx instanceof MoneroTxWallet)) throw new MoneroError("Wallet output's transaction must be of type MoneroTxWallet");
-        base.SetTx(tx);
+        base.SetKeyImage(keyImage);
         return this;
     }
 
-    public MoneroOutputWallet SetTx(MoneroTxWallet tx)
+    public override MoneroOutputWallet SetTx(MoneroTx? tx)
     {
+        //if (tx != null && !(tx instanceof MoneroTxWallet)) throw new MoneroError("Wallet output's transaction must be of type MoneroTxWallet");
         base.SetTx(tx);
         return this;
     }
@@ -50,7 +60,7 @@ public class MoneroOutputWallet : MoneroOutput
         return accountIndex;
     }
 
-    public MoneroOutputWallet SetAccountIndex(uint? accountIndex)
+    public virtual MoneroOutputWallet SetAccountIndex(uint? accountIndex)
     {
         this.accountIndex = accountIndex;
         return this;
@@ -61,7 +71,7 @@ public class MoneroOutputWallet : MoneroOutput
         return subaddressIndex;
     }
 
-    public MoneroOutputWallet SetSubaddressIndex(uint? subaddressIndex)
+    public virtual MoneroOutputWallet SetSubaddressIndex(uint? subaddressIndex)
     {
         this.subaddressIndex = subaddressIndex;
         return this;
@@ -73,23 +83,23 @@ public class MoneroOutputWallet : MoneroOutput
         return this;
     }
 
-    public bool IsSpent()
+    public bool? IsSpent()
     {
         return isSpent;
     }
 
-    public MoneroOutputWallet SetIsSpent(bool isSpent)
+    public virtual MoneroOutputWallet SetIsSpent(bool? isSpent)
     {
         this.isSpent = isSpent;
         return this;
     }
 
-    public bool IsFrozen()
+    public bool? IsFrozen()
     {
         return isFrozen;
     }
 
-    public MoneroOutputWallet SetIsFrozen(bool isFrozen)
+    public virtual MoneroOutputWallet SetIsFrozen(bool? isFrozen)
     {
         this.isFrozen = isFrozen;
         return this;
@@ -99,6 +109,6 @@ public class MoneroOutputWallet : MoneroOutput
     public bool? IsLocked()
     {
         if (GetTx() == null) return null;
-        return GetTx().IsLocked();
+        return GetTx()!.IsLocked();
     }
 }

--- a/Monero/Wallet/Common/MoneroSubaddress.cs
+++ b/Monero/Wallet/Common/MoneroSubaddress.cs
@@ -13,6 +13,21 @@ public class MoneroSubaddress
     private bool? isUsed;
     private ulong? numBlocksToUnlock;
 
+    public bool Equals(MoneroSubaddress? other)
+    {
+        if (other == null) return false;
+        if (this == other) return true;
+        return accountIndex == other.accountIndex &&
+                index == other.index &&
+                address == other.address &&
+                label == other.label &&
+                balance == other.balance &&
+                unlockedBalance == other.unlockedBalance &&
+                numUnspentOutputs == other.numUnspentOutputs &&
+                isUsed == other.isUsed &&
+                numBlocksToUnlock == other.numBlocksToUnlock;
+    }
+
     public MoneroSubaddress() { }
 
     public MoneroSubaddress(string address)
@@ -24,6 +39,24 @@ public class MoneroSubaddress
     {
         this.accountIndex = accountIndex;
         this.index = index;
+    }
+
+    public MoneroSubaddress(MoneroSubaddress other)
+    {
+        accountIndex = other.accountIndex;
+        index = other.index;
+        address = other.address;
+        label = other.label;
+        balance = other.balance;
+        unlockedBalance = other.unlockedBalance;
+        numUnspentOutputs = other.numUnspentOutputs;
+        isUsed = other.isUsed;
+        numBlocksToUnlock = other.numBlocksToUnlock;
+    }
+
+    public MoneroSubaddress Clone()
+    {
+        return new MoneroSubaddress(this);
     }
 
     public uint? GetAccountIndex()

--- a/Monero/Wallet/Common/MoneroSyncResult.cs
+++ b/Monero/Wallet/Common/MoneroSyncResult.cs
@@ -3,40 +3,40 @@ namespace Monero.Wallet.Common;
 
 public class MoneroSyncResult
 {
-    private ulong _numBlocksFetched;
-    private bool _receivedMoney;
+    private ulong? numBlocksFetched;
+    private bool? receivedMoney;
 
-    public MoneroSyncResult(ulong numBlocksFetched, bool receivedMoney)
+    public MoneroSyncResult(ulong? numBlocksFetched = null, bool? receivedMoney = null)
     {
-        _numBlocksFetched = numBlocksFetched;
-        _receivedMoney = receivedMoney;
+        this.numBlocksFetched = numBlocksFetched;
+        this.receivedMoney = receivedMoney;
     }
 
     public MoneroSyncResult(MoneroSyncResult syncResult)
     {
-        _numBlocksFetched = syncResult._numBlocksFetched;
-        _receivedMoney = syncResult._receivedMoney;
+        numBlocksFetched = syncResult.numBlocksFetched;
+        receivedMoney = syncResult.receivedMoney;
     }
 
-    public ulong GetNumBlocksFetched()
+    public ulong? GetNumBlocksFetched()
     {
-        return _numBlocksFetched;
+        return numBlocksFetched;
     }
 
-    public MoneroSyncResult SetNumBlocksFetched(ulong numBlocksFetched)
+    public MoneroSyncResult SetNumBlocksFetched(ulong? numBlocksFetched)
     {
-        _numBlocksFetched = numBlocksFetched;
+        this.numBlocksFetched = numBlocksFetched;
         return this;
     }
 
-    public bool IsReceivedMoney()
+    public bool? GetReceivedMoney()
     {
-        return _receivedMoney;
+        return receivedMoney;
     }
 
-    public MoneroSyncResult SetReceivedMoney(bool receivedMoney)
+    public MoneroSyncResult SetReceivedMoney(bool? receivedMoney)
     {
-        _receivedMoney = receivedMoney;
+        this.receivedMoney = receivedMoney;
         return this;
     }
 

--- a/Monero/Wallet/Common/MoneroTransfer.cs
+++ b/Monero/Wallet/Common/MoneroTransfer.cs
@@ -1,13 +1,14 @@
 ﻿
+using System.Text;
 using Monero.Common;
 
 namespace Monero.Wallet.Common;
 
 public abstract class MoneroTransfer
 {
-    protected MoneroTxWallet _tx;
-    protected ulong? _amount;
-    protected uint? _accountIndex;
+    private MoneroTxWallet? _tx;
+    private ulong? _amount;
+    private uint? _accountIndex;
 
     public MoneroTransfer() { }
 
@@ -20,12 +21,12 @@ public abstract class MoneroTransfer
 
     public abstract MoneroTransfer Clone();
 
-    public MoneroTxWallet GetTx()
+    public MoneroTxWallet? GetTx()
     {
         return _tx;
     }
 
-    public virtual MoneroTransfer SetTx(MoneroTxWallet tx)
+    public virtual MoneroTransfer SetTx(MoneroTxWallet? tx)
     {
         _tx = tx;
         return this;
@@ -67,7 +68,7 @@ public abstract class MoneroTransfer
         // merge txs if they're different which comes back to merging transfers
         if (this.GetTx() != transfer.GetTx())
         {
-            this.GetTx().Merge(transfer.GetTx());
+            this.GetTx()!.Merge(transfer.GetTx()!);
             return this;
         }
 
@@ -87,4 +88,35 @@ public abstract class MoneroTransfer
         return this;
     }
 
+    public bool Equals(MoneroTransfer? other)
+    {
+        if (other == null) return false;
+        if (this == other) return true;
+        if (_accountIndex == null)
+        {
+            if (other._accountIndex != null) return false;
+        }
+        else if (!_accountIndex.Equals(other._accountIndex)) return false;
+        if (_amount == null)
+        {
+            if (other._amount != null) return false;
+        }
+        else if (!_amount.Equals(other._amount)) return false;
+        return true;
+    }
+
+    public override string ToString()
+    {
+        return ToString(0);
+    }
+
+    public virtual string ToString(int indent)
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.Append(GenUtils.KvLine("Is incoming", this.IsIncoming(), indent));
+        sb.Append(GenUtils.KvLine("Amount", this.GetAmount() != null ? this.GetAmount().ToString() : null, indent));
+        sb.Append(GenUtils.KvLine("Account index", this.GetAccountIndex(), indent));
+        string str = sb.ToString();
+        return str.Length == 0 ? str : str.Substring(0, str.Length - 1);	  // strip last newline
+    }
 }

--- a/Monero/Wallet/Common/MoneroTransferQuery.cs
+++ b/Monero/Wallet/Common/MoneroTransferQuery.cs
@@ -4,13 +4,13 @@ namespace Monero.Wallet.Common;
 
 public class MoneroTransferQuery : MoneroTransfer
 {
-    protected MoneroTxQuery? txQuery;
+    private MoneroTxQuery? txQuery;
     private bool? isIncoming;
     private string? address;
-    private List<string> addresses = [];
+    private List<string>? addresses;
     private uint? subaddressIndex;
-    private List<uint> subaddressIndices = [];
-    private List<MoneroDestination> destinations = [];
+    private List<uint>? subaddressIndices;
+    private List<MoneroDestination>? destinations;
     private bool? hasDestinations;
 
     public MoneroTransferQuery()
@@ -20,29 +20,35 @@ public class MoneroTransferQuery : MoneroTransfer
 
     public MoneroTransferQuery(MoneroTransferQuery query) : base(query)
     {
-        this.isIncoming = query.isIncoming;
-        this.address = query.address;
-        if (query.addresses != null) this.addresses = new List<string>(query.addresses);
-        this.subaddressIndex = query.subaddressIndex;
-        if (query.subaddressIndices != null) this.subaddressIndices = new List<uint>(query.subaddressIndices);
+        isIncoming = query.isIncoming;
+        address = query.address;
+        if (query.addresses != null) addresses = new List<string>(query.addresses);
+        subaddressIndex = query.subaddressIndex;
+        if (query.subaddressIndices != null) subaddressIndices = new List<uint>(query.subaddressIndices);
         if (query.destinations != null)
         {
-            this.destinations = new List<MoneroDestination>();
-            foreach (MoneroDestination destination in query.GetDestinations()) this.destinations.Add(destination.Clone());
+            destinations = new List<MoneroDestination>();
+            foreach (MoneroDestination destination in query.GetDestinations() ?? []) destinations.Add(destination.Clone());
         }
-        this.hasDestinations = query.hasDestinations;
-        this.txQuery = query.txQuery; // reference original by default, MoneroTxQuery's deep copy will Set this to itself
+        hasDestinations = query.hasDestinations;
+        txQuery = query.txQuery; // reference original by default, MoneroTxQuery's deep copy will Set this to itself
         Validate();
     }
 
     private void Validate()
     {
-        if (subaddressIndex != null && subaddressIndex < 0) throw new MoneroError("Subaddress index must be >= 0");
-        if (subaddressIndices != null) foreach (uint subaddressIdx in subaddressIndices) if (subaddressIdx < 0) throw new MoneroError("Subaddress indices must be >= 0");
+        //if (_subaddressIndex != null && _subaddressIndex < 0) throw new MoneroError("Subaddress index must be >= 0");
+        //if (_subaddressIndices != null) foreach (uint subaddressIdx in _subaddressIndices) if (subaddressIdx < 0) throw new MoneroError("Subaddress indices must be >= 0");
     }
     public override MoneroTransferQuery Clone()
     {
         return new MoneroTransferQuery(this);
+    }
+
+    public override MoneroTransferQuery SetAmount(ulong? amount)
+    {
+        base.SetAmount(amount);
+        return this;
     }
 
     public MoneroTxQuery? GetTxQuery()
@@ -50,10 +56,10 @@ public class MoneroTransferQuery : MoneroTransfer
         return txQuery;
     }
 
-    public MoneroTransferQuery SetTxQuery(MoneroTxQuery txQuery)
+    public MoneroTransferQuery SetTxQuery(MoneroTxQuery? query, bool setTransferQuery = true)
     {
-        this.txQuery = txQuery;
-        if (txQuery != null) txQuery.SetTransferQuery(this);
+        txQuery = query;
+        if (setTransferQuery && txQuery != null) txQuery.SetTransferQuery(this);
         return this;
     }
 
@@ -62,7 +68,7 @@ public class MoneroTransferQuery : MoneroTransfer
         return isIncoming;
     }
 
-    public MoneroTransferQuery SetIsIncoming(bool isIncoming)
+    public MoneroTransferQuery SetIsIncoming(bool? isIncoming)
     {
         this.isIncoming = isIncoming;
         return this;
@@ -73,7 +79,7 @@ public class MoneroTransferQuery : MoneroTransfer
         return isIncoming == null ? null : !isIncoming;
     }
 
-    public MoneroTransferQuery SetIsOutgoing(bool isOutgoing)
+    public MoneroTransferQuery SetIsOutgoing(bool? isOutgoing)
     {
         isIncoming = isOutgoing == null ? null : !isOutgoing;
         return this;
@@ -84,18 +90,18 @@ public class MoneroTransferQuery : MoneroTransfer
         return address;
     }
 
-    public MoneroTransferQuery SetAddress(string address)
+    public MoneroTransferQuery SetAddress(string? address)
     {
         this.address = address;
         return this;
     }
 
-    public List<string> GetAddresses()
+    public List<string>? GetAddresses()
     {
         return addresses;
     }
 
-    public MoneroTransferQuery SetAddresses(List<string> addresses)
+    public MoneroTransferQuery SetAddresses(List<string>? addresses)
     {
         this.addresses = addresses;
         return this;
@@ -119,24 +125,24 @@ public class MoneroTransferQuery : MoneroTransfer
         return this;
     }
 
-    public List<uint> GetSubaddressIndices()
+    public List<uint>? GetSubaddressIndices()
     {
         return subaddressIndices;
     }
 
-    public MoneroTransferQuery SetSubaddressIndices(List<uint> subaddressIndices)
+    public MoneroTransferQuery SetSubaddressIndices(List<uint>? subaddressIndices)
     {
         this.subaddressIndices = subaddressIndices;
         Validate();
         return this;
     }
 
-    public List<MoneroDestination> GetDestinations()
+    public List<MoneroDestination>? GetDestinations()
     {
         return destinations;
     }
 
-    public MoneroTransferQuery SetDestinations(List<MoneroDestination> destinations)
+    public MoneroTransferQuery SetDestinations(List<MoneroDestination>? destinations)
     {
         this.destinations = destinations;
         return this;
@@ -147,14 +153,72 @@ public class MoneroTransferQuery : MoneroTransfer
         return hasDestinations;
     }
 
-    public MoneroTransferQuery SetHasDestinations(bool hasDestinations)
+    public MoneroTransferQuery SetHasDestinations(bool? hasDestinations)
     {
         this.hasDestinations = hasDestinations;
         return this;
     }
 
-    public bool MeetsCriteria(MoneroTransfer transfer)
+    public virtual bool MeetsCriteria(MoneroTransfer? transfer, bool queryParent = true)
     {
-        throw new NotImplementedException();
+        if (transfer == null) throw new MoneroError("transfer is null");
+
+        // filter on common fields
+        if (IsIncoming() != null && IsIncoming() != transfer.IsIncoming()) return false;
+        if (IsOutgoing() != null && IsOutgoing() != transfer.IsOutgoing()) return false;
+        if (GetAmount() != null && ((ulong)GetAmount()!).CompareTo(transfer.GetAmount()) != 0) return false;
+        if (GetAccountIndex() != null && !GetAccountIndex().Equals(transfer.GetAccountIndex())) return false;
+
+        // filter on incoming fields
+        if (transfer is MoneroIncomingTransfer)
+        {
+            if (HasDestinations() == true) return false;
+            MoneroIncomingTransfer inTransfer = (MoneroIncomingTransfer)transfer;
+            if (GetAddress() != null && !GetAddress()!.Equals(inTransfer.GetAddress())) return false;
+            if (GetAddresses() != null && !GetAddresses()!.Contains(inTransfer.GetAddress()!)) return false;
+            if (GetSubaddressIndex() != null && !GetSubaddressIndex().Equals(inTransfer.GetSubaddressIndex())) return false;
+            if (GetSubaddressIndices() != null && !GetSubaddressIndices()!.Contains((uint)inTransfer.GetSubaddressIndex()!)) return false;
+        }
+
+        // filter on outgoing fields
+        else if (transfer is MoneroOutgoingTransfer)
+        {
+            MoneroOutgoingTransfer outTransfer = (MoneroOutgoingTransfer)transfer;
+
+            // filter on addresses
+            if (GetAddress() != null && (outTransfer.GetAddresses() == null || !outTransfer.GetAddresses()!.Contains(GetAddress()!))) return false;   // TODO: will filter all transfers if they don't contain addresses
+            if (GetAddresses() != null)
+            {
+                HashSet<string> intersections = new HashSet<string>(GetAddresses()!);
+                intersections.IntersectWith(outTransfer.GetAddresses()!);
+                if (intersections.Count == 0) return false;  // must have overlapping addresses
+            }
+
+            // filter on subaddress indices
+            if (GetSubaddressIndex() != null && (outTransfer.GetSubaddressIndices() == null || !outTransfer.GetSubaddressIndices()!.Contains((uint)GetSubaddressIndex()!))) return false;
+            if (GetSubaddressIndices() != null)
+            {
+                HashSet<uint> intersections = new HashSet<uint>(GetSubaddressIndices()!);
+                intersections.IntersectWith(outTransfer.GetSubaddressIndices()!);
+                if (intersections.Count == 0) return false;  // must have overlapping subaddress indices
+            }
+
+            // filter on having destinations
+            if (HasDestinations() != null)
+            {
+                if (HasDestinations() == true && outTransfer.GetDestinations() == null) return false;
+                if (!HasDestinations() == true && outTransfer.GetDestinations() != null) return false;
+            }
+
+            // filter on destinations TODO: start with test for this
+            //    if (GetDestinations() != null && GetDestinations() != transfer.GetDestinations()) return false;
+        }
+
+        // otherwise invalid type
+        else throw new Exception("Transfer must be MoneroIncomingTransfer or MoneroOutgoingTransfer");
+
+        // filter with tx filter
+        if (queryParent && GetTxQuery() != null && !GetTxQuery()!.MeetsCriteria(transfer.GetTx()!, false)) return false;
+        return true;
     }
 }

--- a/Monero/Wallet/Common/MoneroTxQuery.cs
+++ b/Monero/Wallet/Common/MoneroTxQuery.cs
@@ -7,16 +7,16 @@ public class MoneroTxQuery : MoneroTxWallet
 {
     private bool? isOutgoing;
     private bool? isIncoming;
-    private List<string> hashes = [];
+    private List<string>? hashes;
     private bool? hasPaymentId;
-    private List<string> paymentIds = [];
+    private List<string>? paymentIds;
     private ulong? height;
     private ulong? minHeight;
     private ulong? maxHeight;
     private bool? includeOutputs;
-    protected MoneroTransferQuery? transferQuery;
-    protected MoneroOutputQuery? inputQuery;
-    protected MoneroOutputQuery? outputQuery;
+    private MoneroTransferQuery? transferQuery;
+    private MoneroOutputQuery? inputQuery;
+    private MoneroOutputQuery? outputQuery;
 
     public MoneroTxQuery()
     {
@@ -25,23 +25,41 @@ public class MoneroTxQuery : MoneroTxWallet
 
     public MoneroTxQuery(MoneroTxQuery query) : base(query)
     {
-        this.isOutgoing = query.isOutgoing;
-        this.isIncoming = query.isIncoming;
-        if (query.hashes != null) this.hashes = new List<string>(query.hashes);
-        this.hasPaymentId = query.hasPaymentId;
-        if (query.paymentIds != null) this.paymentIds = new List<string>(query.paymentIds);
-        this.height = query.height;
-        this.minHeight = query.minHeight;
-        this.maxHeight = query.maxHeight;
-        this.includeOutputs = query.includeOutputs;
-        if (query.transferQuery != null) this.SetTransferQuery(new MoneroTransferQuery(query.transferQuery));
-        if (query.inputQuery != null) this.SetInputQuery(new MoneroOutputQuery(query.inputQuery));
-        if (query.outputQuery != null) this.SetOutputQuery(new MoneroOutputQuery(query.outputQuery));
+        isOutgoing = query.isOutgoing;
+        isIncoming = query.isIncoming;
+        if (query.hashes != null) hashes = new List<string>(query.hashes);
+        hasPaymentId = query.hasPaymentId;
+        if (query.paymentIds != null) paymentIds = new List<string>(query.paymentIds);
+        height = query.height;
+        minHeight = query.minHeight;
+        maxHeight = query.maxHeight;
+        includeOutputs = query.includeOutputs;
+        if (query.transferQuery != null) SetTransferQuery(new MoneroTransferQuery(query.transferQuery));
+        if (query.inputQuery != null) SetInputQuery(new MoneroOutputQuery(query.inputQuery));
+        if (query.outputQuery != null) SetOutputQuery(new MoneroOutputQuery(query.outputQuery));
     }
 
     public override MoneroTxQuery Clone()
     {
         return new MoneroTxQuery(this);
+    }
+
+    public override MoneroTxQuery SetIsConfirmed(bool? isConfirmed)
+    {
+        base.SetIsConfirmed(isConfirmed);
+        return this;
+    }
+
+    public override MoneroTxQuery SetInTxPool(bool? inTxPool)
+    {
+        base.SetInTxPool(inTxPool);
+        return this;
+    }
+
+    public override MoneroTxQuery SetIsFailed(bool? isFailed)
+    {
+        base.SetIsFailed(isFailed);
+        return this;
     }
 
     public override MoneroTxQuery SetIsLocked(bool? isLocked)
@@ -72,18 +90,20 @@ public class MoneroTxQuery : MoneroTxWallet
         return this;
     }
 
-    public override MoneroTxQuery SetHash(string hash)
+    public override MoneroTxQuery SetHash(string? hash)
     {
         base.SetHash(hash);
-        return SetHashes([hash]);
+        if (hash != null) SetHashes([hash]);
+        else SetHashes(null);
+        return this;
     }
 
-    public List<string> GetHashes()
+    public List<string>? GetHashes()
     {
         return hashes;
     }
 
-    public MoneroTxQuery SetHashes(List<string> hashes)
+    public MoneroTxQuery SetHashes(List<string>? hashes)
     {
         this.hashes = hashes;
         return this;
@@ -100,31 +120,33 @@ public class MoneroTxQuery : MoneroTxWallet
         return this;
     }
 
-    public List<string> GetPaymentIds()
+    public List<string>? GetPaymentIds()
     {
         return paymentIds;
     }
 
-    public MoneroTxQuery SetPaymentIds(List<string> paymentIds)
+    public MoneroTxQuery SetPaymentIds(List<string>? paymentIds)
     {
         this.paymentIds = paymentIds;
         return this;
     }
 
-    public MoneroTxQuery SetPaymentId(string paymentId)
+    public override MoneroTxQuery SetPaymentId(string? paymentId)
     {
-        return SetPaymentIds([paymentId]);
+        if (paymentId != null) SetPaymentIds([paymentId]);
+        else SetPaymentIds(null);
+        return this;
     }
 
-    public ulong? GetHeight()
-    {
-        return height;
-    }
-
-    public MoneroTxQuery SetHeight(ulong height)
+    public MoneroTxQuery SetHeight(ulong? height)
     {
         this.height = height;
         return this;
+    }
+
+    public override ulong? GetHeight()
+    {
+        return height;
     }
 
     public ulong? GetMinHeight()
@@ -132,7 +154,7 @@ public class MoneroTxQuery : MoneroTxWallet
         return minHeight;
     }
 
-    public MoneroTxQuery SetMinHeight(ulong minHeight)
+    public MoneroTxQuery SetMinHeight(ulong? minHeight)
     {
         this.minHeight = minHeight;
         return this;
@@ -143,7 +165,7 @@ public class MoneroTxQuery : MoneroTxWallet
         return maxHeight;
     }
 
-    public MoneroTxQuery SetMaxHeight(ulong maxHeight)
+    public MoneroTxQuery SetMaxHeight(ulong? maxHeight)
     {
         this.maxHeight = maxHeight;
         return this;
@@ -171,10 +193,10 @@ public class MoneroTxQuery : MoneroTxWallet
         return transferQuery;
     }
 
-    public MoneroTxQuery SetTransferQuery(MoneroTransferQuery transferQuery)
+    public MoneroTxQuery SetTransferQuery(MoneroTransferQuery? transferQuery)
     {
         this.transferQuery = transferQuery;
-        if (transferQuery != null) transferQuery.SetTxQuery(this);
+        if (transferQuery != null) transferQuery.SetTxQuery(this, false);
         return this;
     }
 
@@ -183,7 +205,7 @@ public class MoneroTxQuery : MoneroTxWallet
         return inputQuery;
     }
 
-    public MoneroTxQuery SetInputQuery(MoneroOutputQuery inputQuery)
+    public MoneroTxQuery SetInputQuery(MoneroOutputQuery? inputQuery)
     {
         this.inputQuery = inputQuery;
         if (inputQuery != null) inputQuery.SetTxQuery(this);
@@ -195,20 +217,104 @@ public class MoneroTxQuery : MoneroTxWallet
         return outputQuery;
     }
 
-    public MoneroTxQuery SetOutputQuery(MoneroOutputQuery outputQuery)
+    public MoneroTxQuery SetOutputQuery(MoneroOutputQuery? outputQuery)
     {
         this.outputQuery = outputQuery;
-        if (outputQuery != null) outputQuery.SetTxQuery(this);
+        if (outputQuery != null) outputQuery.SetTxQuery(this, false);
         return this;
     }
 
-    public bool MeetsCriteria(MoneroTx tx)
+    public bool MeetsCriteria(MoneroTxWallet tx, bool queryChildren = true)
     {
-        throw new NotImplementedException("MoneroTxQuery.MeetsCriteria(MoneroTx tx) is not implemented yet. Please implement this method to filter transactions based on the query criteria.");
+        if (tx == null) throw new MoneroError("No tx given to MoneroTxQuery.MeetsCriteria()");
+
+        // filter on tx
+        if (GetHash() != null && !GetHash()!.Equals(tx.GetHash())) return false;
+        if (GetPaymentId() != null && !GetPaymentId()!.Equals(tx.GetPaymentId())) return false;
+        if (IsConfirmed() != null && IsConfirmed() != tx.IsConfirmed()) return false;
+        if (InTxPool() != null && InTxPool() != tx.InTxPool()) return false;
+        if (GetRelay() != null && GetRelay() != tx.GetRelay()) return false;
+        if (IsRelayed() != null && IsRelayed() != tx.IsRelayed()) return false;
+        if (IsFailed() != null && IsFailed() != tx.IsFailed()) return false;
+        if (IsMinerTx() != null && IsMinerTx() != tx.IsMinerTx()) return false;
+        if (IsLocked() != null && IsLocked() != tx.IsLocked()) return false;
+
+        // filter on having a payment id
+        if (HasPaymentId() != null)
+        {
+            if (HasPaymentId() == true && tx.GetPaymentId() == null) return false;
+            if (HasPaymentId() != true && tx.GetPaymentId() != null) return false;
+        }
+
+        // filter on incoming
+        if (IsIncoming() != null && IsIncoming() != (tx.IsIncoming() == true)) return false;
+
+        // filter on outgoing
+        if (IsOutgoing() != null && IsOutgoing() != (tx.IsOutgoing() == true)) return false;
+
+        // filter on remaining fields
+        ulong? txHeight = tx.GetBlock() == null ? null : tx.GetBlock()!.GetHeight();
+        if (GetHashes() != null && !GetHashes()!.Contains(tx.GetHash()!)) return false;
+        if (GetPaymentIds() != null && !GetPaymentIds()!.Contains(tx.GetPaymentId()!)) return false;
+        if (GetHeight() != null && !GetHeight().Equals(txHeight)) return false;
+        if (GetMinHeight() != null && txHeight != null && txHeight < GetMinHeight()) return false; // do not filter unconfirmed
+        if (GetMaxHeight() != null && (txHeight == null || txHeight > GetMaxHeight())) return false;
+
+        // done if not querying transfers or outputs
+        if (!queryChildren) return true;
+
+        // at least one transfer must meet transfer query if defined
+        if (GetTransferQuery() != null)
+        {
+            bool matchFound = false;
+            if (tx.GetOutgoingTransfer() != null && GetTransferQuery()!.MeetsCriteria(tx.GetOutgoingTransfer(), false)) matchFound = true;
+            else if (tx.GetIncomingTransfers() != null)
+            {
+                foreach (MoneroIncomingTransfer incomingTransfer in tx.GetIncomingTransfers()!)
+                {
+                    if (GetTransferQuery()!.MeetsCriteria(incomingTransfer, false))
+                    {
+                        matchFound = true;
+                        break;
+                    }
+                }
+            }
+            if (!matchFound) return false;
+        }
+
+        // at least one input must meet input query if defined
+        if (GetInputQuery() != null)
+        {
+            if (tx.GetInputs() == null || tx.GetInputs()!.Count == 0) return false;
+            bool matchFound = false;
+            foreach (MoneroOutputWallet input in tx.GetInputsWallet())
+            {
+                if (GetInputQuery()!.MeetsCriteria(input, false))
+                {
+                    matchFound = true;
+                    break;
+                }
+            }
+            if (!matchFound) return false;
+        }
+
+        // at least one output must meet output query if defined
+        if (GetOutputQuery() != null)
+        {
+            if (tx.GetOutputs() == null || tx.GetOutputs()!.Count == 0) return false;
+            bool matchFound = false;
+            foreach (MoneroOutputWallet output in tx.GetOutputsWallet())
+            {
+                if (GetOutputQuery()!.MeetsCriteria(output, false))
+                {
+                    matchFound = true;
+                    break;
+                }
+            }
+            if (!matchFound) return false;
+        }
+
+        return true;  // transaction meets query criteria
     }
 
-    public bool MeetsCriteria(MoneroTxWallet tx)
-    {
-        throw new NotImplementedException("MoneroTxQuery.MeetsCriteria(MoneroTxWallet tx) is not implemented yet. Please implement this method to filter transactions based on the query criteria.");
-    }
 }

--- a/Monero/Wallet/Common/MoneroTxSet.cs
+++ b/Monero/Wallet/Common/MoneroTxSet.cs
@@ -1,53 +1,79 @@
-﻿namespace Monero.Wallet.Common;
+﻿using Monero.Common;
+
+namespace Monero.Wallet.Common;
+
 
 public class MoneroTxSet
 {
-    private List<MoneroTxWallet> _txs = [];
-    private string? _multisigTxHex;
-    private string? _unsignedTxHex;
-    private string? _signedTxHex;
+    private List<MoneroTxWallet>? txs;
+    private string? multisigTxHex;
+    private string? unsignedTxHex;
+    private string? signedTxHex;
 
-    public List<MoneroTxWallet> GetTxs()
+    public List<MoneroTxWallet>? GetTxs()
     {
-        return _txs;
+        return txs;
     }
 
-    public MoneroTxSet SetTxs(List<MoneroTxWallet> txs)
+    public MoneroTxSet SetTxs(List<MoneroTxWallet>? txs)
     {
-        _txs = txs ?? [];
+        this.txs = txs;
         return this;
     }
 
     public string? GetMultisigTxHex()
     {
-        return _multisigTxHex;
+        return multisigTxHex;
     }
 
     public MoneroTxSet SetMultisigTxHex(string? multisigTxHex)
     {
-        _multisigTxHex = multisigTxHex;
+        this.multisigTxHex = multisigTxHex;
         return this;
     }
 
     public string? GetUnsignedTxHex()
     {
-        return _unsignedTxHex;
+        return unsignedTxHex;
     }
 
     public MoneroTxSet SetUnsignedTxHex(string? unsignedTxHex)
     {
-        _unsignedTxHex = unsignedTxHex;
+        this.unsignedTxHex = unsignedTxHex;
         return this;
     }
 
     public string? GetSignedTxHex()
     {
-        return _signedTxHex;
+        return signedTxHex;
     }
 
     public MoneroTxSet SetSignedTxHex(string? signedTxHex)
     {
-        _signedTxHex = signedTxHex;
+        this.signedTxHex = signedTxHex;
+        return this;
+    }
+
+    public MoneroTxSet Merge(MoneroTxSet? txSet)
+    {
+        if (txSet == null) throw new MoneroError("Tx set is null");
+        if (this == txSet) return this;
+
+        // merge sets
+        SetMultisigTxHex(GenUtils.Reconcile(GetMultisigTxHex(), txSet.GetMultisigTxHex()));
+        SetUnsignedTxHex(GenUtils.Reconcile(GetUnsignedTxHex(), txSet.GetUnsignedTxHex()));
+        SetSignedTxHex(GenUtils.Reconcile(GetSignedTxHex(), txSet.GetSignedTxHex()));
+
+        // merge txs
+        if (txSet.GetTxs() != null)
+        {
+            foreach (MoneroTxWallet tx in txSet.GetTxs()!)
+            {
+                tx.SetTxSet(this);
+                MoneroUtils.MergeTx(txs!, tx);
+            }
+        }
+
         return this;
     }
 }

--- a/Monero/Wallet/Common/MoneroTxWallet.cs
+++ b/Monero/Wallet/Common/MoneroTxWallet.cs
@@ -4,19 +4,34 @@ namespace Monero.Wallet.Common;
 
 public class MoneroTxWallet : MoneroTx
 {
-    private MoneroTxSet txSet;
+    private MoneroTxSet? txSet;
     private bool? isIncoming;
     private bool? isOutgoing;
-    private List<MoneroIncomingTransfer> incomingTransfers;
-    private MoneroOutgoingTransfer outgoingTransfer;
-    private string note;
+    private List<MoneroIncomingTransfer>? incomingTransfers;
+    private MoneroOutgoingTransfer? outgoingTransfer;
+    private string? note;
     private bool? isLocked;
-    private ulong inputSum;
-    private ulong outputSum;
-    private string changeAddress;
-    private ulong changeAmount;
-    private uint numDummyOutputs;
-    private string extraHex;  // TODO: refactor MoneroTx to only use extra as hex string
+    private ulong? inputSum;
+    private ulong? outputSum;
+    private string? changeAddress;
+    private ulong? changeAmount;
+    private uint? numDummyOutputs;
+    private string? extraHex;  // TODO: refactor MoneroTx to only use extra as hex string
+
+    public bool Equals(MoneroTxWallet other, bool checkInputs = true, bool checkOutputs = true)
+    {
+        if (!base.Equals(other, checkInputs, checkOutputs)) return false;
+
+        return IsIncoming() == other.IsIncoming() &&
+                IsOutgoing() == other.IsOutgoing() &&
+                GetNote() == other.GetNote() &&
+                IsLocked() == other.IsLocked() &&
+                GetInputSum() == other.GetInputSum() &&
+                GetChangeAddress() == other.GetChangeAddress() &&
+                GetChangeAmount() == other.GetChangeAmount() &&
+                GetNumDummyOutputs() == other.GetNumDummyOutputs() &&
+                GetExtraHex() == other.GetExtraHex();
+    }
 
     public MoneroTxWallet()
     {
@@ -25,26 +40,26 @@ public class MoneroTxWallet : MoneroTx
 
     public MoneroTxWallet(MoneroTxWallet tx) : base(tx)
     {
-        this.txSet = tx.txSet;
-        this.isIncoming = tx.isIncoming;
-        this.isOutgoing = tx.isOutgoing;
+        txSet = tx.txSet;
+        isIncoming = tx.isIncoming;
+        isOutgoing = tx.isOutgoing;
         if (tx.incomingTransfers != null)
         {
-            this.incomingTransfers = new List<MoneroIncomingTransfer>();
+            incomingTransfers = new List<MoneroIncomingTransfer>();
             foreach (MoneroIncomingTransfer transfer in tx.incomingTransfers)
             {
-                this.incomingTransfers.Add(transfer.Clone().SetTx(this));
+                incomingTransfers.Add(transfer.Clone().SetTx(this));
             }
         }
-        if (tx.outgoingTransfer != null) this.outgoingTransfer = tx.outgoingTransfer.Clone().SetTx(this);
-        this.note = tx.note;
-        this.isLocked = tx.isLocked;
-        this.inputSum = tx.inputSum;
-        this.outputSum = tx.outputSum;
-        this.changeAddress = tx.changeAddress;
-        this.changeAmount = tx.changeAmount;
-        this.numDummyOutputs = tx.numDummyOutputs;
-        this.extraHex = tx.extraHex;
+        if (tx.outgoingTransfer != null) outgoingTransfer = tx.outgoingTransfer.Clone().SetTx(this);
+        note = tx.note;
+        isLocked = tx.isLocked;
+        inputSum = tx.inputSum;
+        outputSum = tx.outputSum;
+        changeAddress = tx.changeAddress;
+        changeAmount = tx.changeAmount;
+        numDummyOutputs = tx.numDummyOutputs;
+        extraHex = tx.extraHex;
     }
 
     public override MoneroTxWallet Clone()
@@ -52,7 +67,92 @@ public class MoneroTxWallet : MoneroTx
         return new MoneroTxWallet(this);
     }
 
-    public MoneroTxSet GetTxSet()
+    public override MoneroTxWallet Merge(MoneroTx tx)
+    {
+        if (tx != null && tx is not MoneroTxWallet) throw new MoneroError("Wallet transaction must be merged with type MoneroTxWallet");
+        return Merge((MoneroTxWallet)tx!);
+    }
+
+    public MoneroTxWallet Merge(MoneroTxWallet tx)
+    {
+        if (!(tx is MoneroTxWallet)) throw new MoneroError("Wallet transaction must be merged with type MoneroTxWallet");
+        if (this == tx) return this;
+
+        // merge base classes
+        base.Merge(tx);
+
+        // merge tx set if they're different which comes back to merging txs
+        if (txSet != tx.GetTxSet())
+        {
+            if (txSet == null)
+            {
+                txSet = new MoneroTxSet();
+                txSet.SetTxs([this]);
+            }
+            if (tx.GetTxSet() == null)
+            {
+                tx.SetTxSet(new MoneroTxSet());
+                tx.GetTxSet()!.SetTxs([tx]);
+            }
+            txSet.Merge(tx.GetTxSet());
+            return this;
+        }
+
+        // merge incoming transfers
+        if (tx.GetIncomingTransfers() != null)
+        {
+            if (GetIncomingTransfers() == null) SetIncomingTransfers(new List<MoneroIncomingTransfer>());
+            foreach (MoneroIncomingTransfer transfer in tx.GetIncomingTransfers()!)
+            {
+                transfer.SetTx(this);
+                MergeIncomingTransfer(GetIncomingTransfers()!, transfer);
+            }
+        }
+
+        // merge outgoing transfer
+        if (tx.GetOutgoingTransfer() != null)
+        {
+            tx.GetOutgoingTransfer()!.SetTx(this);
+            if (GetOutgoingTransfer() == null) SetOutgoingTransfer(tx.GetOutgoingTransfer());
+            else GetOutgoingTransfer()!.Merge(tx.GetOutgoingTransfer()!);
+        }
+
+        // merge simple extensions
+        SetIsIncoming(GenUtils.Reconcile(IsIncoming(), tx.IsIncoming(), null, true, null)); // outputs seen on confirmation
+        SetIsOutgoing(GenUtils.Reconcile(IsOutgoing(), tx.IsOutgoing()));
+        SetNote(GenUtils.Reconcile(GetNote(), tx.GetNote()));
+        SetIsLocked(GenUtils.Reconcile(IsLocked(), tx.IsLocked(), null, false, null));  // tx can become unlocked
+        SetInputSum(GenUtils.Reconcile(GetInputSum(), tx.GetInputSum()));
+        SetOutputSum(GenUtils.Reconcile(GetOutputSum(), tx.GetOutputSum()));
+        SetChangeAddress(GenUtils.Reconcile(GetChangeAddress(), tx.GetChangeAddress()));
+        SetChangeAmount(GenUtils.Reconcile(GetChangeAmount(), tx.GetChangeAmount()));
+        SetNumDummyOutputs(GenUtils.Reconcile(GetNumDummyOutputs(), tx.GetNumDummyOutputs()));
+        SetExtraHex(GenUtils.Reconcile(GetExtraHex(), tx.GetExtraHex()));
+
+        return this;  // for chaining
+    }
+
+    // private helper to merge transfers
+    private static void MergeIncomingTransfer(List<MoneroIncomingTransfer> transfers, MoneroIncomingTransfer transfer)
+    {
+        foreach (MoneroIncomingTransfer aTransfer in transfers)
+        {
+            if (aTransfer.GetAccountIndex() == transfer.GetAccountIndex() && aTransfer.GetSubaddressIndex() == transfer.GetSubaddressIndex())
+            {
+                aTransfer.Merge(transfer);
+                return;
+            }
+        }
+        transfers.Add(transfer);
+    }
+
+    public override MoneroTxWallet SetInTxPool(bool? inTxPool)
+    {
+        base.SetInTxPool(inTxPool);
+        return this;
+    }
+
+    public MoneroTxSet? GetTxSet()
     {
         return txSet;
     }
@@ -89,27 +189,22 @@ public class MoneroTxWallet : MoneroTx
     {
         if (GetIncomingTransfers() == null) return null;
         ulong incomingAmt = 0;
-        foreach (MoneroTransfer transfer in this.GetIncomingTransfers()) incomingAmt += (ulong)transfer.GetAmount();
+        foreach (MoneroIncomingTransfer transfer in GetIncomingTransfers()!) incomingAmt += (ulong)transfer.GetAmount()!;
         return incomingAmt;
     }
 
     public ulong? GetOutgoingAmount()
     {
-        return GetOutgoingTransfer() != null ? GetOutgoingTransfer().GetAmount() : null;
+        return GetOutgoingTransfer() != null ? GetOutgoingTransfer()!.GetAmount() : null;
     }
 
-    public List<MoneroTransfer> GetTransfers()
-    {
-        return GetTransfers(null);
-    }
-
-    public List<MoneroTransfer> GetTransfers(MoneroTransferQuery query)
+    public List<MoneroTransfer> GetTransfers(MoneroTransferQuery? query = null)
     {
         List<MoneroTransfer> transfers = new List<MoneroTransfer>();
-        if (GetOutgoingTransfer() != null && (query == null || query.MeetsCriteria(GetOutgoingTransfer()))) transfers.Add(GetOutgoingTransfer());
+        if (GetOutgoingTransfer() != null && (query == null || query.MeetsCriteria(GetOutgoingTransfer()))) transfers.Add(GetOutgoingTransfer()!);
         if (GetIncomingTransfers() != null)
         {
-            foreach (MoneroTransfer transfer in GetIncomingTransfers())
+            foreach (MoneroIncomingTransfer transfer in GetIncomingTransfers()!)
             {
                 if (query == null || query.MeetsCriteria(transfer)) transfers.Add(transfer);
             }
@@ -117,55 +212,55 @@ public class MoneroTxWallet : MoneroTx
         return transfers;
     }
 
-    public List<MoneroTransfer> filterTransfers(MoneroTransferQuery query)
+    public List<MoneroTransfer> FilterTransfers(MoneroTransferQuery? query)
     {
         List<MoneroTransfer> transfers = new List<MoneroTransfer>();
 
         // collect outgoing transfer or erase if filtered
-        if (GetOutgoingTransfer() != null && (query == null || query.MeetsCriteria(GetOutgoingTransfer()))) transfers.Add(GetOutgoingTransfer());
+        if (GetOutgoingTransfer() != null && (query == null || query.MeetsCriteria(GetOutgoingTransfer()))) transfers.Add(GetOutgoingTransfer()!);
         else SetOutgoingTransfer(null);
 
         // collect incoming transfers or erase if filtered
         if (GetIncomingTransfers() != null)
         {
-            List<MoneroTransfer> toRemoves = new List<MoneroTransfer>();
-            foreach (MoneroTransfer transfer in GetIncomingTransfers())
+            var toRemoves = new HashSet<MoneroTransfer>();
+            foreach (MoneroIncomingTransfer transfer in GetIncomingTransfers()!)
             {
                 if (query == null || query.MeetsCriteria(transfer)) transfers.Add(transfer);
                 else toRemoves.Add(transfer);
             }
 
-            // TODO GetIncomingTransfers().RemoveAll(toRemoves);
-            if (GetIncomingTransfers().Count == 0) SetIncomingTransfers(null);
+            GetIncomingTransfers()!.RemoveAll(x => toRemoves.Contains(x));
+            if (GetIncomingTransfers()!.Count == 0) SetIncomingTransfers(null);
         }
 
         return transfers;
     }
 
-    public List<MoneroIncomingTransfer> GetIncomingTransfers()
+    public List<MoneroIncomingTransfer>? GetIncomingTransfers()
     {
         return incomingTransfers;
     }
 
-    public virtual MoneroTxWallet SetIncomingTransfers(List<MoneroIncomingTransfer> incomingTransfers)
+    public virtual MoneroTxWallet SetIncomingTransfers(List<MoneroIncomingTransfer>? incomingTransfers)
     {
         this.incomingTransfers = incomingTransfers;
         return this;
     }
 
-    public MoneroOutgoingTransfer GetOutgoingTransfer()
+    public MoneroOutgoingTransfer? GetOutgoingTransfer()
     {
         return outgoingTransfer;
     }
 
-    public virtual MoneroTxWallet SetOutgoingTransfer(MoneroOutgoingTransfer outgoingTransfer)
+    public virtual MoneroTxWallet SetOutgoingTransfer(MoneroOutgoingTransfer? outgoingTransfer)
     {
         this.outgoingTransfer = outgoingTransfer;
         return this;
     }
 
 
-    public override MoneroTxWallet SetInputs(List<MoneroOutput> inputs)
+    public override MoneroTxWallet SetInputs(List<MoneroOutput>? inputs)
     {
 
         // Validate that all inputs are wallet inputs
@@ -184,18 +279,13 @@ public class MoneroTxWallet : MoneroTx
 
     public virtual MoneroTxWallet SetInputsWallet(List<MoneroOutputWallet> inputs)
     {
-        return SetInputs(new List<MoneroOutput>(inputs));
+        return SetInputs([.. inputs]);
     }
 
-    public List<MoneroOutputWallet> GetInputsWallet()
-    {
-        return GetInputsWallet(null);
-    }
-
-    public List<MoneroOutputWallet> GetInputsWallet(MoneroOutputQuery query)
+    public List<MoneroOutputWallet> GetInputsWallet(MoneroOutputQuery? query = null)
     {
         List<MoneroOutputWallet> inputsWallet = new List<MoneroOutputWallet>();
-        List<MoneroOutput> inputs = GetInputs();
+        List<MoneroOutput>? inputs = GetInputs();
         if (inputs == null) return inputsWallet;
         foreach (MoneroOutput output in inputs)
         {
@@ -204,7 +294,7 @@ public class MoneroTxWallet : MoneroTx
         return inputsWallet;
     }
 
-    public override MoneroTxWallet SetOutputs(List<MoneroOutput> outputs)
+    public override MoneroTxWallet SetOutputs(List<MoneroOutput>? outputs)
     {
 
         // Validate that all outputs are wallet outputs
@@ -226,15 +316,10 @@ public class MoneroTxWallet : MoneroTx
         return SetOutputs([.. outputs]);
     }
 
-    public List<MoneroOutputWallet> GetOutputsWallet()
-    {
-        return GetOutputsWallet(null);
-    }
-
-    public List<MoneroOutputWallet> GetOutputsWallet(MoneroOutputQuery query)
+    public List<MoneroOutputWallet> GetOutputsWallet(MoneroOutputQuery? query = null)
     {
         List<MoneroOutputWallet> outputsWallet = new List<MoneroOutputWallet>();
-        List<MoneroOutput> outputs = GetOutputs();
+        List<MoneroOutput>? outputs = GetOutputs();
         if (outputs == null) return outputsWallet;
         foreach (MoneroOutput output in outputs)
         {
@@ -243,29 +328,31 @@ public class MoneroTxWallet : MoneroTx
         return outputsWallet;
     }
 
-    public List<MoneroOutputWallet> filterOutputsWallet(MoneroOutputQuery query)
+    public List<MoneroOutputWallet> FilterOutputsWallet(MoneroOutputQuery query)
     {
         List<MoneroOutputWallet> outputs = new List<MoneroOutputWallet>();
         if (GetOutputs() != null)
         {
-            List<MoneroOutput> toRemoves = new List<MoneroOutput>();
-            foreach (MoneroOutput output in GetOutputs())
+            var toRemoves = new HashSet<MoneroOutput>();
+            foreach (MoneroOutput output in GetOutputs()!)
             {
                 if (query == null || query.MeetsCriteria((MoneroOutputWallet)output)) outputs.Add((MoneroOutputWallet)output);
                 else toRemoves.Add(output);
             }
-            // TODO GetOutputs().RemoveAll(toRemoves);
-            if (GetOutputs().Count == 0) SetOutputs(null);
+
+            GetOutputs()!.RemoveAll(x => toRemoves.Contains(x));
+
+            if (GetOutputs()!.Count == 0) SetOutputs(null);
         }
         return outputs;
     }
 
-    public string GetNote()
+    public string? GetNote()
     {
         return note;
     }
 
-    public virtual MoneroTxWallet SetNote(string note)
+    public virtual MoneroTxWallet SetNote(string? note)
     {
         this.note = note;
         return this;
@@ -282,67 +369,67 @@ public class MoneroTxWallet : MoneroTx
         return this;
     }
 
-    public ulong GetInputSum()
+    public ulong? GetInputSum()
     {
         return inputSum;
     }
 
-    public virtual MoneroTxWallet SetInputSum(ulong inputSum)
+    public virtual MoneroTxWallet SetInputSum(ulong? inputSum)
     {
         this.inputSum = inputSum;
         return this;
     }
 
-    public ulong GetOutputSum()
+    public ulong? GetOutputSum()
     {
         return outputSum;
     }
 
-    public virtual MoneroTxWallet SetOutputSum(ulong outputSum)
+    public virtual MoneroTxWallet SetOutputSum(ulong? outputSum)
     {
         this.outputSum = outputSum;
         return this;
     }
 
-    public string GetChangeAddress()
+    public string? GetChangeAddress()
     {
         return changeAddress;
     }
 
-    public virtual MoneroTxWallet SetChangeAddress(string changeAddress)
+    public virtual MoneroTxWallet SetChangeAddress(string? changeAddress)
     {
         this.changeAddress = changeAddress;
         return this;
     }
 
-    public ulong GetChangeAmount()
+    public ulong? GetChangeAmount()
     {
         return changeAmount;
     }
 
-    public virtual MoneroTxWallet SetChangeAmount(ulong changeAmount)
+    public virtual MoneroTxWallet SetChangeAmount(ulong? changeAmount)
     {
         this.changeAmount = changeAmount;
         return this;
     }
 
-    public uint GetNumDummyOutputs()
+    public uint? GetNumDummyOutputs()
     {
         return numDummyOutputs;
     }
 
-    public virtual MoneroTxWallet SetNumDummyOutputs(uint numDummyOutputs)
+    public virtual MoneroTxWallet SetNumDummyOutputs(uint? numDummyOutputs)
     {
         this.numDummyOutputs = numDummyOutputs;
         return this;
     }
 
-    public string GetExtraHex()
+    public string? GetExtraHex()
     {
         return extraHex;
     }
 
-    public virtual MoneroTxWallet SetExtraHex(string extraHex)
+    public virtual MoneroTxWallet SetExtraHex(string? extraHex)
     {
         this.extraHex = extraHex;
         return this;

--- a/Monero/Wallet/MoneroWallet.cs
+++ b/Monero/Wallet/MoneroWallet.cs
@@ -3,6 +3,7 @@ using Monero.Wallet.Common;
 
 namespace Monero.Wallet;
 
+
 public interface MoneroWallet
 {
     public static readonly string DEFAULT_LANGUAGE = "English";
@@ -11,1168 +12,1168 @@ public interface MoneroWallet
 
     /**
     * Register a listener to receive wallet notifications.
-    *
+    * 
     * @param listener is the listener to receive wallet notifications
     */
     public void AddListener(MoneroWalletListener listener);
 
     /**
-     * Unregister a listener to receive wallet notifications.
-     *
-     * @param listener is the listener to unregister
-     */
+        * Unregister a listener to receive wallet notifications.
+        * 
+        * @param listener is the listener to unregister
+        */
     public void RemoveListener(MoneroWalletListener listener);
 
     /**
-     * Get the listeners registered with the wallet.
-     *
-     * @return the registered listeners
-     */
+        * Get the listeners registered with the wallet.
+        * 
+        * @return the registered listeners
+        */
     public List<MoneroWalletListener> GetListeners();
 
     /**
-     * Indicates if the wallet is view-only, meaning it does not have the private
-     * spend key and can therefore only observe incoming outputs.
-     *
-     * @return {bool} true if the wallet is view-only, false otherwise
-     */
+        * Indicates if the wallet is view-only, meaning it does not have the private
+        * spend key and can therefore only observe incoming outputs.
+        * 
+        * @return {bool} true if the wallet is view-only, false otherwise
+        */
     public bool IsViewOnly();
 
     /**
-     * Set the wallet's daemon connection.
-     *
-     * @param uri is the daemon's URI
-     * @param username is the username to authenticate with the daemon (optional)
-     * @param password is the password to authenticate with the daemon (optional)
-     */
+        * Set the wallet's daemon connection.
+        * 
+        * @param uri is the daemon's URI
+        * @param username is the username to authenticate with the daemon (optional)
+        * @param password is the password to authenticate with the daemon (optional)
+        */
     public void SetDaemonConnection(string? uri, string? username = null, string? password = null);
 
     /**
-     * Set the wallet's daemon connection
-     *
-     * @param daemonConnection manages daemon connection information
-     */
+        * Set the wallet's daemon connection
+        * 
+        * @param daemonConnection manages daemon connection information
+        */
     public void SetDaemonConnection(MoneroRpcConnection? daemonConnection);
 
     /**
-     * Get the wallet's daemon connection.
-     *
-     * @return the wallet's daemon connection
-     */
+        * Get the wallet's daemon connection.
+        * 
+        * @return the wallet's daemon connection
+        */
     public MoneroRpcConnection? GetDaemonConnection();
 
     /**
-     * Set the wallet's daemon connection manager.
-     *
-     * @param connectionManager manages connections to monerod
-     */
+        * Set the wallet's daemon connection manager.
+        * 
+        * @param connectionManager manages connections to monerod
+        */
     public void SetConnectionManager(MoneroConnectionManager? connectionManager);
 
     /**
-     * Get the wallet's daemon connection manager.
-     *
-     * @return the wallet's daemon connection manager
-     */
+        * Get the wallet's daemon connection manager.
+        * 
+        * @return the wallet's daemon connection manager
+        */
     public MoneroConnectionManager? GetConnectionManager();
 
     /**
-     * Set the Tor proxy to the daemon.
-     *
-     * @param uri the Tor proxy URI
-     */
+        * Set the Tor proxy to the daemon.
+        * 
+        * @param uri the Tor proxy URI
+        */
     public void SetProxyUri(string? uri);
 
     /**
-     * Indicates if the wallet is connected a daemon.
-     *
-     * @return true if the wallet is connected to a daemon, false otherwise
-     */
+        * Indicates if the wallet is connected a daemon.
+        * 
+        * @return true if the wallet is connected to a daemon, false otherwise
+        */
     public bool IsConnectedToDaemon();
 
     /**
-     * Returns the wallet version.
-     *
-     * @return the wallet version
-     */
+        * Returns the wallet version.
+        * 
+        * @return the wallet version
+        */
     public MoneroVersion GetVersion();
 
     public MoneroNetworkType GetNetworkType();
 
     /**
-     * Get the wallet's path.
-     *
-     * @return the path the wallet can be opened with
-     */
+        * Get the wallet's path.
+        * 
+        * @return the path the wallet can be opened with
+        */
     public string GetPath();
 
     /**
-     * Get the wallet's mnemonic phrase or seed.
-     *
-     * @return the wallet's mnemonic phrase or seed.
-     */
+        * Get the wallet's mnemonic phrase or seed.
+        * 
+        * @return the wallet's mnemonic phrase or seed.
+        */
     public string GetSeed();
 
     /**
-     * Get the language of the wallet's mnemonic phrase or seed.
-     *
-     * @return the language of the wallet's mnemonic phrase or seed
-     */
+        * Get the language of the wallet's mnemonic phrase or seed.
+        * 
+        * @return the language of the wallet's mnemonic phrase or seed
+        */
     public string GetSeedLanguage();
 
     /**
-     * Get the wallet's private view key.
-     *
-     * @return the wallet's private view key
-     */
+        * Get the wallet's private view key.
+        * 
+        * @return the wallet's private view key
+        */
     public string GetPrivateViewKey();
 
     /**
-     * Get the wallet's private spend key.
-     *
-     * @return the wallet's private spend key
-     */
+        * Get the wallet's private spend key.
+        * 
+        * @return the wallet's private spend key
+        */
     public string GetPrivateSpendKey();
 
     /**
-     * Get the wallet's public view key.
-     *
-     * @return the wallet's public view key
-     */
+        * Get the wallet's public view key.
+        * 
+        * @return the wallet's public view key
+        */
     public string GetPublicViewKey();
 
     /**
-     * Get the wallet's public spend key.
-     *
-     * @return the wallet's public spend key
-     */
+        * Get the wallet's public spend key.
+        * 
+        * @return the wallet's public spend key
+        */
     public string GetPublicSpendKey();
 
     /**
-     * Get the wallet's primary address.
-     *
-     * @return the wallet's primary address
-     */
+        * Get the wallet's primary address.
+        * 
+        * @return the wallet's primary address
+        */
     public string GetPrimaryAddress();
 
     /**
-     * Get the address of a specific subaddress.
-     *
-     * @param accountIdx specifies the account index of the address's subaddress
-     * @param subaddressIdx specifies the subaddress index within the account
-     * @return the receive address of the specified subaddress
-     */
+        * Get the address of a specific subaddress.
+        * 
+        * @param accountIdx specifies the account index of the address's subaddress
+        * @param subaddressIdx specifies the subaddress index within the account
+        * @return the receiver address of the specified subaddress index
+        */
     public string GetAddress(uint accountIdx, uint subaddressIdx);
 
     /**
-     * Get the account and subaddress index of the given address.
-     *
-     * @param address is the address to Get the account and subaddress index from
-     * @return the account and subaddress indices
-     */
+        * Get the account and subaddress index of the given address.
+        * 
+        * @param address is the address to Get the account and subaddress index from
+        * @return the account and subaddress indices
+        */
     public MoneroSubaddress GetAddressIndex(string address);
 
     /**
-     * Get an integrated address based on the given standard address and payment
-     * ID. Uses the wallet's primary address if an address is not given.
-     * Generates a random payment ID if a payment ID is not given.
-     *
-     * @param standardAddress is the standard address to generate the integrated address from (wallet's primary address if null)
-     * @param paymentId is the payment ID to generate an integrated address from (randomly generated if null)
-     * @return the integrated address
-     */
+        * Get an integrated address based on the given standard address and payment
+        * ID. Uses the wallet's primary address if an address is not given.
+        * Generates a random payment ID if a payment ID is not given.
+        * 
+        * @param standardAddress is the standard address to generate the integrated address from (wallet's primary address if null)
+        * @param paymentId is the payment ID to generate an integrated address from (randomly generated if null)
+        * @return the integrated address
+        */
     public MoneroIntegratedAddress GetIntegratedAddress(string? standardAddress = null, string? paymentId = null);
 
     /**
-     * Decode an integrated address to Get its standard address and payment id.
-     *
-     * @param integratedAddress is an integrated address to decode
-     * @return the decoded integrated address including standard address and payment id
-     */
+        * Decode an integrated address to Get its standard address and payment id.
+        * 
+        * @param integratedAddress is an integrated address to decode
+        * @return the decoded integrated address including standard address and payment id
+        */
     public MoneroIntegratedAddress DecodeIntegratedAddress(string integratedAddress);
 
     /**
-     * Get the block height that the wallet is Synced to.
-     *
-     * @return the block height that the wallet is Synced to
-     */
+        * Get the block height that the wallet is Synced to.
+        * 
+        * @return the block height that the wallet is Synced to
+        */
     public ulong GetHeight();
 
     /**
-     * Get the blockchain's height.
-     *
-     * @return the blockchain's height
-     */
+        * Get the blockchain's height.
+        * 
+        * @return the blockchain's height
+        */
     public ulong GetDaemonHeight();
 
     /**
-     * Get the blockchain's height by date as a conservative estimate for scanning.
-     *
-     * @param year year of the height to Get
-     * @param month month of the height to Get as a number between 1 and 12
-     * @param day day of the height to Get as a number between 1 and 31
-     * @return the blockchain's approximate height at the given date
-     */
+        * Get the blockchain's height by date as a conservative estimate for scanning.
+        * 
+        * @param year year of the height to Get
+        * @param month month of the height to Get as a number between 1 and 12
+        * @param day day of the height to Get as a number between 1 and 31
+        * @return the blockchain's approximate height at the given date
+        */
     public ulong GetHeightByDate(int year, int month, int day);
 
     /**
-     * Synchronize the wallet with the daemon as a one-time Synchronous process.
-     *
-     * @param listener listener to receive notifications during Synchronization
-     * @return the Sync result
-     */
+        * Synchronize the wallet with the daemon as a one-time Synchronous process.
+        * 
+        * @param listener listener to receive notifications during Synchronization
+        * @return the Sync result
+        */
     public MoneroSyncResult Sync(MoneroWalletListener listener);
 
     /**
-     * Synchronize the wallet with the daemon as a one-time Synchronous process.
-     *
-     * @param startHeight is the start height to Sync from (defaults to the last Synced block)
-     * @param listener listener to receive notifications during Synchronization
-     * @return the Sync result
-     */
+        * Synchronize the wallet with the daemon as a one-time Synchronous process.
+        * 
+        * @param startHeight is the start height to Sync from (defaults to the last Synced block)
+        * @param listener listener to receive notifications during Synchronization
+        * @return the Sync result
+        */
     public MoneroSyncResult Sync(ulong? startHeight = null, MoneroWalletListener? listener = null);
 
     /**
-     * Start background Synchronizing with a maximum period between Syncs.
-     *
-     * @param SyncPeriodInMs maximum period between Syncs in milliseconds
-     */
-    public void StartSyncing(ulong? SyncPeriodInMs = null);
+        * Start background Synchronizing with a maximum period between Syncs.
+        * 
+        * @param SyncPeriodInMs maximum period between Syncs in milliseconds
+        */
+    public void StartSyncing(ulong? syncPeriodInMs = null);
 
     /**
-     * Stop Synchronizing the wallet with the daemon.
-     */
+        * Stop Synchronizing the wallet with the daemon.
+        */
     public void StopSyncing();
 
     /**
-     * Scan transactions by their hash/id.
-     *
-     * @param txHashes tx hashes to scan
-     */
+        * Scan transactions by their hash/id.
+        * 
+        * @param txHashes tx hashes to scan
+        */
     public void ScanTxs(List<string> txHashes);
 
     /**
-     * Rescan the blockchain for spent outputs.
-     *
-     * Note: this can only be called with a trusted daemon.
-     *
-     * Example use case: peer multisig hex is import when connected to an untrusted daemon,
-     * so the wallet will not rescan spent outputs.  Then the wallet connects to a trusted
-     * daemon.  This method should be manually invoked to rescan outputs.
-     */
+        * Rescan the blockchain for spent outputs.
+        *
+        * Note: this can only be called with a trusted daemon.
+        *
+        * Example use case: peer multisig hex is import when connected to an untrusted daemon,
+        * so the wallet will not rescan spent outputs.  Then the wallet connects to a trusted
+        * daemon.  This method should be manually invoked to rescan outputs.
+        */
     public void RescanSpent();
 
     /**
-     * Rescan the blockchain from scratch, losing any information which cannot be recovered from
-     * the blockchain itself.
-     *
-     * WARNING: This method discards local wallet data like destination addresses, tx secret keys,
-     * tx notes, etc.
-     */
+        * Rescan the blockchain from scratch, losing any information which cannot be recovered from
+        * the blockchain itself.
+        * 
+        * WARNING: This method discards local wallet data like destination addresses, tx secret keys,
+        * tx notes, etc.
+        */
     public void RescanBlockchain();
 
     /**
-     * Get a subaddress's balance.
-     *
-     * @param accountIdx index of the account to Get the balance of (default all accounts if null)
-     * @param subaddressIdx index of the subaddress to Get the balance of (default all subaddresses if null)
-     * @return the requested balance
-     */
+        * Get a subaddress's balance.
+        * 
+        * @param accountIdx index of the account to Get the balance of (default all accounts if null)
+        * @param subaddressIdx index of the subaddress to Get the balance of (default all subaddresses if null)
+        * @return the requested balance
+        */
     public ulong GetBalance(uint? accountIdx = null, uint? subaddressIdx = null);
 
     /**
-     * Get a subaddress's unlocked balance.
-     *
-     * @param accountIdx index of the subaddress to Get the unlocked balance of (default all accounts if null)
-     * @param subaddressIdx index of the subaddress to Get the unlocked balance of (default all subaddresses if null)
-     * @return the requested unlocked balance
-     */
+        * Get a subaddress's unlocked balance.
+        * 
+        * @param accountIdx index of the subaddress to Get the unlocked balance of (default all accounts if null)
+        * @param subaddressIdx index of the subaddress to Get the unlocked balance of (default all subaddresses if null)
+        * @return the requested unlocked balance
+        */
     public ulong GetUnlockedBalance(uint? accountIdx = null, uint? subaddressIdx = null);
 
     /**
-     * Get accounts with a given tag.
-     *
-     * @param tag is the tag for filtering accounts, all accounts if null
-     * @return all accounts with the given tag
-     */
+        * Get accounts with a given tag.
+        * 
+        * @param tag is the tag for filtering accounts, all accounts if null
+        * @return all accounts with the given tag
+        */
     public List<MoneroAccount> GetAccounts(string tag);
 
     /**
-     * Get accounts with a given tag.
-     *
-     * @param includeSubaddresses specifies if subaddresses should be included
-     * @param tag is the tag for filtering accounts, all accounts if null
-     * @return all accounts with the given tag
-     */
+        * Get accounts with a given tag.
+        * 
+        * @param includeSubaddresses specifies if subaddresses should be included
+        * @param tag is the tag for filtering accounts, all accounts if null
+        * @return all accounts with the given tag
+        */
     public List<MoneroAccount> GetAccounts(bool includeSubaddresses = false, string? tag = null);
 
     /**
-     * Get an account.
-     *
-     * @param accountIdx specifies the account to Get
-     * @param includeSubaddresses specifies if subaddresses should be included
-     * @return the retrieved account
-     */
+        * Get an account.
+        * 
+        * @param accountIdx specifies the account to Get
+        * @param includeSubaddresses specifies if subaddresses should be included
+        * @return the retrieved account
+        */
     public MoneroAccount GetAccount(uint accountIdx, bool includeSubaddresses = false);
 
     /**
-     * Create a new account with a label for the first subaddress.
-     *
-     * @param label specifies the label for account's first subaddress (optional)
-     * @return the created account
-     */
+        * Create a new account with a label for the first subaddress.
+        * 
+        * @param label specifies the label for account's first subaddress (optional)
+        * @return the created account
+        */
     public MoneroAccount CreateAccount(string? label = null);
 
     /**
-     * Set an account label.
-     *
-     * @param accountIdx index of the account to set the label for
-     * @param label the label to set
-     */
+        * Set an account label.
+        * 
+        * @param accountIdx index of the account to set the label for
+        * @param label the label to set
+        */
     public void SetAccountLabel(uint accountIdx, string label);
 
     /**
-     * Get subaddresses in an account.
-     *
-     * @param accountIdx specifies the account to Get subaddresses within
-     * @param subaddressIndices are specific subaddresses to Get (optional)
-     * @return the retrieved subaddresses
-     */
+        * Get subaddresses in an account.
+        * 
+        * @param accountIdx specifies the account to Get subaddresses within
+        * @param subaddressIndices are specific subaddresses to Get (optional)
+        * @return the retrieved subaddresses
+        */
     public List<MoneroSubaddress> GetSubaddresses(uint accountIdx, List<uint>? subaddressIndices = null);
 
     /**
-     * Get a subaddress.
-     *
-     * @param accountIdx specifies the index of the subaddress's account
-     * @param subaddressIdx specifies index of the subaddress within the account
-     * @return the retrieved subaddress
-     */
+        * Get a subaddress.
+        * 
+        * @param accountIdx specifies the index of the subaddress's account
+        * @param subaddressIdx specifies index of the subaddress within the account
+        * @return the retrieved subaddress
+        */
     public MoneroSubaddress GetSubaddress(uint accountIdx, uint subaddressIdx);
 
     /**
-     * Create a subaddress within an account.
-     *
-     * @param accountIdx specifies the index of the account to Create the subaddress within
-     * @param label specifies the the label for the subaddress (optional)
-     * @return the created subaddress
-     */
+        * Create a subaddress within an account.
+        * 
+        * @param accountIdx specifies the index of the account to Create the subaddress within
+        * @param label specifies the the label for the subaddress (optional)
+        * @return the created subaddress
+        */
     public MoneroSubaddress CreateSubaddress(uint accountIdx, string? label = null);
 
     /**
-     * Set a subaddress label.
-     *
-     * @param accountIdx index of the account to set the label for
-     * @param subaddressIdx index of the subaddress to set the label for
-     * @param label the label to set
-     */
+        * Set a subaddress label.
+        * 
+        * @param accountIdx index of the account to set the label for
+        * @param subaddressIdx index of the subaddress to set the label for
+        * @param label the label to set
+        */
     public void SetSubaddressLabel(uint accountIdx, uint subaddressIdx, string label);
 
     /**
-     * Get a wallet transaction by hash.
-     *
-     * @param txHash is the hash of a transaction to Get
-     * @return the identified transaction or null if not found
-     */
+        * Get a wallet transaction by hash.
+        * 
+        * @param txHash is the hash of a transaction to Get
+        * @return the identified transaction or null if not found
+        */
     public MoneroTxWallet? GetTx(string txHash);
 
     /**
-     * Get all wallet transactions.  Wallet transactions contain one or more
-     * transfers that are either incoming or outgoing to the wallet.
-     *
-     * @return all wallet transactions
-     */
+        * Get all wallet transactions.  Wallet transactions contain one or more
+        * transfers that are either incoming or outgoing to the wallet.
+        * 
+        * @return all wallet transactions
+        */
     public List<MoneroTxWallet> GetTxs();
 
     /**
-     * Get wallet transactions by hash.
-     *
-     * @param txHashes are hashes of transactions to Get
-     * @return the found transactions
-     */
+        * Get wallet transactions by hash.
+        * 
+        * @param txHashes are hashes of transactions to Get
+        * @return the found transactions
+        */
     public List<MoneroTxWallet> GetTxs(List<string> txHashes);
 
     /**
-     * <p>Get wallet transactions that meet the criteria defined in a query object.</p>
-     *
-     * <p>Transactions must meet every criteria defined in the query in order to
-     * be returned.  All criteria are optional and no filtering is applied when
-     * not defined.</p>
-     *
-     * <p>
-     * All supported query criteria:<br>
-     * &nbsp;&nbsp; isConfirmed - path of the wallet to open<br>
-     * &nbsp;&nbsp; password - password of the wallet to open<br>
-     * &nbsp;&nbsp; networkType - network type of the wallet to open (one of MoneroNetworkType.MAINNET|TESTNET|STAGENET)<br>
-     * &nbsp;&nbsp; serverUri - uri of the wallet's daemon (optional)<br>
-     * &nbsp;&nbsp; serverUsername - username to authenticate with the daemon (optional)<br>
-     * &nbsp;&nbsp; serverPassword - password to authenticate with the daemon (optional)<br>
-     * &nbsp;&nbsp; server - MoneroRpcConnection to a monero daemon (optional)<br>
-     * &nbsp;&nbsp; isConfirmed - Get txs that are confirmed or not (optional)<br>
-     * &nbsp;&nbsp; inTxPool - Get txs that are in the tx pool or not (optional)<br>
-     * &nbsp;&nbsp; isRelayed - Get txs that are relayed or not (optional)<br>
-     * &nbsp;&nbsp; isFailed - Get txs that are failed or not (optional)<br>
-     * &nbsp;&nbsp; isMinerTx - Get miner txs or not (optional)<br>
-     * &nbsp;&nbsp; hash - Get a tx with the hash (optional)<br>
-     * &nbsp;&nbsp; hashes - Get txs with the hashes (optional)<br>
-     * &nbsp;&nbsp; paymentId - Get transactions with the payment id (optional)<br>
-     * &nbsp;&nbsp; paymentIds - Get transactions with the payment ids (optional)<br>
-     * &nbsp;&nbsp; hasPaymentId - Get transactions with a payment id or not (optional)<br>
-     * &nbsp;&nbsp; minHeight - Get txs with height greater than or equal to the given height (optional)<br>
-     * &nbsp;&nbsp; maxHeight - Get txs with height less than or equal to the given height (optional)<br>
-     * &nbsp;&nbsp; isOutgoing - Get txs with an outgoing transfer or not (optional)<br>
-     * &nbsp;&nbsp; isIncoming - Get txs with an incoming transfer or not (optional)<br>
-     * &nbsp;&nbsp; transferQuery - Get txs that have a transfer that meets this query (optional)<br>
-     * &nbsp;&nbsp; includeOutputs - specifies that tx outputs should be returned with tx results (optional)<br>
-     * </p>
-     *
-     * @param query specifies properties of the transactions to Get
-     * @return wallet transactions that meet the query
-     */
+        * Get wallet transactions that meet the criteria defined in a query object.
+        * 
+        * Transactions must meet every criteria defined in the query in order to
+        * be returned.  All criteria are optional and no filtering is applied when
+        * not defined.
+        * 
+        * 
+        * All supported query criteria:
+        * isConfirmed - path of the wallet to open
+        * password - password of the wallet to open
+        * networkType - network type of the wallet to open (one of MoneroNetworkType.MAINNET|TESTNET|STAGENET)
+        * serverUri - uri of the wallet's daemon (optional)
+        * serverUsername - username to authenticate with the daemon (optional)
+        * serverPassword - password to authenticate with the daemon (optional)
+        * server - MoneroRpcConnection to a monero daemon (optional)
+        * isConfirmed - Get txs that are confirmed or not (optional)
+        * inTxPool - Get txs that are in the tx pool or not (optional)
+        * isRelayed - Get txs that are relayed or not (optional)
+        * isFailed - Get txs that are failed or not (optional)
+        * isMinerTx - Get miner txs or not (optional)
+        * hash - Get a tx with the hash (optional)
+        * hashes - Get txs with the hashes (optional)
+        * paymentId - Get transactions with the payment id (optional)
+        * paymentIds - Get transactions with the payment ids (optional)
+        * hasPaymentId - Get transactions with a payment id or not (optional)
+        * minHeight - Get txs with height greater than or equal to the given height (optional)
+        * maxHeight - Get txs with height less than or equal to the given height (optional)
+        * isOutgoing - Get txs with an outgoing transfer or not (optional)
+        * isIncoming - Get txs with an incoming transfer or not (optional)
+        * transferQuery - Get txs that have a transfer that meets this query (optional)
+        * includeOutputs - specifies that tx outputs should be returned with tx results (optional)
+        * 
+        * 
+        * @param query specifies properties of the transactions to Get
+        * @return wallet transactions that meet the query
+        */
     public List<MoneroTxWallet> GetTxs(MoneroTxQuery query);
 
     /**
-     * Get all incoming and outgoing transfers to and from this wallet.  An
-     * outgoing transfer represents a total amount sent from one or more
-     * subaddresses within an account to individual destination addresses, each
-     * with their own amount.  An incoming transfer represents a total amount
-     * received into a subaddress within an account.  Transfers belong to
-     * transactions which are stored on the blockchain.
-     *
-     * @return all wallet transfers
-     */
+        * Get all incoming and outgoing transfers to and from this wallet.  An
+        * outgoing transfer represents a total amount sent from one or more
+        * subaddresses within an account to individual destination addresses, each
+        * with their own amount.  An incoming transfer represents a total amount
+        * received into a subaddress within an account.  Transfers belong to
+        * transactions which are stored on the blockchain.
+        * 
+        * @return all wallet transfers
+        */
     public List<MoneroTransfer> GetTransfers();
 
     /**
-     * Get incoming and outgoing transfers to and from an account.  An outgoing
-     * transfer represents a total amount sent from one or more subaddresses
-     * within an account to individual destination addresses, each with their
-     * own amount.  An incoming transfer represents a total amount received into
-     * a subaddress within an account.  Transfers belong to transactions which
-     * are stored on the blockchain.
-     *
-     * @param accountIdx is the index of the account to Get transfers from
-     * @return transfers to/from the account
-     */
+        * Get incoming and outgoing transfers to and from an account.  An outgoing
+        * transfer represents a total amount sent from one or more subaddresses
+        * within an account to individual destination addresses, each with their
+        * own amount.  An incoming transfer represents a total amount received into
+        * a subaddress within an account.  Transfers belong to transactions which
+        * are stored on the blockchain.
+        * 
+        * @param accountIdx is the index of the account to Get transfers from
+        * @return transfers to/from the account
+        */
     public List<MoneroTransfer> GetTransfers(uint accountIdx);
 
     /**
-     * Get incoming and outgoing transfers to and from a subaddress.  An outgoing
-     * transfer represents a total amount sent from one or more subaddresses
-     * within an account to individual destination addresses, each with their
-     * own amount.  An incoming transfer represents a total amount received into
-     * a subaddress within an account.  Transfers belong to transactions which
-     * are stored on the blockchain.
-     *
-     * @param accountIdx is the index of the account to Get transfers from
-     * @param subaddressIdx is the index of the subaddress to Get transfers from
-     * @return transfers to/from the subaddress
-     */
+        * Get incoming and outgoing transfers to and from a subaddress.  An outgoing
+        * transfer represents a total amount sent from one or more subaddresses
+        * within an account to individual destination addresses, each with their
+        * own amount.  An incoming transfer represents a total amount received into
+        * a subaddress within an account.  Transfers belong to transactions which
+        * are stored on the blockchain.
+        * 
+        * @param accountIdx is the index of the account to Get transfers from
+        * @param subaddressIdx is the index of the subaddress to Get transfers from
+        * @return transfers to/from the subaddress
+        */
     public List<MoneroTransfer> GetTransfers(uint accountIdx, uint subaddressIdx);
 
     /**
-     * <p>Get tranfsers that meet the criteria defined in a query object.</p>
-     *
-     * <p>Transfers must meet every criteria defined in the query in order to be
-     * returned.  All criteria are optional and no filtering is applied when not
-     * defined.</p>
-     *
-     * All supported query criteria:<br>
-     * &nbsp;&nbsp; isOutgoing - Get transfers that are outgoing or not (optional)<br>
-     * &nbsp;&nbsp; isIncoming - Get transfers that are incoming or not (optional)<br>
-     * &nbsp;&nbsp; address - wallet's address that a transfer either originated from (if outgoing) or is destined for (if incoming) (optional)<br>
-     * &nbsp;&nbsp; accountIndex - Get transfers that either originated from (if outgoing) or are destined for (if incoming) a specific account index (optional)<br>
-     * &nbsp;&nbsp; subaddressIndex - Get transfers that either originated from (if outgoing) or are destined for (if incoming) a specific subaddress index (optional)<br>
-     * &nbsp;&nbsp; subaddressIndices - Get transfers that either originated from (if outgoing) or are destined for (if incoming) specific subaddress indices (optional)<br>
-     * &nbsp;&nbsp; amount - amount being transferred (optional)<br>
-     * &nbsp;&nbsp; destinations - individual destinations of an outgoing transfer, which is local wallet data and NOT recoverable from the blockchain (optional)<br>
-     * &nbsp;&nbsp; hasDestinations - Get transfers that have destinations or not (optional)<br>
-     * &nbsp;&nbsp; txQuery - Get transfers whose transaction meets this query (optional)<br>
-     *
-     * @param query specifies attributes of transfers to Get
-     * @return wallet transfers that meet the query
-     */
+        * Get transfers that meet the criteria defined in a query object.
+        * 
+        * Transfers must meet every criteria defined in the query in order to be
+        * returned.  All criteria are optional and no filtering is applied when not
+        * defined.
+        * 
+        * All supported query criteria:
+        * isOutgoing - Get transfers that are outgoing or not (optional)
+        * isIncoming - Get transfers that are incoming or not (optional)
+        * address - wallet's address that a transfer either originated from (if outgoing) or is destined for (if incoming) (optional)
+        * accountIndex - Get transfers that either originated from (if outgoing) or are destined for (if incoming) a specific account index (optional)
+        * subaddressIndex - Get transfers that either originated from (if outgoing) or are destined for (if incoming) a specific subaddress index (optional)
+        * subaddressIndices - Get transfers that either originated from (if outgoing) or are destined for (if incoming) specific subaddress indices (optional)
+        * amount - amount being transferred (optional)
+        * destinations - individual destinations of an outgoing transfer, which is local wallet data and NOT recoverable from the blockchain (optional)
+        * hasDestinations - Get transfers that have destinations or not (optional)
+        * txQuery - Get transfers whose transaction meets this query (optional)
+        * 
+        * @param query specifies attributes of transfers to Get
+        * @return wallet transfers that meet the query
+        */
     public List<MoneroTransfer> GetTransfers(MoneroTransferQuery query);
 
     /**
-     * Get all of the wallet's incoming transfers.
-     *
-     * @return the wallet's incoming transfers
-     */
+        * Get all wallet's incoming transfers.
+        * 
+        * @return the wallet's incoming transfers
+        */
     public List<MoneroIncomingTransfer> GetIncomingTransfers();
 
     /**
-     * <p>Get incoming transfers that meet a query.</p>
-     *
-     * <p>
-     * All supported query criteria:<br>
-     * &nbsp;&nbsp; address - Get incoming transfers to a specific address in the wallet (optional)<br>
-     * &nbsp;&nbsp; accountIndex - Get incoming transfers to a specific account index (optional)<br>
-     * &nbsp;&nbsp; subaddressIndex - Get incoming transfers to a specific subaddress index (optional)<br>
-     * &nbsp;&nbsp; subaddressIndices - Get transfers destined for specific subaddress indices (optional)<br>
-     * &nbsp;&nbsp; amount - amount being transferred (optional)<br>
-     * &nbsp;&nbsp; txQuery - Get transfers whose transaction meets this query (optional)<br>
-     * </p>
-     *
-     * @param query specifies which incoming transfers to Get
-     * @return incoming transfers that meet the query
-     */
+        * Get incoming transfers that meet a query.
+        * 
+        * 
+        * All supported query criteria:
+        * address - Get incoming transfers to a specific address in the wallet (optional)
+        * accountIndex - Get incoming transfers to a specific account index (optional)
+        * subaddressIndex - Get incoming transfers to a specific subaddress index (optional)
+        * subaddressIndices - Get transfers destined for specific subaddress indices (optional)
+        * amount - amount being transferred (optional)
+        * txQuery - Get transfers whose transaction meets this query (optional)
+        * 
+        * 
+        * @param query specifies which incoming transfers to Get
+        * @return incoming transfers that meet the query
+        */
     public List<MoneroIncomingTransfer> GetIncomingTransfers(MoneroTransferQuery query);
 
     /**
-     * Get all of the wallet's outgoing transfers.
-     *
-     * @return the wallet's outgoing transfers
-     */
+        * Get all wallet's outgoing transfers.
+        * 
+        * @return the wallet's outgoing transfers
+        */
     public List<MoneroOutgoingTransfer> GetOutgoingTransfers();
 
     /**
-     * <p>Get outgoing transfers that meet a query.</p>
-     *
-     * <p>
-     * All supported query criteria:<br>
-     * &nbsp;&nbsp; address - Get outgoing transfers from a specific address in the wallet (optional)<br>
-     * &nbsp;&nbsp; accountIndex - Get outgoing transfers from a specific account index (optional)<br>
-     * &nbsp;&nbsp; subaddressIndex - Get outgoing transfers from a specific subaddress index (optional)<br>
-     * &nbsp;&nbsp; subaddressIndices - Get outgoing transfers from specific subaddress indices (optional)<br>
-     * &nbsp;&nbsp; amount - amount being transferred (optional)<br>
-     * &nbsp;&nbsp; destinations - individual destinations of an outgoing transfer, which is local wallet data and NOT recoverable from the blockchain (optional)<br>
-     * &nbsp;&nbsp; hasDestinations - Get transfers that have destinations or not (optional)<br>
-     * &nbsp;&nbsp; txQuery - Get transfers whose transaction meets this query (optional)<br>
-     * </p>
-     *
-     * @param query specifies which outgoing transfers to Get
-     * @return outgoing transfers that meet the query
-     */
+        * Get outgoing transfers that meet a query.
+        * 
+        * 
+        * All supported query criteria:
+        * address - Get outgoing transfers from a specific address in the wallet (optional)
+        * accountIndex - Get outgoing transfers from a specific account index (optional)
+        * subaddressIndex - Get outgoing transfers from a specific subaddress index (optional)
+        * subaddressIndices - Get outgoing transfers from specific subaddress indices (optional)
+        * amount - amount being transferred (optional)
+        * destinations - individual destinations of an outgoing transfer, which is local wallet data and NOT recoverable from the blockchain (optional)
+        * hasDestinations - Get transfers that have destinations or not (optional)
+        * txQuery - Get transfers whose transaction meets this query (optional)
+        * 
+        * 
+        * @param query specifies which outgoing transfers to Get
+        * @return outgoing transfers that meet the query
+        */
     public List<MoneroOutgoingTransfer> GetOutgoingTransfers(MoneroTransferQuery query);
 
     /**
-     * Get outputs Created from previous transactions that belong to the wallet
-     * (i.e. that the wallet can spend one time).  Outputs are part of
-     * transactions which are stored in blocks on the blockchain.
-     *
-     * @return all wallet outputs
-     */
+        * Get outputs Created from previous transactions that belong to the wallet
+        * (i.e. that the wallet can spend one time).  Outputs are part of
+        * transactions which are stored in blocks on the blockchain.
+        * 
+        * @return all wallet outputs
+        */
     public List<MoneroOutputWallet> GetOutputs();
 
     /**
-     * <p>Get outputs which meet the criteria defined in a query object.</p>
-     *
-     * <p>Outputs must meet every criteria defined in the query in order to be
-     * returned.  All criteria are optional and no filtering is applied when not
-     * defined.</p>
-     *
-     * <p>
-     * All supported query criteria:<br>
-     * &nbsp;&nbsp; accountIndex - Get outputs associated with a specific account index (optional)<br>
-     * &nbsp;&nbsp; subaddressIndex - Get outputs associated with a specific subaddress index (optional)<br>
-     * &nbsp;&nbsp; subaddressIndices - Get outputs associated with specific subaddress indices (optional)<br>
-     * &nbsp;&nbsp; amount - Get outputs with a specific amount (optional)<br>
-     * &nbsp;&nbsp; minAmount - Get outputs greater than or equal to a minimum amount (optional)<br>
-     * &nbsp;&nbsp; maxAmount - Get outputs less than or equal to a maximum amount (optional)<br>
-     * &nbsp;&nbsp; isSpent - Get outputs that are spent or not (optional)<br>
-     * &nbsp;&nbsp; keyImage - Get outputs that match the fields defined in the given key image (optional)<br>
-     * &nbsp;&nbsp; txQuery - Get outputs whose transaction meets this filter (optional)<br>
-     * </p>
-     *
-     * @param query specifies attributes of outputs to Get
-     * @return the queried outputs
-     */
-    public List<MoneroOutputWallet> GetOutputs(MoneroOutputQuery query);
+        * Get outputs which meet the criteria defined in a query object.
+        * 
+        * Outputs must meet every criteria defined in the query in order to be
+        * returned.  All criteria are optional and no filtering is applied when not
+        * defined.
+        * 
+        * 
+        * All supported query criteria:
+        * accountIndex - Get outputs associated with a specific account index (optional)
+        * subaddressIndex - Get outputs associated with a specific subaddress index (optional)
+        * subaddressIndices - Get outputs associated with specific subaddress indices (optional)
+        * amount - Get outputs with a specific amount (optional)
+        * minAmount - Get outputs greater than or equal to a minimum amount (optional)
+        * maxAmount - Get outputs less than or equal to a maximum amount (optional)
+        * isSpent - Get outputs that are spent or not (optional)
+        * keyImage - Get outputs that match the fields defined in the given key image (optional)
+        * txQuery - Get outputs whose transaction meets this filter (optional)
+        * 
+        * 
+        * @param query specifies attributes of outputs to Get
+        * @return the queried outputs
+        */
+    public List<MoneroOutputWallet> GetOutputs(MoneroOutputQuery? query);
 
     /**
-     * Export outputs in hex format.
-     *
-     * @param all exports all outputs if true, else exports the outputs since the last export
-     * @return outputs in hex format
-     */
+        * Export outputs in hex format.
+        *
+        * @param all exports all outputs if true, else exports the outputs since the last export
+        * @return outputs in hex format
+        */
     public string ExportOutputs(bool all = false);
 
     /**
-     * Import outputs in hex format.
-     *
-     * @param outputsHex are outputs in hex format
-     * @return the number of outputs imported
-     */
+        * Import outputs in hex format.
+        * 
+        * @param outputsHex are outputs in hex format
+        * @return the number of outputs imported
+        */
     public int ImportOutputs(string outputsHex);
 
     /**
-     * Export signed key images.
-     *
-     * @param all exports all key images if true, else exports the key images since the last export
-     * @return signed key images
-     */
+        * Export signed key images.
+        * 
+        * @param all exports all key images if true, else exports the key images since the last export
+        * @return signed key images
+        */
     public List<MoneroKeyImage> ExportKeyImages(bool all = false);
 
     /**
-     * Import signed key images and verify their spent status.
-     *
-     * @param keyImages are key images to import and verify (requires hex and signature)
-     * @return results of the import
-     */
+        * Import signed key images and verify their spent status.
+        * 
+        * @param keyImages are key images to import and verify (requires hex and signature)
+        * @return results of the import
+        */
     public MoneroKeyImageImportResult ImportKeyImages(List<MoneroKeyImage> keyImages);
 
     /**
-     * Get new key images from the last imported outputs.
-     *
-     * @return the key images from the last imported outputs
-     */
+        * Get new key images from the last imported outputs.
+        * 
+        * @return the key images from the last imported outputs
+        */
     public List<MoneroKeyImage> GetNewKeyImagesFromLastImport();
 
     /**
-     * Freeze an output.
-     *
-     * @param keyImage key image of the output to freeze
-     */
+        * Freeze an output.
+        * 
+        * @param keyImage key image of the output to freeze
+        */
     public void FreezeOutput(string keyImage);
 
     /**
-     * Thaw a frozen output.
-     *
-     * @param keyImage key image of the output to thaw
-     */
+        * Thaw a frozen output.
+        * 
+        * @param keyImage key image of the output to thaw
+        */
     public void ThawOutput(string keyImage);
 
     /**
-     * Check if an output is frozen.
-     *
-     * @param keyImage key image of the output to check if frozen
-     * @return true if the output is frozen, false otherwise
-     */
+        * Check if an output is frozen.
+        * 
+        * @param keyImage key image of the output to check if frozen
+        * @return true if the output is frozen, false otherwise
+        */
     public bool IsOutputFrozen(string keyImage);
 
     /**
-     * Get the current default fee priority (unimportant, normal, elevated, etc).
-     *
-     * @return the current fee priority
-     */
+        * Get the current default fee priority (unimportant, normal, elevated, etc.).
+        * 
+        * @return the current fee priority
+        */
     public MoneroTxPriority GetDefaultFeePriority();
 
     /**
-     * Create a transaction to transfer funds from this wallet.
-     *
-     * <p>
-     * All supported configuration:<br>
-     * &nbsp;&nbsp; address - single destination address (required unless `destinations` provided)<br>
-     * &nbsp;&nbsp; amount - single destination amount (required unless `destinations` provided)<br>
-     * &nbsp;&nbsp; accountIndex - source account index to transfer funds from (required)<br>
-     * &nbsp;&nbsp; subaddressIndex - source subaddress index to transfer funds from (optional)<br>
-     * &nbsp;&nbsp; subaddressIndices - source subaddress indices to transfer funds from (optional)<br>
-     * &nbsp;&nbsp; relay - relay the transaction to peers to commit to the blockchain (default false)<br>
-     * &nbsp;&nbsp; priority - transaction priority (default MoneroTxPriority.NORMAL)<br>
-     * &nbsp;&nbsp; destinations - addresses and amounts in a multi-destination tx (required unless `address` and `amount` provided)<br>
-     * &nbsp;&nbsp; subtractFeeFrom - list of destination indices to split the transaction fee (optional)<br>
-     * &nbsp;&nbsp; paymentId - transaction payment ID (optional)<br>
-     * &nbsp;&nbsp; unlockTime - minimum height or timestamp for the transaction to unlock (default 0)<br>
-     * </p>
-     *
-     * @param config configures the transaction to Create
-     * @return the created transaction
-     */
+        * Create a transaction to transfer funds from this wallet.
+        * 
+        * 
+        * All supported configuration:
+        * address - single destination address (required unless `destinations` provided)
+        * amount - single destination amount (required unless `destinations` provided)
+        * accountIndex - source account index to transfer funds from (required)
+        * subaddressIndex - source subaddress index to transfer funds from (optional)
+        * subaddressIndices - source subaddress indices to transfer funds from (optional)
+        * relay - relay the transaction to peers to commit to the blockchain (default false)
+        * priority - transaction priority (default MoneroTxPriority.NORMAL)
+        * destinations - addresses and amounts in a multi-destination tx (required unless `address` and `amount` provided)
+        * subtractFeeFrom - list of destination indices to split the transaction fee (optional)
+        * paymentId - transaction payment ID (optional)
+        * unlockTime - minimum height or timestamp for the transaction to unlock (default 0)
+        * 
+        * 
+        * @param config configures the transaction to Create
+        * @return the created transaction
+        */
     public MoneroTxWallet CreateTx(MoneroTxConfig config);
 
     /**
-     * Create one or more transactions to transfer funds from this wallet.
-     *
-     * <p>
-     * All supported configuration:<br>
-     * &nbsp;&nbsp; address - single destination address (required unless `destinations` provided)<br>
-     * &nbsp;&nbsp; amount - single destination amount (required unless `destinations` provided)<br>
-     * &nbsp;&nbsp; accountIndex - source account index to transfer funds from (required)<br>
-     * &nbsp;&nbsp; subaddressIndex - source subaddress index to transfer funds from (optional)<br>
-     * &nbsp;&nbsp; subaddressIndices - source subaddress indices to transfer funds from (optional)<br>
-     * &nbsp;&nbsp; relay - relay the transactions to peers to commit to the blockchain (default false)<br>
-     * &nbsp;&nbsp; priority - transaction priority (default MoneroTxPriority.NORMAL)<br>
-     * &nbsp;&nbsp; destinations - addresses and amounts in a multi-destination tx (required unless `address` and `amount` provided)<br>
-     * &nbsp;&nbsp; paymentId - transaction payment ID (optional)<br>
-     * &nbsp;&nbsp; unlockTime - minimum height or timestamp for the transactions to unlock (default 0)<br>
-     * &nbsp;&nbsp; canSplit - allow funds to be transferred using multiple transactions (default true)<br>
-     * </p>
-     *
-     * @param config configures the transactions to Create
-     * @return the created transactions
-     */
+        * Create one or more transactions to transfer funds from this wallet.
+        * 
+        * 
+        * All supported configuration:
+        * address - single destination address (required unless `destinations` provided)
+        * amount - single destination amount (required unless `destinations` provided)
+        * accountIndex - source account index to transfer funds from (required)
+        * subaddressIndex - source subaddress index to transfer funds from (optional)
+        * subaddressIndices - source subaddress indices to transfer funds from (optional)
+        * relay - relay the transactions to peers to commit to the blockchain (default false)
+        * priority - transaction priority (default MoneroTxPriority.NORMAL)
+        * destinations - addresses and amounts in a multi-destination tx (required unless `address` and `amount` provided)
+        * paymentId - transaction payment ID (optional)
+        * unlockTime - minimum height or timestamp for the transactions to unlock (default 0)
+        * canSplit - allow funds to be transferred using multiple transactions (default true)
+        * 
+        * 
+        * @param config configures the transactions to Create
+        * @return the created transactions
+        */
     public List<MoneroTxWallet> CreateTxs(MoneroTxConfig config);
 
     /**
-     * Sweep an output with a given key image.
-     *
-     * <p>
-     * All supported configuration:<br>
-     * &nbsp;&nbsp; address - single destination address (required)<br>
-     * &nbsp;&nbsp; keyImage - key image to sweep (required)<br>
-     * &nbsp;&nbsp; relay - relay the transaction to peers to commit to the blockchain (default false)<br>
-     * &nbsp;&nbsp; unlockTime - minimum height or timestamp for the transaction to unlock (default 0)<br>
-     * &nbsp;&nbsp; priority - transaction priority (default MoneroTxPriority.NORMAL)<br>
-     * </p>
-     *
-     * @param config configures the sweep transaction
-     * @return the created transaction
-     */
+        * Sweep an output with a given key image.
+        * 
+        * 
+        * All supported configuration:
+        * address - single destination address (required)
+        * keyImage - key image to sweep (required)
+        * relay - relay the transaction to peers to commit to the blockchain (default false)
+        * unlockTime - minimum height or timestamp for the transaction to unlock (default 0)
+        * priority - transaction priority (default MoneroTxPriority.NORMAL)
+        * 
+        * 
+        * @param config configures the sweep transaction
+        * @return the created transaction
+        */
     public MoneroTxWallet SweepOutput(MoneroTxConfig config);
 
     /**
-     * Sweep all unlocked funds according to the given config.
-     *
-     * <p>
-     * All supported configuration:<br>
-     * &nbsp;&nbsp; address - single destination address (required)<br>
-     * &nbsp;&nbsp; accountIndex - source account index to sweep from (optional, defaults to all accounts)<br>
-     * &nbsp;&nbsp; subaddressIndex - source subaddress index to sweep from (optional, defaults to all subaddresses)<br>
-     * &nbsp;&nbsp; subaddressIndices - source subaddress indices to sweep from (optional)<br>
-     * &nbsp;&nbsp; relay - relay the transactions to peers to commit to the blockchain (default false)<br>
-     * &nbsp;&nbsp; priority - transaction priority (default MoneroTxPriority.NORMAL)<br>
-     * &nbsp;&nbsp; unlockTime - minimum height or timestamp for the transactions to unlock (default 0)<br>
-     * &nbsp;&nbsp; sweepEachSubaddress - sweep each subaddress individually if true (default false)<br>
-     * </p>
-     *
-     * @param config is the sweep configuration
-     * @return the created transactions
-     */
+        * Sweep all unlocked funds according to the given config.
+        * 
+        * 
+        * All supported configuration:
+        * address - single destination address (required)
+        * accountIndex - source account index to sweep from (optional, defaults to all accounts)
+        * subaddressIndex - source subaddress index to sweep from (optional, defaults to all subaddresses)
+        * subaddressIndices - source subaddress indices to sweep from (optional)
+        * relay - relay the transactions to peers to commit to the blockchain (default false)
+        * priority - transaction priority (default MoneroTxPriority.NORMAL)
+        * unlockTime - minimum height or timestamp for the transactions to unlock (default 0)
+        * sweepEachSubaddress - sweep each subaddress individually if true (default false)
+        * 
+        * 
+        * @param config is the sweep configuration
+        * @return the created transactions
+        */
     public List<MoneroTxWallet> SweepUnlocked(MoneroTxConfig config);
 
     /**
-     * Sweep all unmixable dust outputs back to the wallet to make them easier to spend and mix.
-     *
-     * NOTE: Dust only exists pre RCT, so this method will throw "no dust to sweep" on new wallets.
-     *
-     * @param relay specifies if the resulting transaction should be relayed (defaults to false i.e. not relayed)
-     * @return the created transactions
-     */
+        * Sweep all unmixable dust outputs back to the wallet to make them easier to spend and mix.
+        * 
+        * NOTE: Dust only exists pre RCT, so this method will throw "no dust to sweep" on new wallets.
+        * 
+        * @param relay specifies if the resulting transaction should be relayed (defaults to false i.e. not relayed)
+        * @return the created transactions
+        */
     public List<MoneroTxWallet> SweepDust(bool relay);
 
     /**
-     * Relay a previously Created transaction.
-     *
-     * @param txMetadata is transaction metadata previously Created without relaying
-     * @return the hash of the relayed tx
-     */
+        * Relay a previously Created transaction.
+        * 
+        * @param txMetadata is transaction metadata previously Created without relaying
+        * @return the hash of the relayed tx
+        */
     public string RelayTx(string txMetadata);
 
     /**
-     * Relay a previously Created transaction.
-     *
-     * @param tx is the transaction to relay
-     * @return the hash of the relayed tx
-     */
+        * Relay a previously Created transaction.
+        * 
+        * @param tx is the transaction to relay
+        * @return the hash of the relayed tx
+        */
     public string RelayTx(MoneroTxWallet tx);
 
     /**
-     * Relay previously Created transactions.
-     *
-     * @param txMetadatas are transaction metadata previously Created without relaying
-     * @return the hashes of the relayed txs
-     */
+        * Relay previously Created transactions.
+        * 
+        * @param txMetadatas are transaction metadata previously Created without relaying
+        * @return the hashes of the relayed txs
+        */
     public List<string> RelayTxs(List<string> txMetadatas);
 
     /**
-     * Relay previously Created transactions.
-     *
-     * @param txs are the transactions to relay
-     * @return the hashes of the relayed txs
-     */
+        * Relay previously Created transactions.
+        * 
+        * @param txs are the transactions to relay
+        * @return the hashes of the relayed txs
+        */
     public List<string> RelayTxs(List<MoneroTxWallet> txs);
 
     /**
-     * Describe a tx set from unsigned tx hex.
-     *
-     * @param unsignedTxHex unsigned tx hex
-     * @return the tx set containing structured transactions
-     */
+        * Describe a tx set from unsigned tx hex.
+        * 
+        * @param unsignedTxHex unsigned tx hex
+        * @return the tx set containing structured transactions
+        */
     public MoneroTxSet DescribeUnsignedTxSet(string unsignedTxHex);
 
     /**
-     * Describe a tx set from multisig tx hex.
-     *
-     * @param multisigTxHex multisig tx hex
-     * @return the tx set containing structured transactions
-     */
+        * Describe a tx set from multisig tx hex.
+        * 
+        * @param multisigTxHex multisig tx hex
+        * @return the tx set containing structured transactions
+        */
     public MoneroTxSet DescribeMultisigTxSet(string multisigTxHex);
 
     /**
-     * Describe a tx set containing unsigned or multisig tx hex to a new tx set containing structured transactions.
-     *
-     * @param txSet is a tx set containing unsigned or multisig tx hex
-     * @return the tx set containing structured transactions
-     */
+        * Describe a tx set containing unsigned or multisig tx hex to a new tx set containing structured transactions.
+        * 
+        * @param txSet is a tx set containing unsigned or multisig tx hex
+        * @return the tx set containing structured transactions
+        */
     public MoneroTxSet DescribeTxSet(MoneroTxSet txSet);
 
     /**
-     * Sign unsigned transactions from a view-only wallet.
-     *
-     * @param unsignedTxHex is unsigned transaction hex from when the transactions were Created
-     * @return the signed transaction set
-     */
+        * Sign unsigned transactions from a view-only wallet.
+        * 
+        * @param unsignedTxHex is unsigned transaction hex from when the transactions were Created
+        * @return the signed transaction set
+        */
     public MoneroTxSet SignTxs(string unsignedTxHex);
 
     /**
-     * Submit signed transactions from a view-only wallet.
-     *
-     * @param signedTxHex is signed transaction hex from signTxs()
-     * @return the resulting transaction hashes
-     */
+        * Submit signed transactions from a view-only wallet.
+        * 
+        * @param signedTxHex is signed transaction hex from signTxs()
+        * @return the resulting transaction hashes
+        */
     public List<string> SubmitTxs(string signedTxHex);
 
     /**
-     * Sign a message.
-     *
-     * @param message the message to sign
-     * @param signatureType sign with spend key or view key
-     * @param accountIdx the account index of the message signature (default 0)
-     * @param subaddressIdx the subaddress index of the message signature (default 0)
-     * @return the signature
-     */
+        * Sign a message.
+        * 
+        * @param message the message to sign
+        * @param signatureType sign with spend key or view key
+        * @param accountIdx the account index of the message signature (default 0)
+        * @param subaddressIdx the subaddress index of the message signature (default 0)
+        * @return the signature
+        */
     public string SignMessage(string message, MoneroMessageSignatureType signatureType = MoneroMessageSignatureType.SIGN_WITH_SPEND_KEY, uint accountIdx = 0, uint subaddressIdx = 0);
 
     /**
-     * Verify a signature on a message.
-     *
-     * @param message is the signed message
-     * @param address is the signing address
-     * @param signature is the signature
-     * @return the message signature verification result
-     */
+        * Verify a signature on a message.
+        * 
+        * @param message is the signed message
+        * @param address is the signing address
+        * @param signature is the signature
+        * @return the message signature verification result
+        */
     public MoneroMessageSignatureResult VerifyMessage(string message, string address, string signature);
 
     /**
-     * Get a transaction's secret key from its hash.
-     *
-     * @param txHash is the transaction's hash
-     * @return is the transaction's secret key
-     */
+        * Get a transaction's secret key from its hash.
+        * 
+        * @param txHash is the transaction's hash
+        * @return is the transaction's secret key
+        */
     public string GetTxKey(string txHash);
 
     /**
-     * Check a transaction in the blockchain with its secret key.
-     *
-     * @param txHash specifies the transaction to check
-     * @param txKey is the transaction's secret key
-     * @param address is the destination public address of the transaction
-     * @return the result of the check
-     */
+        * Check a transaction in the blockchain with its secret key.
+        * 
+        * @param txHash specifies the transaction to check
+        * @param txKey is the transaction's secret key
+        * @param address is the destination public address of the transaction
+        * @return the result of the check
+        */
     public MoneroCheckTx CheckTxKey(string txHash, string txKey, string address);
 
     /**
-     * Get a transaction signature to prove it.
-     *
-     * @param txHash specifies the transaction to prove
-     * @param address is the destination public address of the transaction
-     * @param message is a message to include with the signature to further authenticate the proof (optional)
-     * @return the transaction signature
-     */
+        * Get a transaction signature to prove it.
+        * 
+        * @param txHash specifies the transaction to prove
+        * @param address is the destination public address of the transaction
+        * @param message is a message to include with the signature to further authenticate the proof (optional)
+        * @return the transaction signature
+        */
     public string GetTxProof(string txHash, string address, string? message = null);
 
     /**
-     * Prove a transaction by checking its signature.
-     *
-     * @param txHash specifies the transaction to prove
-     * @param address is the destination public address of the transaction
-     * @param message is a message included with the signature to further authenticate the proof (optional)
-     * @param signature is the transaction signature to confirm
-     * @return the result of the check
-     */
+        * Prove a transaction by checking its signature.
+        * 
+        * @param txHash specifies the transaction to prove
+        * @param address is the destination public address of the transaction
+        * @param message is a message included with the signature to further authenticate the proof (optional)
+        * @param signature is the transaction signature to confirm
+        * @return the result of the check
+        */
     public MoneroCheckTx CheckTxProof(string txHash, string address, string message, string signature);
 
     /**
-     * Generate a signature to prove a spend. Unlike proving a transaction, it does not require the destination public address.
-     *
-     * @param txHash specifies the transaction to prove
-     * @param message is a message to include with the signature to further authenticate the proof (optional)
-     * @return the transaction signature
-     */
+        * Generate a signature to prove a spend. Unlike proving a transaction, it does not require the destination public address.
+        * 
+        * @param txHash specifies the transaction to prove
+        * @param message is a message to include with the signature to further authenticate the proof (optional)
+        * @return the transaction signature
+        */
     public string GetSpendProof(string txHash, string? message = null);
 
     /**
-     * Prove a spend using a signature. Unlike proving a transaction, it does not require the destination public address.
-     *
-     * @param txHash specifies the transaction to prove
-     * @param message is a message included with the signature to further authenticate the proof (optional)
-     * @param signature is the transaction signature to confirm
-     * @return true if the signature is good, false otherwise
-     */
+        * Prove a spend using a signature. Unlike proving a transaction, it does not require the destination public address.
+        * 
+        * @param txHash specifies the transaction to prove
+        * @param message is a message included with the signature to further authenticate the proof (optional)
+        * @param signature is the transaction signature to confirm
+        * @return true if the signature is good, false otherwise
+        */
     public bool CheckSpendProof(string txHash, string message, string signature);
 
     /**
-     * Generate a signature to prove the entire balance of the wallet.
-     *
-     * @param message is a message included with the signature to further authenticate the proof (optional)
-     * @return the reserve proof signature
-     */
+        * Generate a signature to prove the entire balance of the wallet.
+        * 
+        * @param message is a message included with the signature to further authenticate the proof (optional)
+        * @return the reserve proof signature
+        */
     public string GetReserveProofWallet(string message);
 
     /**
-     * Generate a signature to prove an available amount in an account.
-     *
-     * @param accountIdx specifies the account to prove ownership of the amount
-     * @param amount is the minimum amount to prove as available in the account
-     * @param message is a message to include with the signature to further authenticate the proof (optional)
-     * @return the reserve proof signature
-     */
+        * Generate a signature to prove an available amount in an account.
+        * 
+        * @param accountIdx specifies the account to prove ownership of the amount
+        * @param amount is the minimum amount to prove as available in the account
+        * @param message is a message to include with the signature to further authenticate the proof (optional)
+        * @return the reserve proof signature
+        */
     public string GetReserveProofAccount(uint accountIdx, ulong amount, string message);
 
     /**
-     * Proves a wallet has a disposable reserve using a signature.
-     *
-     * @param address is the public wallet address
-     * @param message is a message included with the signature to further authenticate the proof (optional)
-     * @param signature is the reserve proof signature to check
-     * @return the result of checking the signature proof
-     */
+        * Proves a wallet has a disposable reserve using a signature.
+        * 
+        * @param address is the public wallet address
+        * @param message is a message included with the signature to further authenticate the proof (optional)
+        * @param signature is the reserve proof signature to check
+        * @return the result of checking the signature proof
+        */
     public MoneroCheckReserve CheckReserveProof(string address, string message, string signature);
 
     /**
-     * Get a transaction note.
-     *
-     * @param txHash specifies the transaction to Get the note of
-     * @return the tx note
-     */
+        * Get a transaction note.
+        * 
+        * @param txHash specifies the transaction to Get the note of
+        * @return the tx note
+        */
     public string? GetTxNote(string txHash);
 
     /**
-     * Get notes for multiple transactions.
-     *
-     * @param txHashes identify the transactions to Get notes for
-     * @return notes for the transactions
-     */
+        * Get notes for multiple transactions.
+        * 
+        * @param txHashes identify the transactions to Get notes for
+        * @return notes for the transactions
+        */
     public List<string> GetTxNotes(List<string> txHashes);
 
     /**
-     * Set a note for a specific transaction.
-     *
-     * @param txHash specifies the transaction
-     * @param note specifies the note
-     */
+        * Set a note for a specific transaction.
+        * 
+        * @param txHash specifies the transaction
+        * @param note specifies the note
+        */
     public void SetTxNote(string txHash, string note);
 
     /**
-     * Set notes for multiple transactions.
-     *
-     * @param txHashes specify the transactions to set notes for
-     * @param notes are the notes to set for the transactions
-     */
+        * Set notes for multiple transactions.
+        * 
+        * @param txHashes specify the transactions to set notes for
+        * @param notes are the notes to set for the transactions
+        */
     public void SetTxNotes(List<string> txHashes, List<string> notes);
 
     /**
-     * Get all address book entries.
-     *
-     * @return the address book entries
-     */
+        * Get all address book entries.
+        * 
+        * @return the address book entries
+        */
     public List<MoneroAddressBookEntry> GetAddressBookEntries();
 
     /**
-     * Get address book entries.
-     *
-     * @param entryIndices are indices of the entries to Get (optional)
-     * @return the address book entries
-     */
+        * Get address book entries.
+        * 
+        * @param entryIndices are indices of the entries to Get (optional)
+        * @return the address book entries
+        */
     public List<MoneroAddressBookEntry> GetAddressBookEntries(List<uint> entryIndices);
 
     /**
-     * Add an address book entry.
-     *
-     * @param address is the entry address
-     * @param description is the entry description (optional)
-     * @return the index of the added entry
-     */
-    public int AddAddressBookEntry(string address, string description);
+        * Add an address book entry.
+        * 
+        * @param address is the entry address
+        * @param description is the entry description (optional)
+        * @return the index of the added entry
+        */
+    public uint AddAddressBookEntry(string address, string description);
 
     /**
-     * Edit an address book entry.
-     *
-     * @param index is the index of the address book entry to edit
-     * @param setAddress specifies if the address should be updated
-     * @param address is the updated address
-     * @param setDescription specifies if the description should be updated
-     * @param description is the updated description
-     */
+        * Edit an address book entry.
+        * 
+        * @param index is the index of the address book entry to edit
+        * @param setAddress specifies if the address should be updated
+        * @param address is the updated address
+        * @param setDescription specifies if the description should be updated
+        * @param description is the updated description
+        */
     public void EditAddressBookEntry(uint index, bool setAddress, string address, bool setDescription, string description);
 
     /**
-     * Delete an address book entry.
-     *
-     * @param entryIdx is the index of the entry to delete
-     */
+        * Delete an address book entry.
+        * 
+        * @param entryIdx is the index of the entry to delete
+        */
     public void DeleteAddressBookEntry(uint entryIdx);
 
     /**
-     * Tag accounts.
-     *
-     * @param tag is the tag to apply to the specified accounts
-     * @param accountIndices are the indices of the accounts to tag
-     */
+        * Tag accounts.
+        * 
+        * @param tag is the tag to apply to the specified accounts
+        * @param accountIndices are the indices of the accounts to tag
+        */
     public void TagAccounts(string tag, List<uint> accountIndices);
 
     /**
-     * Untag acconts.
-     *
-     * @param accountIndices are the indices of the accounts to untag
-     */
+        * Untag acconts.
+        * 
+        * @param accountIndices are the indices of the accounts to untag
+        */
     public void UntagAccounts(List<uint> accountIndices);
 
     /**
-     * Return all account tags.
-     *
-     * @return the wallet's account tags
-     */
+        * Return all account tags.
+        * 
+        * @return the wallet's account tags
+        */
     public List<MoneroAccountTag> GetAccountTags();
 
     /**
-     * Sets a human-readable description for a tag.
-     *
-     * @param tag is the tag to set a description for
-     * @param label is the label to set for the tag
-     */
+        * Sets a human-readable description for a tag.
+        * 
+        * @param tag is the tag to set a description for
+        * @param label is the label to set for the tag
+        */
     public void SetAccountTagLabel(string tag, string label);
 
     /**
-     * Creates a payment URI from a send configuration.
-     *
-     * @param config specifies configuration for a potential tx
-     * @return the payment uri
-     */
+        * Creates a payment URI from a send configuration.
+        * 
+        * @param config specifies configuration for a potential tx
+        * @return the payment uri
+        */
     public string GetPaymentUri(MoneroTxConfig config);
 
     /**
-     * Parses a payment URI to a transaction configuration.
-     *
-     * @param uri is the payment uri to parse
-     * @return the send configuration parsed from the uri
-     */
+        * Parses a payment URI to a transaction configuration.
+        * 
+        * @param uri is the payment uri to parse
+        * @return the send configuration parsed from the uri
+        */
     public MoneroTxConfig ParsePaymentUri(string uri);
 
     /**
-     * Get an attribute.
-     *
-     * @param key is the attribute to Get the value of
-     * @return the attribute's value
-     */
+        * Get an attribute.
+        * 
+        * @param key is the attribute to Get the value of
+        * @return the attribute's value
+        */
     public string? GetAttribute(string key);
 
     /**
-     * Set an arbitrary attribute.
-     *
-     * @param key is the attribute key
-     * @param val is the attribute value
-     */
+        * Set an arbitrary attribute.
+        * 
+        * @param key is the attribute key
+        * @param val is the attribute value
+        */
     public void SetAttribute(string key, string val);
 
     /**
-     * Start mining.
-     *
-     * @param numThreads is the number of threads Created for mining (optional)
-     * @param backgroundMining specifies if mining should occur in the background (optional)
-     * @param ignoreBattery specifies if the battery should be ignored for mining (optional)
-     */
+        * Start mining.
+        * 
+        * @param numThreads is the number of threads Created for mining (optional)
+        * @param backgroundMining specifies if mining should occur in the background (optional)
+        * @param ignoreBattery specifies if the battery should be ignored for mining (optional)
+        */
     public void StartMining(ulong numThreads, bool backgroundMining, bool ignoreBattery);
 
     /**
-     * Stop mining.
-     */
+        * Stop mining.
+        */
     public void StopMining();
 
     /**
-     * Indicates if importing multisig data is needed for returning a correct balance.
-     *
-     * @return true if importing multisig data is needed for returning a correct balance, false otherwise
-     */
+        * Indicates if importing multisig data is needed for returning a correct balance.
+        * 
+        * @return true if importing multisig data is needed for returning a correct balance, false otherwise
+        */
     public bool IsMultisigImportNeeded();
 
     /**
-     * Indicates if this wallet is a multisig wallet.
-     *
-     * @return true if this is a multisig wallet, false otherwise
-     */
+        * Indicates if this wallet is a multisig wallet.
+        * 
+        * @return true if this is a multisig wallet, false otherwise
+        */
     public bool IsMultisig();
 
     /**
-     * Get multisig info about this wallet.
-     *
-     * @return multisig info about this wallet
-     */
+        * Get multisig info about this wallet.
+        * 
+        * @return multisig info about this wallet
+        */
     public MoneroMultisigInfo GetMultisigInfo();
 
     /**
-     * Get multisig info as hex to share with participants to begin creating a
-     * multisig wallet.
-     *
-     * @return this wallet's multisig hex to share with participants
-     */
+        * Get multisig info as hex to share with participants to begin creating a
+        * multisig wallet.
+        * 
+        * @return this wallet's multisig hex to share with participants
+        */
     public string PrepareMultisig();
 
     /**
-     * Make this wallet multisig by importing multisig hex from participants.
-     *
-     * @param multisigHexes are multisig hex from each participant
-     * @param threshold is the number of signatures needed to sign transfers
-     * @param password is the wallet password
-     * @return this wallet's multisig hex to share with participants
-     */
+        * Make this wallet multisig by importing multisig hex from participants.
+        * 
+        * @param multisigHexes are multisig hex from each participant
+        * @param threshold is the number of signatures needed to sign transfers
+        * @param password is the wallet password
+        * @return this wallet's multisig hex to share with participants
+        */
     public string MakeMultisig(List<string> multisigHexes, int threshold, string password);
 
     /**
-     * Exchange multisig hex with participants in a M/N multisig wallet.
-     *
-     * This process must be repeated with participants exactly N-M times.
-     *
-     * @param multisigHexes are multisig hex from each participant
-     * @param password is the wallet's password // TODO monero-project: redundant? wallet is Created with password
-     * @return the result which has the multisig's address xor this wallet's multisig hex to share with participants iff not done
-     */
+        * Exchange multisig hex with participants in a M/N multisig wallet.
+        * 
+        * This process must be repeated with participants exactly N-M times.
+        * 
+        * @param multisigHexes are multisig hex from each participant
+        * @param password is the wallet's password // TODO monero-project: redundant? wallet is Created with password
+        * @return the result which has the multisig's address xor this wallet's multisig hex to share with participants iff not done
+        */
     public MoneroMultisigInitResult ExchangeMultisigKeys(List<string> multisigHexes, string password);
 
     /**
-     * Export this wallet's multisig info as hex for other participants.
-     *
-     * @return this wallet's multisig info as hex for other participants
-     */
+        * Export this wallet's multisig info as hex for other participants.
+        * 
+        * @return this wallet's multisig info as hex for other participants
+        */
     public string ExportMultisigHex();
 
     /**
-     * Import multisig info as hex from other participants.
-     *
-     * @param multisigHexes are multisig hex from each participant
-     * @return the number of outputs signed with the given multisig hex
-     */
+        * Import multisig info as hex from other participants.
+        * 
+        * @param multisigHexes are multisig hex from each participant
+        * @return the number of outputs signed with the given multisig hex
+        */
     public int ImportMultisigHex(List<string> multisigHexes);
 
     /**
-     * Sign multisig transactions from a multisig wallet.
-     *
-     * @param multisigTxHex represents unsigned multisig transactions as hex
-     * @return the result of signing the multisig transactions
-     */
+        * Sign multisig transactions from a multisig wallet.
+        * 
+        * @param multisigTxHex represents unsigned multisig transactions as hex
+        * @return the result of signing the multisig transactions
+        */
     public MoneroMultisigSignResult SignMultisigTxHex(string multisigTxHex);
 
     /**
-     * Submit signed multisig transactions from a multisig wallet.
-     *
-     * @param signedMultisigTxHex is signed multisig hex returned from signMultisigTxHex()
-     * @return the resulting transaction hashes
-     */
+        * Submit signed multisig transactions from a multisig wallet.
+        * 
+        * @param signedMultisigTxHex is signed multisig hex returned from signMultisigTxHex()
+        * @return the resulting transaction hashes
+        */
     public List<string> SubmitMultisigTxHex(string signedMultisigTxHex);
 
     /**
-     * Change the wallet password.
-     *
-     * @param oldPassword is the wallet's old password
-     * @param newPassword is the wallet's new password
-     */
+        * Change the wallet password.
+        * 
+        * @param oldPassword is the wallet's old password
+        * @param newPassword is the wallet's new password
+        */
     public void ChangePassword(string oldPassword, string newPassword);
 
     /**
-     * Save the wallet at its current path.
-     */
+        * Save the wallet at its current path.
+        */
     public void Save();
 
     /**
-     * Optionally save then close the wallet.
-     *
-     * @param save specifies if the wallet should be saved before being closed (default false)
-     */
+        * Optionally save then close the wallet.
+        *
+        * @param save specifies if the wallet should be saved before being closed (default false)
+        */
     public void Close(bool save = false);
 
     /**
-     * Indicates if this wallet is closed or not.
-     *
-     * @return true if the wallet is closed, false otherwise
-     */
+        * Indicates if this wallet is closed or not.
+        * 
+        * @return true if the wallet is closed, false otherwise
+        */
     public bool IsClosed();
 }

--- a/Monero/Wallet/MoneroWalletKeys.cs
+++ b/Monero/Wallet/MoneroWalletKeys.cs
@@ -22,7 +22,7 @@ public class MoneroWalletKeys : MoneroWalletDefault
 
     #region Override Base Methods
 
-    public override int AddAddressBookEntry(string address, string description)
+    public override uint AddAddressBookEntry(string address, string description)
     {
         throw new NotImplementedException("Not supported by keys only wallet");
     }
@@ -493,5 +493,4 @@ public class MoneroWalletKeys : MoneroWalletDefault
     }
 
     #endregion
-
 }

--- a/Monero/Wallet/MoneroWalletLight.cs
+++ b/Monero/Wallet/MoneroWalletLight.cs
@@ -7,7 +7,7 @@ public class MoneroWalletLight : MoneroWalletKeys
 {
     #region Override Base Methods
 
-    public override int AddAddressBookEntry(string address, string description)
+    public override uint AddAddressBookEntry(string address, string description)
     {
         throw new NotImplementedException("Not supported by monero-wallet-light");
     }


### PR DESCRIPTION
This PR contains

1. TestMoneroWalletCommon implementation, a base class to test a generic MoneroWallet instance.
2. TestMoneroWalletRpc implementation, wich extends TestMoneroWalletCommon for testing MoneroWalletRpc code.
3. Fixes to MoneroWalletRpc and data model in Monero.Wallet in order to pass TestMoneroWalletRpc tests.

The next PR will focus on consolidating the missing part of MoneroDaemonRpc, and enabling tests in TestMoneroDaemonRpc that depend on a MoneroWalletRpc instance.