### PR TITLE
Separate unit and integration tests

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -29,9 +29,12 @@ jobs:
       - name: Build
         run: dotnet build --no-restore
 
+      - name: Run unit tests
+        run: dotnet test Monero.UnitTests/Monero.UnitTests.csproj --no-build --logger:trx
+
       - name: Run integration tests
-        run: docker compose -f Monero.Test/docker-compose.yml run tests
+        run: docker compose -f Monero.IntegrationTests/docker-compose.yml run tests
     
       - name: Cleanup Docker containers
         if: always()
-        run: docker compose -f Monero.Test/docker-compose.yml down -v
+        run: docker compose -f Monero.IntegrationTests/docker-compose.yml down -v

--- a/Monero.IntegrationTests/Dockerfile
+++ b/Monero.IntegrationTests/Dockerfile
@@ -8,4 +8,4 @@ RUN dotnet restore
 
 RUN dotnet build --no-restore
 
-CMD ["dotnet", "test", "--filter", "TestMoneroUtils|TestMoneroRpcConnection|TestMoneroDaemonRpc", "--no-build", "--logger:trx"]
+CMD ["dotnet", "test", "--filter", "TestMoneroRpcConnection|TestMoneroDaemonRpc", "--no-build", "--logger:trx"]

--- a/Monero.IntegrationTests/Monero.IntegrationTests.csproj
+++ b/Monero.IntegrationTests/Monero.IntegrationTests.csproj
@@ -24,4 +24,8 @@
         <Using Include="Xunit"/>
     </ItemGroup>
 
+    <ItemGroup>
+      <Folder Include="TestResults\" />
+    </ItemGroup>
+
 </Project>

--- a/Monero.IntegrationTests/TestMoneroConnectionManager.cs
+++ b/Monero.IntegrationTests/TestMoneroConnectionManager.cs
@@ -1,8 +1,8 @@
 using Monero.Common;
-using Monero.Test.Utils;
+using Monero.IntegrationTests.Utils;
 using Monero.Wallet;
 
-namespace Monero.Test;
+namespace Monero.IntegrationTests;
 
 public class TestMoneroConnectionManager
 {

--- a/Monero.IntegrationTests/TestMoneroDaemonRpc.cs
+++ b/Monero.IntegrationTests/TestMoneroDaemonRpc.cs
@@ -3,11 +3,11 @@ using Microsoft.VisualBasic;
 using Monero.Common;
 using Monero.Daemon;
 using Monero.Daemon.Common;
-using Monero.Test.Utils;
+using Monero.IntegrationTests.Utils;
 using Monero.Wallet;
 using Monero.Wallet.Common;
 
-namespace Monero.Test;
+namespace Monero.IntegrationTests;
 
 public class MoneroDaemonRpcFixture : IDisposable
 {

--- a/Monero.IntegrationTests/TestMoneroRpcConnection.cs
+++ b/Monero.IntegrationTests/TestMoneroRpcConnection.cs
@@ -1,7 +1,7 @@
 using Monero.Common;
-using Monero.Test.Utils;
+using Monero.IntegrationTests.Utils;
 
-namespace Monero.Test;
+namespace Monero.IntegrationTests;
 
 public class TestMoneroRpcConnection
 {

--- a/Monero.IntegrationTests/TestMoneroWalletCommon.cs
+++ b/Monero.IntegrationTests/TestMoneroWalletCommon.cs
@@ -1,10 +1,10 @@
 using Monero.Common;
 using Monero.Daemon;
-using Monero.Test.Utils;
+using Monero.IntegrationTests.Utils;
 using Monero.Wallet;
 using Monero.Wallet.Common;
 
-namespace Monero.Test;
+namespace Monero.IntegrationTests;
 
 public abstract class TestMoneroWalletCommon
 {

--- a/Monero.IntegrationTests/TestMoneroWalletLight.cs
+++ b/Monero.IntegrationTests/TestMoneroWalletLight.cs
@@ -1,7 +1,7 @@
 using Monero.Wallet;
 using Monero.Wallet.Common;
 
-namespace Monero.Test;
+namespace Monero.IntegrationTests;
 
 public class TestMoneroWalletLight : TestMoneroWalletCommon
 {

--- a/Monero.IntegrationTests/TestMoneroWalletRpc.cs
+++ b/Monero.IntegrationTests/TestMoneroWalletRpc.cs
@@ -1,9 +1,9 @@
 using Monero.Common;
-using Monero.Test.Utils;
+using Monero.IntegrationTests.Utils;
 using Monero.Wallet;
 using Monero.Wallet.Common;
 
-namespace Monero.Test;
+namespace Monero.IntegrationTests;
 
 public class TestMoneroWalletRpc : TestMoneroWalletCommon
 {

--- a/Monero.IntegrationTests/Utils/StartMining.cs
+++ b/Monero.IntegrationTests/Utils/StartMining.cs
@@ -1,4 +1,4 @@
-namespace Monero.Test.Utils;
+namespace Monero.IntegrationTests.Utils;
 
 public static class StartMining
 {

--- a/Monero.IntegrationTests/Utils/StopMining.cs
+++ b/Monero.IntegrationTests/Utils/StopMining.cs
@@ -1,4 +1,4 @@
-namespace Monero.Test.Utils;
+namespace Monero.IntegrationTests.Utils;
 
 public static class StopMining
 {

--- a/Monero.IntegrationTests/Utils/TestUtils.cs
+++ b/Monero.IntegrationTests/Utils/TestUtils.cs
@@ -6,7 +6,7 @@ using Monero.Daemon.Common;
 using Monero.Wallet;
 using Monero.Wallet.Common;
 
-namespace Monero.Test.Utils;
+namespace Monero.IntegrationTests.Utils;
 
 internal abstract class TestUtils
 {

--- a/Monero.IntegrationTests/Utils/WalletTxTracker.cs
+++ b/Monero.IntegrationTests/Utils/WalletTxTracker.cs
@@ -4,7 +4,7 @@ using Monero.Daemon.Common;
 using Monero.Wallet;
 using Monero.Wallet.Common;
 
-namespace Monero.Test.Utils;
+namespace Monero.IntegrationTests.Utils;
 
 public class WalletTxTracker
 {

--- a/Monero.IntegrationTests/docker-compose.yml
+++ b/Monero.IntegrationTests/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   tests:
     build:
       context: ..
-      dockerfile: Monero.Test/Dockerfile
+      dockerfile: Monero.IntegrationTests/Dockerfile
     depends_on:
       - xmr_wallet
 

--- a/Monero.UnitTests/GlobalUsings.cs
+++ b/Monero.UnitTests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/Monero.UnitTests/Monero.UnitTests.csproj
+++ b/Monero.UnitTests/Monero.UnitTests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0"/>
+        <PackageReference Include="xunit" Version="2.4.2"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Monero\Monero.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Monero.UnitTests/TestMoneroUtils.cs
+++ b/Monero.UnitTests/TestMoneroUtils.cs
@@ -1,7 +1,7 @@
 using Monero.Common;
 using Monero.Wallet.Common;
 
-namespace Monero.Test;
+namespace Monero.UnitTests;
 
 public class TestMoneroUtils
 {

--- a/monero-csharp.sln
+++ b/monero-csharp.sln
@@ -5,7 +5,9 @@ VisualStudioVersion = 17.14.36202.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Monero", "Monero\Monero.csproj", "{DA177BA4-AA4F-48DB-8F0A-F15D04B84A5F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Monero.Test", "Monero.Test\Monero.Test.csproj", "{68899F01-BA02-4FAA-879D-93EAD566E0D1}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Monero.IntegrationTests", "Monero.IntegrationTests\Monero.IntegrationTests.csproj", "{68899F01-BA02-4FAA-879D-93EAD566E0D1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Monero.UnitTests", "Monero.UnitTests\Monero.UnitTests.csproj", "{E97E4D14-6039-4C80-A9EA-C1818B873F5A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{68899F01-BA02-4FAA-879D-93EAD566E0D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{68899F01-BA02-4FAA-879D-93EAD566E0D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{68899F01-BA02-4FAA-879D-93EAD566E0D1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E97E4D14-6039-4C80-A9EA-C1818B873F5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E97E4D14-6039-4C80-A9EA-C1818B873F5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E97E4D14-6039-4C80-A9EA-C1818B873F5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E97E4D14-6039-4C80-A9EA-C1818B873F5A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This PR separates Monero.Test into two new projects:

1. Monero.UnitTests, moved TestMoneroUtils there
2. Monero.IntegrationTests, moved all tests that require a monerod/wallet-rpc instance