### PR TITLE
Apply _camelcase/camelcase to private/static fields

### DIFF
--- a/Monero.IntegrationTests/TestMoneroDaemonRpc.cs
+++ b/Monero.IntegrationTests/TestMoneroDaemonRpc.cs
@@ -2026,9 +2026,9 @@ public class TestMoneroDaemonRpc : IClassFixture<MoneroDaemonRpcFixture>
             Assert.True(stats.GetBytesMed() > 0);
             Assert.True(stats.GetBytesMin() > 0);
             Assert.True(stats.GetBytesTotal() > 0);
-            Assert.True(stats.GetHisto98pc() == null || stats.GetHisto98pc() > 0);
+            Assert.True(stats.GetHisto98Pc() == null || stats.GetHisto98Pc() > 0);
             Assert.True(stats.GetOldestTimestamp() > 0);
-            Assert.True(stats.GetNum10m() >= 0);
+            Assert.True(stats.GetNum10M() >= 0);
             Assert.True(stats.GetNumDoubleSpends() >= 0);
             Assert.True(stats.GetNumFailing() >= 0);
             Assert.True(stats.GetNumNotRelayed() >= 0);
@@ -2039,9 +2039,9 @@ public class TestMoneroDaemonRpc : IClassFixture<MoneroDaemonRpcFixture>
             Assert.Null(stats.GetBytesMed());
             Assert.Null(stats.GetBytesMin());
             Assert.True(0 == (long)stats.GetBytesTotal());
-            Assert.Null(stats.GetHisto98pc());
+            Assert.Null(stats.GetHisto98Pc());
             Assert.Null(stats.GetOldestTimestamp());
-            Assert.True(0 == (int)stats.GetNum10m());
+            Assert.True(0 == (int)stats.GetNum10M());
             Assert.True(0 == (int)stats.GetNumDoubleSpends());
             Assert.True(0 == (int)stats.GetNumFailing());
             Assert.True(0 == (int)stats.GetNumNotRelayed());

--- a/Monero.IntegrationTests/TestMoneroWalletCommon.cs
+++ b/Monero.IntegrationTests/TestMoneroWalletCommon.cs
@@ -58,9 +58,9 @@ public abstract class TestMoneroWalletCommon
                 MoneroUtils.ValidatePrivateViewKey(moneroWallet.GetPrivateViewKey());
                 MoneroUtils.ValidatePrivateSpendKey(moneroWallet.GetPrivateSpendKey());
                 MoneroUtils.ValidateMnemonic(moneroWallet.GetSeed());
-                if (moneroWallet.GetWalletType() != MoneroWalletType.RPC)
+                if (moneroWallet.GetWalletType() != MoneroWalletType.Rpc)
                 {
-                    Assert.True(MoneroWallet.DEFAULT_LANGUAGE ==
+                    Assert.True(MoneroWallet.DefaultLanguage ==
                                 moneroWallet.GetSeedLanguage()); // TODO monero-wallet-rpc: get seed language
                 }
             }
@@ -132,9 +132,9 @@ public abstract class TestMoneroWalletCommon
                 Assert.True(privateViewKey == moneroWallet.GetPrivateViewKey());
                 Assert.True(privateSpendKey == moneroWallet.GetPrivateSpendKey());
                 Assert.True(TestUtils.SEED == moneroWallet.GetSeed());
-                if (moneroWallet.GetWalletType() != MoneroWalletType.RPC)
+                if (moneroWallet.GetWalletType() != MoneroWalletType.Rpc)
                 {
-                    Assert.True(MoneroWallet.DEFAULT_LANGUAGE == moneroWallet.GetSeedLanguage());
+                    Assert.True(MoneroWallet.DefaultLanguage == moneroWallet.GetSeedLanguage());
                 }
             }
             catch (Exception e)
@@ -201,9 +201,9 @@ public abstract class TestMoneroWalletCommon
                 Assert.True(TestUtils.SEED == moneroWallet.GetSeed());
                 MoneroUtils.ValidateAddress(moneroWallet.GetPrimaryAddress());
                 Assert.True(TestUtils.ADDRESS != moneroWallet.GetPrimaryAddress());
-                if (moneroWallet.GetWalletType() != MoneroWalletType.RPC)
+                if (moneroWallet.GetWalletType() != MoneroWalletType.Rpc)
                 {
-                    Assert.True(MoneroWallet.DEFAULT_LANGUAGE ==
+                    Assert.True(MoneroWallet.DefaultLanguage ==
                                 moneroWallet.GetSeedLanguage()); // TODO monero-wallet-rpc: support
                 }
             }
@@ -261,11 +261,11 @@ public abstract class TestMoneroWalletCommon
 
                 Assert.True(moneroWallet.IsConnectedToDaemon(),
                     "Wallet created from keys is not connected to authenticated daemon");
-                if (moneroWallet.GetWalletType() != MoneroWalletType.RPC)
+                if (moneroWallet.GetWalletType() != MoneroWalletType.Rpc)
                 {
                     MoneroUtils.ValidateMnemonic(moneroWallet
                         .GetSeed()); // TODO monero-wallet-rpc: cannot get seed from wallet created from keys?
-                    Assert.True(MoneroWallet.DEFAULT_LANGUAGE == moneroWallet.GetSeedLanguage());
+                    Assert.True(MoneroWallet.DefaultLanguage == moneroWallet.GetSeedLanguage());
                 }
             }
             catch (Exception e)
@@ -280,7 +280,7 @@ public abstract class TestMoneroWalletCommon
             }
 
             // recreate test wallet from spend key
-            if (moneroWallet.GetWalletType() != MoneroWalletType.RPC)
+            if (moneroWallet.GetWalletType() != MoneroWalletType.Rpc)
             {
                 // TODO monero-wallet-rpc: cannot create wallet from spend key?
                 moneroWallet = CreateWallet(new MoneroWalletConfig().SetPrivateSpendKey(privateSpendKey)
@@ -299,11 +299,11 @@ public abstract class TestMoneroWalletCommon
 
                     Assert.True(moneroWallet.IsConnectedToDaemon(),
                         "Wallet created from keys is not connected to authenticated daemon");
-                    if (moneroWallet.GetWalletType() != MoneroWalletType.RPC)
+                    if (moneroWallet.GetWalletType() != MoneroWalletType.Rpc)
                     {
                         MoneroUtils.ValidateMnemonic(moneroWallet
                             .GetSeed()); // TODO monero-wallet-rpc: cannot get seed from wallet created from keys?
-                        Assert.True(MoneroWallet.DEFAULT_LANGUAGE == moneroWallet.GetSeedLanguage());
+                        Assert.True(MoneroWallet.DefaultLanguage == moneroWallet.GetSeedLanguage());
                     }
                 }
                 catch (Exception e)
@@ -576,7 +576,7 @@ public abstract class TestMoneroWalletCommon
     {
         Assert.True(TEST_NON_RELAYS);
         string language = wallet.GetSeedLanguage();
-        Assert.True(MoneroWallet.DEFAULT_LANGUAGE == language);
+        Assert.True(MoneroWallet.DefaultLanguage == language);
     }
 
     // Can get a list of supported languages for the seed

--- a/Monero/Daemon/Common/MoneroAltChain.cs
+++ b/Monero/Daemon/Common/MoneroAltChain.cs
@@ -2,64 +2,64 @@ namespace Monero.Daemon.Common;
 
 public class MoneroAltChain
 {
-    private List<string>? blockHashes;
-    private ulong? difficulty;
-    private ulong? height;
-    private ulong? length;
-    private string? mainChainParentBlockHash;
+    private List<string>? _blockHashes;
+    private ulong? _difficulty;
+    private ulong? _height;
+    private ulong? _length;
+    private string? _mainChainParentBlockHash;
 
     public List<string>? GetBlockHashes()
     {
-        return blockHashes;
+        return _blockHashes;
     }
 
     public MoneroAltChain SetBlockHashes(List<string>? blockHashes)
     {
-        this.blockHashes = blockHashes;
+        this._blockHashes = blockHashes;
         return this;
     }
 
     public ulong? GetDifficulty()
     {
-        return difficulty;
+        return _difficulty;
     }
 
     public MoneroAltChain SetDifficulty(ulong? difficulty)
     {
-        this.difficulty = difficulty;
+        this._difficulty = difficulty;
         return this;
     }
 
     public ulong? GetHeight()
     {
-        return height;
+        return _height;
     }
 
     public MoneroAltChain SetHeight(ulong? height)
     {
-        this.height = height;
+        this._height = height;
         return this;
     }
 
     public ulong? GetLength()
     {
-        return length;
+        return _length;
     }
 
     public MoneroAltChain SetLength(ulong? length)
     {
-        this.length = length;
+        this._length = length;
         return this;
     }
 
     public string? GetMainChainParentBlockHash()
     {
-        return mainChainParentBlockHash;
+        return _mainChainParentBlockHash;
     }
 
     public MoneroAltChain SetMainChainParentBlockHash(string? mainChainParentBlockHash)
     {
-        this.mainChainParentBlockHash = mainChainParentBlockHash;
+        this._mainChainParentBlockHash = mainChainParentBlockHash;
         return this;
     }
 }

--- a/Monero/Daemon/Common/MoneroBan.cs
+++ b/Monero/Daemon/Common/MoneroBan.cs
@@ -2,52 +2,52 @@ namespace Monero.Daemon.Common;
 
 public class MoneroBan
 {
-    private string? host; // e.g. 192.168.1.100
-    private uint? ip; // integer formatted IP
-    private bool? isBanned;
-    private ulong? seconds;
+    private string? _host; // e.g. 192.168.1.100
+    private uint? _ip; // integer formatted IP
+    private bool? _isBanned;
+    private ulong? _seconds;
 
     public string? GetHost()
     {
-        return host;
+        return _host;
     }
 
     public MoneroBan SetHost(string? host)
     {
-        this.host = host;
+        this._host = host;
         return this;
     }
 
     public uint? GetIp()
     {
-        return ip;
+        return _ip;
     }
 
     public MoneroBan SetIp(uint? ip)
     {
-        this.ip = ip;
+        this._ip = ip;
         return this;
     }
 
     public bool? IsBanned()
     {
-        return isBanned;
+        return _isBanned;
     }
 
     public MoneroBan SetIsBanned(bool? isBanned)
     {
-        this.isBanned = isBanned;
+        this._isBanned = isBanned;
         return this;
     }
 
     public ulong? GetSeconds()
     {
-        return seconds;
+        return _seconds;
     }
 
     public MoneroBan SetSeconds(ulong? seconds)
     {
-        this.seconds = seconds;
+        this._seconds = seconds;
         return this;
     }
 }

--- a/Monero/Daemon/Common/MoneroBlockTemplate.cs
+++ b/Monero/Daemon/Common/MoneroBlockTemplate.cs
@@ -2,114 +2,114 @@ namespace Monero.Daemon.Common;
 
 public class MoneroBlockTemplate
 {
-    private string? blockHashingBlob;
-    private string? blockTemplateBlob;
-    private ulong? difficulty;
-    private ulong? expectedReward;
-    private ulong? height;
-    private string? nextSeedHash;
-    private string? prevHash;
-    private ulong? reservedOffset;
-    private string? seedHash;
-    private ulong? seedHeight;
+    private string? _blockHashingBlob;
+    private string? _blockTemplateBlob;
+    private ulong? _difficulty;
+    private ulong? _expectedReward;
+    private ulong? _height;
+    private string? _nextSeedHash;
+    private string? _prevHash;
+    private ulong? _reservedOffset;
+    private string? _seedHash;
+    private ulong? _seedHeight;
 
     public string? GetBlockTemplateBlob()
     {
-        return blockTemplateBlob;
+        return _blockTemplateBlob;
     }
 
     public void SetBlockTemplateBlob(string? blockTemplateBlob)
     {
-        this.blockTemplateBlob = blockTemplateBlob;
+        this._blockTemplateBlob = blockTemplateBlob;
     }
 
     public string? GetBlockHashingBlob()
     {
-        return blockHashingBlob;
+        return _blockHashingBlob;
     }
 
     public void SetBlockHashingBlob(string? blockHashingBlob)
     {
-        this.blockHashingBlob = blockHashingBlob;
+        this._blockHashingBlob = blockHashingBlob;
     }
 
     public ulong? GetDifficulty()
     {
-        return difficulty;
+        return _difficulty;
     }
 
     public void SetDifficulty(ulong? difficulty)
     {
-        this.difficulty = difficulty;
+        this._difficulty = difficulty;
     }
 
     public ulong? GetExpectedReward()
     {
-        return expectedReward;
+        return _expectedReward;
     }
 
     public void SetExpectedReward(ulong? expectedReward)
     {
-        this.expectedReward = expectedReward;
+        this._expectedReward = expectedReward;
     }
 
     public ulong? GetHeight()
     {
-        return height;
+        return _height;
     }
 
     public void SetHeight(ulong? height)
     {
-        this.height = height;
+        this._height = height;
     }
 
     public string? GetPrevHash()
     {
-        return prevHash;
+        return _prevHash;
     }
 
     public void SetPrevHash(string? prevHash)
     {
-        this.prevHash = prevHash;
+        this._prevHash = prevHash;
     }
 
     public ulong? GetReservedOffset()
     {
-        return reservedOffset;
+        return _reservedOffset;
     }
 
     public void SetReservedOffset(ulong? reservedOffset)
     {
-        this.reservedOffset = reservedOffset;
+        this._reservedOffset = reservedOffset;
     }
 
     public ulong? GetSeedHeight()
     {
-        return seedHeight;
+        return _seedHeight;
     }
 
     public void SetSeedHeight(ulong? seedHeight)
     {
-        this.seedHeight = seedHeight;
+        this._seedHeight = seedHeight;
     }
 
     public string? GetSeedHash()
     {
-        return seedHash;
+        return _seedHash;
     }
 
     public void SetSeedHash(string? seedHash)
     {
-        this.seedHash = seedHash;
+        this._seedHash = seedHash;
     }
 
     public string? GetNextSeedHash()
     {
-        return nextSeedHash;
+        return _nextSeedHash;
     }
 
     public void SetNextSeedHash(string? nextSeedHash)
     {
-        this.nextSeedHash = nextSeedHash;
+        this._nextSeedHash = nextSeedHash;
     }
 }

--- a/Monero/Daemon/Common/MoneroConnectionSpan.cs
+++ b/Monero/Daemon/Common/MoneroConnectionSpan.cs
@@ -2,81 +2,81 @@ namespace Monero.Daemon.Common;
 
 public class MoneroConnectionSpan
 {
-    private string? connectionId;
-    private ulong? numBlocks;
-    private ulong? rate;
-    private string? remoteAddress;
-    private ulong? size;
-    private ulong? speed;
-    private ulong? startHeight;
+    private string? _connectionId;
+    private ulong? _numBlocks;
+    private ulong? _rate;
+    private string? _remoteAddress;
+    private ulong? _size;
+    private ulong? _speed;
+    private ulong? _startHeight;
 
     public string? GetConnectionId()
     {
-        return connectionId;
+        return _connectionId;
     }
 
     public void SetConnectionId(string? connectionId)
     {
-        this.connectionId = connectionId;
+        this._connectionId = connectionId;
     }
 
     public ulong? GetNumBlocks()
     {
-        return numBlocks;
+        return _numBlocks;
     }
 
     public void SetNumBlocks(ulong? numBlocks)
     {
-        this.numBlocks = numBlocks;
+        this._numBlocks = numBlocks;
     }
 
     public string? GetRemoteAddress()
     {
-        return remoteAddress;
+        return _remoteAddress;
     }
 
     public void SetRemoteAddress(string? remoteAddress)
     {
-        this.remoteAddress = remoteAddress;
+        this._remoteAddress = remoteAddress;
     }
 
     public ulong? GetRate()
     {
-        return rate;
+        return _rate;
     }
 
     public void SetRate(ulong? rate)
     {
-        this.rate = rate;
+        this._rate = rate;
     }
 
     public ulong? GetSpeed()
     {
-        return speed;
+        return _speed;
     }
 
     public void SetSpeed(ulong? speed)
     {
-        this.speed = speed;
+        this._speed = speed;
     }
 
     public ulong? GetSize()
     {
-        return size;
+        return _size;
     }
 
     public void SetSize(ulong? size)
     {
-        this.size = size;
+        this._size = size;
     }
 
     public ulong? GetStartHeight()
     {
-        return startHeight;
+        return _startHeight;
     }
 
     public void SetStartHeight(ulong? startHeight)
     {
-        this.startHeight = startHeight;
+        this._startHeight = startHeight;
     }
 }

--- a/Monero/Daemon/Common/MoneroDaemonConfig.cs
+++ b/Monero/Daemon/Common/MoneroDaemonConfig.cs
@@ -4,1089 +4,1089 @@ namespace Monero.Daemon.Common;
 
 public class MoneroDaemonConfig
 {
-    private string? path;
-    private bool? allowLocalIp;
-    private string? banList;
-    private int? blockSyncSize;
-    private string? booststrapDaemonLogin;
-    private string? bootstrapDaemonAddress;
-    private bool? confirmExternalBind;
+    private string? _path;
+    private bool? _allowLocalIp;
+    private string? _banList;
+    private int? _blockSyncSize;
+    private string? _booststrapDaemonLogin;
+    private string? _bootstrapDaemonAddress;
+    private bool? _confirmExternalBind;
 
     // Server
-    private string? dataDir;
-    private string? dbSyncMode;
-    private bool? detach;
-    private bool? disableDnsCheckpoints;
-    private bool? disableRpcBan;
+    private string? _dataDir;
+    private string? _dbSyncMode;
+    private bool? _detach;
+    private bool? _disableDnsCheckpoints;
+    private bool? _disableRpcBan;
 
-    private bool? enableDnsBlocklist;
-    private bool? enforceDnsCheckpointing;
-    private List<string> exclusiveNodes = [];
-    private bool? fastBlockSync;
-    private bool? hideMyPort;
-    private string? i2pAnonymousInbound;
-    private string? i2pTxProxy;
-    private string? igd;
-    private List<string> inPeers = [];
-    private int? limitRate;
-    private int? limitRateDown;
-    private int? limitRateUp;
+    private bool? _enableDnsBlocklist;
+    private bool? _enforceDnsCheckpointing;
+    private List<string> _exclusiveNodes = [];
+    private bool? _fastBlockSync;
+    private bool? _hideMyPort;
+    private string? _i2PAnonymousInbound;
+    private string? _i2PTxProxy;
+    private string? _igd;
+    private List<string> _inPeers = [];
+    private int? _limitRate;
+    private int? _limitRateDown;
+    private int? _limitRateUp;
 
     // Log
-    private string? logFile;
-    private int? logLevel;
-    private int? maxConcurrency;
+    private string? _logFile;
+    private int? _logLevel;
+    private int? _maxConcurrency;
 
-    private int? maxConnectionsPerIp;
+    private int? _maxConnectionsPerIp;
 
-    private int? maxLogFiles;
-    private int? maxLogFileSize;
-    private ulong? maxTxPoolWeight;
+    private int? _maxLogFiles;
+    private int? _maxLogFileSize;
+    private ulong? _maxTxPoolWeight;
 
     // Network type
-    private MoneroNetworkType networkType = MoneroNetworkType.Mainnet;
-    private bool? noIgd;
-    private bool? nonInteractive;
-    private bool? noSync;
-    private bool? noZmq;
-    private bool? offline;
-    private List<string> outPeers = [];
+    private MoneroNetworkType _networkType = MoneroNetworkType.Mainnet;
+    private bool? _noIgd;
+    private bool? _nonInteractive;
+    private bool? _noSync;
+    private bool? _noZmq;
+    private bool? _offline;
+    private List<string> _outPeers = [];
 
-    // P2P Netwrork
-    private string? p2pBindIp;
-    private string? p2pBindIpv6Address;
-    private int? p2pBindPort;
-    private int? p2pBindPortIpv6;
-    private int? p2pExternalPort;
-    private bool? p2pIgnoreIpv4;
-    private bool? p2pUseIpv6;
-    private bool? padTransactions;
-    private List<string> peers = [];
-    private string? pidFile;
-    private int? prepBlocksThreads;
-    private List<string> priorityNodes = [];
+    // P2P Network
+    private string? _p2PBindIp;
+    private string? _p2PBindIpv6Address;
+    private int? _p2PBindPort;
+    private int? _p2PBindPortIpv6;
+    private int? _p2PExternalPort;
+    private bool? _p2PIgnoreIpv4;
+    private bool? _p2PUseIpv6;
+    private bool? _padTransactions;
+    private List<string> _peers = [];
+    private string? _pidFile;
+    private int? _prepBlocksThreads;
+    private List<string> _priorityNodes = [];
 
-    private string? proxy;
+    private string? _proxy;
 
     // Performance
-    private bool? pruneBlockchain;
+    private bool? _pruneBlockchain;
 
     // Node RPC API
-    private bool? publicNode;
+    private bool? _publicNode;
 
-    private bool? restrictedRpc;
-    private string? rpcAccessControlOrigins;
-    private string? rpcBindIp;
-    private string? rpcBindIpv6Address;
-    private int? rpcBindPort;
-    private bool? rpcIgnoreIpv4;
-    private string? rpcLogin;
-    private int? rpcMacConnectionsPerPrivateIp;
-    private int? rpcMaxConnections;
-    private int? rpcMaxConnectionsPerPublicIp;
-    private int? rpcMaxResponseSoftLimit;
-    private string? rpcRestrictedBindIp;
-    private string? rpcRestrictedBindIpv6Address;
-    private int? rpcRestrictedBindPort;
-    private string? rpcSsl;
-    private bool? rpcSslAllowAnyCert;
-    private bool? rpcSslAllowChained;
-    private List<string> rpcSslAllowedFingerprints = [];
-    private string? rpcSslCaCertificates;
-    private string? rpcSslCertificate;
-    private string? rpcSslPrivateKey;
-    private bool? rpcUseIpv6;
-    private string? seedNode;
-    private bool? syncPrunedBlocks;
-    private string? torAnonymousInbound;
+    private bool? _restrictedRpc;
+    private string? _rpcAccessControlOrigins;
+    private string? _rpcBindIp;
+    private string? _rpcBindIpv6Address;
+    private int? _rpcBindPort;
+    private bool? _rpcIgnoreIpv4;
+    private string? _rpcLogin;
+    private int? _rpcMacConnectionsPerPrivateIp;
+    private int? _rpcMaxConnections;
+    private int? _rpcMaxConnectionsPerPublicIp;
+    private int? _rpcMaxResponseSoftLimit;
+    private string? _rpcRestrictedBindIp;
+    private string? _rpcRestrictedBindIpv6Address;
+    private int? _rpcRestrictedBindPort;
+    private string? _rpcSsl;
+    private bool? _rpcSslAllowAnyCert;
+    private bool? _rpcSslAllowChained;
+    private List<string> _rpcSslAllowedFingerprints = [];
+    private string? _rpcSslCaCertificates;
+    private string? _rpcSslCertificate;
+    private string? _rpcSslPrivateKey;
+    private bool? _rpcUseIpv6;
+    private string? _seedNode;
+    private bool? _syncPrunedBlocks;
+    private string? _torAnonymousInbound;
 
     // Tor/I2P and proxies
-    private string? torTxProxy;
-    private string? zmqPub;
-    private string? zmqRpcBindIp;
-    private int? zmqRpcBindPort;
+    private string? _torTxProxy;
+    private string? _zmqPub;
+    private string? _zmqRpcBindIp;
+    private int? _zmqRpcBindPort;
 
     public string? GetPath()
     {
-        return path;
+        return _path;
     }
 
     public MoneroDaemonConfig SetPath(string? path)
     {
-        this.path = path;
+        this._path = path;
         return this;
     }
 
     public MoneroDaemonConfig SetNetworkType(MoneroNetworkType networkType)
     {
-        this.networkType = networkType;
+        this._networkType = networkType;
         return this;
     }
 
     public MoneroNetworkType GetNetworkType()
     {
-        return networkType;
+        return _networkType;
     }
 
     public MoneroDaemonConfig SetLogFile(string? logFile)
     {
-        this.logFile = logFile;
+        this._logFile = logFile;
         return this;
     }
 
     public string? GetLogFile()
     {
-        return logFile;
+        return _logFile;
     }
 
     public MoneroDaemonConfig SetLogLevel(int? logLevel)
     {
-        this.logLevel = logLevel;
+        this._logLevel = logLevel;
         return this;
     }
 
     public int? GetLogLevel()
     {
-        return logLevel;
+        return _logLevel;
     }
 
     public MoneroDaemonConfig SetMaxLogFileSize(int? maxLogFileSize)
     {
-        this.maxLogFileSize = maxLogFileSize;
+        this._maxLogFileSize = maxLogFileSize;
         return this;
     }
 
     public int? GetMaxLogFileSize()
     {
-        return maxLogFileSize;
+        return _maxLogFileSize;
     }
 
     public MoneroDaemonConfig SetMaxLogFiles(int? maxLogFiles)
     {
-        this.maxLogFiles = maxLogFiles;
+        this._maxLogFiles = maxLogFiles;
         return this;
     }
 
     public int? GetMaxLogFiles()
     {
-        return maxLogFiles;
+        return _maxLogFiles;
     }
 
     public MoneroDaemonConfig SetDataDir(string? dataDir)
     {
-        this.dataDir = dataDir;
+        this._dataDir = dataDir;
         return this;
     }
 
     public string? GetDataDir()
     {
-        return dataDir;
+        return _dataDir;
     }
 
     public MoneroDaemonConfig SetPidFile(string? pidFile)
     {
-        this.pidFile = pidFile;
+        this._pidFile = pidFile;
         return this;
     }
 
     public string? GetPidFile()
     {
-        return pidFile;
+        return _pidFile;
     }
 
     public MoneroDaemonConfig SetDetach(bool? detach)
     {
-        this.detach = detach;
+        this._detach = detach;
         return this;
     }
 
     public bool? GetDetach()
     {
-        return detach;
+        return _detach;
     }
 
     public MoneroDaemonConfig SetNonInteractive(bool? nonInteractive)
     {
-        this.nonInteractive = nonInteractive;
+        this._nonInteractive = nonInteractive;
         return this;
     }
 
     public bool? GetNonInteractive()
     {
-        return nonInteractive;
+        return _nonInteractive;
     }
 
     public MoneroDaemonConfig SetMaxTxPoolWeight(ulong? maxTxPoolWeight)
     {
-        this.maxTxPoolWeight = maxTxPoolWeight;
+        this._maxTxPoolWeight = maxTxPoolWeight;
         return this;
     }
 
     public ulong? GetMaxTxPoolWeight()
     {
-        return maxTxPoolWeight;
+        return _maxTxPoolWeight;
     }
 
     public MoneroDaemonConfig SetEnforceDnsCheckpointing(bool? enforceDnsCheckpointing)
     {
-        this.enforceDnsCheckpointing = enforceDnsCheckpointing;
+        this._enforceDnsCheckpointing = enforceDnsCheckpointing;
         return this;
     }
 
     public bool? GetEnforceDnsCheckpointing()
     {
-        return enforceDnsCheckpointing;
+        return _enforceDnsCheckpointing;
     }
 
     public MoneroDaemonConfig SetDisableDnsCheckpoints(bool? disableDnsCheckpoints)
     {
-        this.disableDnsCheckpoints = disableDnsCheckpoints;
+        this._disableDnsCheckpoints = disableDnsCheckpoints;
         return this;
     }
 
     public bool? GetDisableDnsCheckpoints()
     {
-        return disableDnsCheckpoints;
+        return _disableDnsCheckpoints;
     }
 
     public MoneroDaemonConfig SetBanList(string? banList)
     {
-        this.banList = banList;
+        this._banList = banList;
         return this;
     }
 
     public string? GetBanList()
     {
-        return banList;
+        return _banList;
     }
 
     public MoneroDaemonConfig SetEnabledDnsBlocklist(bool? enabledDnsBlocklist)
     {
-        enableDnsBlocklist = enabledDnsBlocklist;
+        _enableDnsBlocklist = enabledDnsBlocklist;
         return this;
     }
 
     public bool? GetEnabledDnsBlocklist()
     {
-        return enableDnsBlocklist;
+        return _enableDnsBlocklist;
     }
 
     public MoneroDaemonConfig SetP2pBindIp(string? p2pBindIp)
     {
-        this.p2pBindIp = p2pBindIp;
+        this._p2PBindIp = p2pBindIp;
         return this;
     }
 
     public string? GetP2pBindIp()
     {
-        return p2pBindIp;
+        return _p2PBindIp;
     }
 
     public MoneroDaemonConfig SetP2pBindPort(int? p2pBindPort)
     {
-        this.p2pBindPort = p2pBindPort;
+        this._p2PBindPort = p2pBindPort;
         return this;
     }
 
     public int? GetP2pBindPort()
     {
-        return p2pBindPort;
+        return _p2PBindPort;
     }
 
     public MoneroDaemonConfig SetP2pExternalPort(int? p2pExternalPort)
     {
-        this.p2pExternalPort = p2pExternalPort;
+        this._p2PExternalPort = p2pExternalPort;
         return this;
     }
 
     public int? GetP2pExternalPort()
     {
-        return p2pExternalPort;
+        return _p2PExternalPort;
     }
 
     public MoneroDaemonConfig SetP2pUseIpv6(bool? p2pUseIpv6)
     {
-        this.p2pUseIpv6 = p2pUseIpv6;
+        this._p2PUseIpv6 = p2pUseIpv6;
         return this;
     }
 
     public bool? GetP2pUseIpv6()
     {
-        return p2pUseIpv6;
+        return _p2PUseIpv6;
     }
 
     public MoneroDaemonConfig SetP2pBindIpv6Address(string? p2pBindIpv6Address)
     {
-        this.p2pBindIpv6Address = p2pBindIpv6Address;
+        this._p2PBindIpv6Address = p2pBindIpv6Address;
         return this;
     }
 
     public string? GetP2pBindIpv6Address()
     {
-        return p2pBindIpv6Address;
+        return _p2PBindIpv6Address;
     }
 
     public MoneroDaemonConfig SetP2pBindPortIpv6(int? p2pBindPortIpv6)
     {
-        this.p2pBindPortIpv6 = p2pBindPortIpv6;
+        this._p2PBindPortIpv6 = p2pBindPortIpv6;
         return this;
     }
 
     public int? GetP2pBindPortIpv6()
     {
-        return p2pBindPortIpv6;
+        return _p2PBindPortIpv6;
     }
 
     public MoneroDaemonConfig SetP2pIgnoreIpv4(bool? p2pIgnoreIpv4)
     {
-        this.p2pIgnoreIpv4 = p2pIgnoreIpv4;
+        this._p2PIgnoreIpv4 = p2pIgnoreIpv4;
         return this;
     }
 
     public bool? GetP2pIgnoreIpv4()
     {
-        return p2pIgnoreIpv4;
+        return _p2PIgnoreIpv4;
     }
 
     public MoneroDaemonConfig SetNoIgd(bool? noIgd)
     {
-        this.noIgd = noIgd;
+        this._noIgd = noIgd;
         return this;
     }
 
     public bool? GetNoIgd()
     {
-        return noIgd;
+        return _noIgd;
     }
 
     public MoneroDaemonConfig SetIgd(string? igd)
     {
-        this.igd = igd;
+        this._igd = igd;
         return this;
     }
 
     public string? GetIgd()
     {
-        return igd;
+        return _igd;
     }
 
     public MoneroDaemonConfig SetHideMyPort(bool? hideMyPort)
     {
-        this.hideMyPort = hideMyPort;
+        this._hideMyPort = hideMyPort;
         return this;
     }
 
     public bool? GetHideMyPort()
     {
-        return hideMyPort;
+        return _hideMyPort;
     }
 
     public MoneroDaemonConfig SetSeedNode(string? seedNode)
     {
-        this.seedNode = seedNode;
+        this._seedNode = seedNode;
         return this;
     }
 
     public string? GetSeedNode()
     {
-        return seedNode;
+        return _seedNode;
     }
 
     public MoneroDaemonConfig SetPeers(List<string> peers)
     {
-        this.peers = peers;
+        this._peers = peers;
         return this;
     }
 
     public List<string> GetPeers()
     {
-        return peers;
+        return _peers;
     }
 
     public MoneroDaemonConfig AddPeer(string peer)
     {
-        peers.Add(peer);
+        _peers.Add(peer);
         return this;
     }
 
     public MoneroDaemonConfig RemovePeer(string peer)
     {
-        peers.Remove(peer);
+        _peers.Remove(peer);
         return this;
     }
 
     public MoneroDaemonConfig RemoveAllPeers()
     {
-        peers.Clear();
+        _peers.Clear();
         return this;
     }
 
     public MoneroDaemonConfig SetPriorityNodes(List<string> priorityNodes)
     {
-        this.priorityNodes = priorityNodes;
+        this._priorityNodes = priorityNodes;
         return this;
     }
 
     public List<string> GetPriorityNodes()
     {
-        return priorityNodes;
+        return _priorityNodes;
     }
 
     public MoneroDaemonConfig AddPriorityNode(string priorityNode)
     {
-        priorityNodes.Add(priorityNode);
+        _priorityNodes.Add(priorityNode);
         return this;
     }
 
     public MoneroDaemonConfig RemovePriorityNode(string priorityNode)
     {
-        priorityNodes.Remove(priorityNode);
+        _priorityNodes.Remove(priorityNode);
         return this;
     }
 
     public MoneroDaemonConfig RemoveAllPriorityNodes()
     {
-        priorityNodes.Clear();
+        _priorityNodes.Clear();
         return this;
     }
 
     public MoneroDaemonConfig SetExclusiveNodes(List<string> exclusiveNodes)
     {
-        this.exclusiveNodes = exclusiveNodes;
+        this._exclusiveNodes = exclusiveNodes;
         return this;
     }
 
     public List<string> GetExclusiveNodes()
     {
-        return exclusiveNodes;
+        return _exclusiveNodes;
     }
 
     public MoneroDaemonConfig SetOutPeers(List<string> outPeers)
     {
-        this.outPeers = outPeers;
+        this._outPeers = outPeers;
         return this;
     }
 
     public MoneroDaemonConfig AddOutPeer(string outPeer)
     {
-        outPeers.Add(outPeer);
+        _outPeers.Add(outPeer);
         return this;
     }
 
     public MoneroDaemonConfig RemoveOutPeer(string outPeer)
     {
-        outPeers.Remove(outPeer);
+        _outPeers.Remove(outPeer);
         return this;
     }
 
     public MoneroDaemonConfig RemoveAllOutPeers()
     {
-        outPeers.Clear();
+        _outPeers.Clear();
         return this;
     }
 
     public List<string> GetOutPeers()
     {
-        return outPeers;
+        return _outPeers;
     }
 
     public MoneroDaemonConfig SetInPeers(List<string> inPeers)
     {
-        this.inPeers = inPeers;
+        this._inPeers = inPeers;
         return this;
     }
 
     public MoneroDaemonConfig AddInPeer(string inPeer)
     {
-        inPeers.Add(inPeer);
+        _inPeers.Add(inPeer);
         return this;
     }
 
     public MoneroDaemonConfig RemoveInPeer(string inPeer)
     {
-        inPeers.Remove(inPeer);
+        _inPeers.Remove(inPeer);
         return this;
     }
 
     public MoneroDaemonConfig RemoveAllInPeers()
     {
-        inPeers.Clear();
+        _inPeers.Clear();
         return this;
     }
 
     public List<string> GetInPeers()
     {
-        return inPeers;
+        return _inPeers;
     }
 
     public MoneroDaemonConfig SetLimitRateUp(int? limitRateUp)
     {
-        this.limitRateUp = limitRateUp;
+        this._limitRateUp = limitRateUp;
         return this;
     }
 
     public int? GetLimitRateUp()
     {
-        return limitRateUp;
+        return _limitRateUp;
     }
 
     public MoneroDaemonConfig SetLimitRateDown(int? limitRateDown)
     {
-        this.limitRateDown = limitRateDown;
+        this._limitRateDown = limitRateDown;
         return this;
     }
 
     public int? GetLimitRateDown()
     {
-        return limitRateDown;
+        return _limitRateDown;
     }
 
     public MoneroDaemonConfig SetLimitRate(int? limitRate)
     {
-        this.limitRate = limitRate;
+        this._limitRate = limitRate;
         return this;
     }
 
     public int? GetLimitRate()
     {
-        return limitRate;
+        return _limitRate;
     }
 
     public MoneroDaemonConfig SetOffline(bool? offline)
     {
-        this.offline = offline;
+        this._offline = offline;
         return this;
     }
 
     public bool? GetOffline()
     {
-        return offline;
+        return _offline;
     }
 
     public MoneroDaemonConfig SetAllowLocalIp(bool? allowLocalIp)
     {
-        this.allowLocalIp = allowLocalIp;
+        this._allowLocalIp = allowLocalIp;
         return this;
     }
 
     public bool? GetAllowLocalIp()
     {
-        return allowLocalIp;
+        return _allowLocalIp;
     }
 
     public MoneroDaemonConfig SetMaxConnectionsPerIp(int? maxConnectionsPerIp)
     {
-        this.maxConnectionsPerIp = maxConnectionsPerIp;
+        this._maxConnectionsPerIp = maxConnectionsPerIp;
         return this;
     }
 
     public int? GetMaxConnectionsPerIp()
     {
-        return maxConnectionsPerIp;
+        return _maxConnectionsPerIp;
     }
 
     public MoneroDaemonConfig SetTorTxProxy(string? torTxProxy)
     {
-        this.torTxProxy = torTxProxy;
+        this._torTxProxy = torTxProxy;
         return this;
     }
 
     public string? GetTorTxProxy()
     {
-        return torTxProxy;
+        return _torTxProxy;
     }
 
     public MoneroDaemonConfig SetTorAnonymousInbound(string? torAnonymousInbound)
     {
-        this.torAnonymousInbound = torAnonymousInbound;
+        this._torAnonymousInbound = torAnonymousInbound;
         return this;
     }
 
     public string? GetTorAnonymousInbound()
     {
-        return torAnonymousInbound;
+        return _torAnonymousInbound;
     }
 
     public MoneroDaemonConfig SetI2pTxProxy(string? i2pTxProxy)
     {
-        this.i2pTxProxy = i2pTxProxy;
+        this._i2PTxProxy = i2pTxProxy;
         return this;
     }
 
     public string? GetI2pTxProxy()
     {
-        return i2pTxProxy;
+        return _i2PTxProxy;
     }
 
     public MoneroDaemonConfig SetI2pAnonymousInbound(string? i2pAnonymousInbound)
     {
-        this.i2pAnonymousInbound = i2pAnonymousInbound;
+        this._i2PAnonymousInbound = i2pAnonymousInbound;
         return this;
     }
 
     public string? GetI2pAnonymousInbound()
     {
-        return i2pAnonymousInbound;
+        return _i2PAnonymousInbound;
     }
 
     public MoneroDaemonConfig SetPadTransactions(bool? padTransactions)
     {
-        this.padTransactions = padTransactions;
+        this._padTransactions = padTransactions;
         return this;
     }
 
     public bool? GetPadTransactions()
     {
-        return padTransactions;
+        return _padTransactions;
     }
 
     public MoneroDaemonConfig SetProxy(string? proxy)
     {
-        this.proxy = proxy;
+        this._proxy = proxy;
         return this;
     }
 
     public string? GetProxy()
     {
-        return proxy;
+        return _proxy;
     }
 
     public MoneroDaemonConfig SetPublicNode(bool? publicNode)
     {
-        this.publicNode = publicNode;
+        this._publicNode = publicNode;
         return this;
     }
 
     public bool? GetPublicNode()
     {
-        return publicNode;
+        return _publicNode;
     }
 
     public MoneroDaemonConfig SetRpcBindIp(string? rpcBindIp)
     {
-        this.rpcBindIp = rpcBindIp;
+        this._rpcBindIp = rpcBindIp;
         return this;
     }
 
     public string? GetRpcBindIp()
     {
-        return rpcBindIp;
+        return _rpcBindIp;
     }
 
     public MoneroDaemonConfig SetRpcBindPort(int? rpcBindPort)
     {
-        this.rpcBindPort = rpcBindPort;
+        this._rpcBindPort = rpcBindPort;
         return this;
     }
 
     public int? GetRpcBindPort()
     {
-        return rpcBindPort;
+        return _rpcBindPort;
     }
 
     public MoneroDaemonConfig SetRpcBindIpv6Address(string? rpcBindIpv6Address)
     {
-        this.rpcBindIpv6Address = rpcBindIpv6Address;
+        this._rpcBindIpv6Address = rpcBindIpv6Address;
         return this;
     }
 
     public string? GetRpcBindIpv6Address()
     {
-        return rpcBindIpv6Address;
+        return _rpcBindIpv6Address;
     }
 
     public MoneroDaemonConfig SetRpcUseIpv6(bool? rpcUseIpv6)
     {
-        this.rpcUseIpv6 = rpcUseIpv6;
+        this._rpcUseIpv6 = rpcUseIpv6;
         return this;
     }
 
     public bool? GetRpcUseIpv6()
     {
-        return rpcUseIpv6;
+        return _rpcUseIpv6;
     }
 
     public MoneroDaemonConfig SetRpcIgnoreIpv4(bool? rpcIgnoreIpv4)
     {
-        this.rpcIgnoreIpv4 = rpcIgnoreIpv4;
+        this._rpcIgnoreIpv4 = rpcIgnoreIpv4;
         return this;
     }
 
     public bool? GetRpcIgnoreIpv4()
     {
-        return rpcIgnoreIpv4;
+        return _rpcIgnoreIpv4;
     }
 
     public MoneroDaemonConfig SetRpcRestrictedBindIp(string? rpcRestrictedBindIp)
     {
-        this.rpcRestrictedBindIp = rpcRestrictedBindIp;
+        this._rpcRestrictedBindIp = rpcRestrictedBindIp;
         return this;
     }
 
     public string? GetRpcRestrictedBindIp()
     {
-        return rpcRestrictedBindIp;
+        return _rpcRestrictedBindIp;
     }
 
     public MoneroDaemonConfig SetRpcRestrictedBindPort(int? rpcRestrictedBindPort)
     {
-        this.rpcRestrictedBindPort = rpcRestrictedBindPort;
+        this._rpcRestrictedBindPort = rpcRestrictedBindPort;
         return this;
     }
 
     public int? GetRpcRestrictedBindPort()
     {
-        return rpcRestrictedBindPort;
+        return _rpcRestrictedBindPort;
     }
 
     public MoneroDaemonConfig SetRpcRestrictedBindIpv6Address(string? rpcRestrictedBindIpv6Address)
     {
-        this.rpcRestrictedBindIpv6Address = rpcRestrictedBindIpv6Address;
+        this._rpcRestrictedBindIpv6Address = rpcRestrictedBindIpv6Address;
         return this;
     }
 
     public string? GetRpcRestrictedBindIpv6Address()
     {
-        return rpcRestrictedBindIpv6Address;
+        return _rpcRestrictedBindIpv6Address;
     }
 
     public MoneroDaemonConfig SetRpcMaxConnections(int? rpcMaxConnections)
     {
-        this.rpcMaxConnections = rpcMaxConnections;
+        this._rpcMaxConnections = rpcMaxConnections;
         return this;
     }
 
     public int? GetRpcMaxConnections()
     {
-        return rpcMaxConnections;
+        return _rpcMaxConnections;
     }
 
     public MoneroDaemonConfig SetRpcMaxConnectionsPerPublicIp(int? rpcMaxConnectionsPerPublicIp)
     {
-        this.rpcMaxConnectionsPerPublicIp = rpcMaxConnectionsPerPublicIp;
+        this._rpcMaxConnectionsPerPublicIp = rpcMaxConnectionsPerPublicIp;
         return this;
     }
 
     public int? GetRpcMaxConnectionsPerPublicIp()
     {
-        return rpcMaxConnectionsPerPublicIp;
+        return _rpcMaxConnectionsPerPublicIp;
     }
 
     public MoneroDaemonConfig SetRpcMaxConnectionsPerPrivateIp(int? rpcMaxConnectionsPerPrivateIp)
     {
-        rpcMacConnectionsPerPrivateIp = rpcMaxConnectionsPerPrivateIp;
+        _rpcMacConnectionsPerPrivateIp = rpcMaxConnectionsPerPrivateIp;
         return this;
     }
 
     public int? GetRpcMaxConnectionsPerPrivateIp()
     {
-        return rpcMacConnectionsPerPrivateIp;
+        return _rpcMacConnectionsPerPrivateIp;
     }
 
     public MoneroDaemonConfig SetRpcMaxResponseSoftLimit(int? rpcMaxResponseSoftLimit)
     {
-        this.rpcMaxResponseSoftLimit = rpcMaxResponseSoftLimit;
+        this._rpcMaxResponseSoftLimit = rpcMaxResponseSoftLimit;
         return this;
     }
 
     public int? GetRpcMaxResponseSoftLimit()
     {
-        return rpcMaxResponseSoftLimit;
+        return _rpcMaxResponseSoftLimit;
     }
 
     public MoneroDaemonConfig SetRpcSsl(string? rpcSsl)
     {
-        this.rpcSsl = rpcSsl;
+        this._rpcSsl = rpcSsl;
         return this;
     }
 
     public string? GetRpcSsl()
     {
-        return rpcSsl;
+        return _rpcSsl;
     }
 
     public MoneroDaemonConfig SetRpcSslPrivateKey(string? rpcSslPrivateKey)
     {
-        this.rpcSslPrivateKey = rpcSslPrivateKey;
+        this._rpcSslPrivateKey = rpcSslPrivateKey;
         return this;
     }
 
     public string? GetRpcSslPrivateKey()
     {
-        return rpcSslPrivateKey;
+        return _rpcSslPrivateKey;
     }
 
     public MoneroDaemonConfig SetRpcSslCertificate(string? rpcSslCertificate)
     {
-        this.rpcSslCertificate = rpcSslCertificate;
+        this._rpcSslCertificate = rpcSslCertificate;
         return this;
     }
 
     public string? GetRpcSslCertificate()
     {
-        return rpcSslCertificate;
+        return _rpcSslCertificate;
     }
 
     public MoneroDaemonConfig SetRpcSslAllowedFingerprints(List<string> rpcSslAllowedFingerprints)
     {
-        this.rpcSslAllowedFingerprints = rpcSslAllowedFingerprints;
+        this._rpcSslAllowedFingerprints = rpcSslAllowedFingerprints;
         return this;
     }
 
     public List<string> GetRpcSslAllowedFingerprints()
     {
-        return rpcSslAllowedFingerprints;
+        return _rpcSslAllowedFingerprints;
     }
 
     public MoneroDaemonConfig SetRpcSslAllowAnyCert(bool? rpcSslAllowAnyCert)
     {
-        this.rpcSslAllowAnyCert = rpcSslAllowAnyCert;
+        this._rpcSslAllowAnyCert = rpcSslAllowAnyCert;
         return this;
     }
 
     public bool? GetRpcSslAllowAnyCert()
     {
-        return rpcSslAllowAnyCert;
+        return _rpcSslAllowAnyCert;
     }
 
     public MoneroDaemonConfig SetRpcSslCaCertificates(string? rpcSslCaCertificates)
     {
-        this.rpcSslCaCertificates = rpcSslCaCertificates;
+        this._rpcSslCaCertificates = rpcSslCaCertificates;
         return this;
     }
 
     public string? GetRpcSslCaCertificates()
     {
-        return rpcSslCaCertificates;
+        return _rpcSslCaCertificates;
     }
 
     public MoneroDaemonConfig SetRpcSslAllowChained(bool? rpcSslAllowChained)
     {
-        this.rpcSslAllowChained = rpcSslAllowChained;
+        this._rpcSslAllowChained = rpcSslAllowChained;
         return this;
     }
 
     public bool? GetRpcSslAllowChained()
     {
-        return rpcSslAllowChained;
+        return _rpcSslAllowChained;
     }
 
     public MoneroDaemonConfig SetRpcLogin(string? rpcLogin)
     {
-        this.rpcLogin = rpcLogin;
+        this._rpcLogin = rpcLogin;
         return this;
     }
 
     public string? GetRpcLogin()
     {
-        return rpcLogin;
+        return _rpcLogin;
     }
 
     public MoneroDaemonConfig SetRpcAccessControlOrigins(string? rpcAccessControlOrigins)
     {
-        this.rpcAccessControlOrigins = rpcAccessControlOrigins;
+        this._rpcAccessControlOrigins = rpcAccessControlOrigins;
         return this;
     }
 
     public string? GetRpcAccessControlOrigins()
     {
-        return rpcAccessControlOrigins;
+        return _rpcAccessControlOrigins;
     }
 
     public MoneroDaemonConfig SetDisableRpcBan(bool? disableRpcBan)
     {
-        this.disableRpcBan = disableRpcBan;
+        this._disableRpcBan = disableRpcBan;
         return this;
     }
 
     public bool? GetDisableRpcBan()
     {
-        return disableRpcBan;
+        return _disableRpcBan;
     }
 
     public MoneroDaemonConfig SetZmqRpcBindIp(string? zmqRpcBindIp)
     {
-        this.zmqRpcBindIp = zmqRpcBindIp;
+        this._zmqRpcBindIp = zmqRpcBindIp;
         return this;
     }
 
     public string? GetZmqRpcBindIp()
     {
-        return zmqRpcBindIp;
+        return _zmqRpcBindIp;
     }
 
     public MoneroDaemonConfig SetZmqRpcBindPort(int? zmqRpcBindPort)
     {
-        this.zmqRpcBindPort = zmqRpcBindPort;
+        this._zmqRpcBindPort = zmqRpcBindPort;
         return this;
     }
 
     public int? GetZmqRpcBindPort()
     {
-        return zmqRpcBindPort;
+        return _zmqRpcBindPort;
     }
 
     public MoneroDaemonConfig SetZmqPub(string? zmqPub)
     {
-        this.zmqPub = zmqPub;
+        this._zmqPub = zmqPub;
         return this;
     }
 
     public string? GetZmqPub()
     {
-        return zmqPub;
+        return _zmqPub;
     }
 
     public MoneroDaemonConfig SetNoZmq(bool? noZmq)
     {
-        this.noZmq = noZmq;
+        this._noZmq = noZmq;
         return this;
     }
 
     public bool? GetNoZmq()
     {
-        return noZmq;
+        return _noZmq;
     }
 
     public MoneroDaemonConfig SetConfirmExternalBind(bool? confirmExternalBind)
     {
-        this.confirmExternalBind = confirmExternalBind;
+        this._confirmExternalBind = confirmExternalBind;
         return this;
     }
 
     public bool? GetConfirmExternalBind()
     {
-        return confirmExternalBind;
+        return _confirmExternalBind;
     }
 
     public MoneroDaemonConfig SetRestrictedRpc(bool? restrictedRpc)
     {
-        this.restrictedRpc = restrictedRpc;
+        this._restrictedRpc = restrictedRpc;
         return this;
     }
 
     public bool? GetRestrictedRpc()
     {
-        return restrictedRpc;
+        return _restrictedRpc;
     }
 
     public MoneroDaemonConfig SetPruneBlockchain(bool? pruneBlockchain)
     {
-        this.pruneBlockchain = pruneBlockchain;
+        this._pruneBlockchain = pruneBlockchain;
         return this;
     }
 
     public bool? GetPruneBlockchain()
     {
-        return pruneBlockchain;
+        return _pruneBlockchain;
     }
 
     public MoneroDaemonConfig SetSyncPrunedBlocks(bool? syncPrunedBlocks)
     {
-        this.syncPrunedBlocks = syncPrunedBlocks;
+        this._syncPrunedBlocks = syncPrunedBlocks;
         return this;
     }
 
     public bool? GetSyncPrunedBlocks()
     {
-        return syncPrunedBlocks;
+        return _syncPrunedBlocks;
     }
 
     public MoneroDaemonConfig SetDbSyncMode(string? dbSyncMode)
     {
-        this.dbSyncMode = dbSyncMode;
+        this._dbSyncMode = dbSyncMode;
         return this;
     }
 
     public string? GetDbSyncMode()
     {
-        return dbSyncMode;
+        return _dbSyncMode;
     }
 
     public MoneroDaemonConfig SetMaxConcurrency(int? maxConcurrency)
     {
-        this.maxConcurrency = maxConcurrency;
+        this._maxConcurrency = maxConcurrency;
         return this;
     }
 
     public int? GetMaxConcurrency()
     {
-        return maxConcurrency;
+        return _maxConcurrency;
     }
 
     public MoneroDaemonConfig SetPrepBlocksThreads(int? prepBlocksThreads)
     {
-        this.prepBlocksThreads = prepBlocksThreads;
+        this._prepBlocksThreads = prepBlocksThreads;
         return this;
     }
 
     public int? GetPrepBlocksThreads()
     {
-        return prepBlocksThreads;
+        return _prepBlocksThreads;
     }
 
     public MoneroDaemonConfig SetFastBlockSync(bool? fastBlockSync)
     {
-        this.fastBlockSync = fastBlockSync;
+        this._fastBlockSync = fastBlockSync;
         return this;
     }
 
     public bool? GetFastBlockSync()
     {
-        return fastBlockSync;
+        return _fastBlockSync;
     }
 
     public MoneroDaemonConfig SetBlockSyncSize(int? blockSyncSize)
     {
-        this.blockSyncSize = blockSyncSize;
+        this._blockSyncSize = blockSyncSize;
         return this;
     }
 
     public int? GetBlockSyncSize()
     {
-        return blockSyncSize;
+        return _blockSyncSize;
     }
 
     public MoneroDaemonConfig SetBootstrapDaemonAddress(string? bootstrapDaemonAddress)
     {
-        this.bootstrapDaemonAddress = bootstrapDaemonAddress;
+        this._bootstrapDaemonAddress = bootstrapDaemonAddress;
         return this;
     }
 
     public string? GetBootstrapDaemonAddress()
     {
-        return bootstrapDaemonAddress;
+        return _bootstrapDaemonAddress;
     }
 
     public MoneroDaemonConfig SetBootstrapDaemonLogin(string? booststrapDaemonLogin)
     {
-        this.booststrapDaemonLogin = booststrapDaemonLogin;
+        this._booststrapDaemonLogin = booststrapDaemonLogin;
         return this;
     }
 
     public string? GetBootstrapDaemonLogin()
     {
-        return booststrapDaemonLogin;
+        return _booststrapDaemonLogin;
     }
 
     public MoneroDaemonConfig SetNoSync(bool? noSync)
     {
-        this.noSync = noSync;
+        this._noSync = noSync;
         return this;
     }
 
     public bool? GetNoSync()
     {
-        return noSync;
+        return _noSync;
     }
 
     public List<string> ToCommandList()
     {
         List<string> cmd = [];
 
-        if (!string.IsNullOrEmpty(path))
+        if (!string.IsNullOrEmpty(_path))
         {
-            cmd.Add(path);
+            cmd.Add(_path);
         }
 
         MoneroNetworkType moneroNetworkType = GetNetworkType();
@@ -1100,475 +1100,475 @@ public class MoneroDaemonConfig
             cmd.Add("--stagenet");
         }
 
-        if (!string.IsNullOrEmpty(logFile))
+        if (!string.IsNullOrEmpty(_logFile))
         {
             cmd.Add("--log-file");
-            cmd.Add(logFile);
+            cmd.Add(_logFile);
         }
 
-        if (logLevel != null)
+        if (_logLevel != null)
         {
             cmd.Add("--log-level");
-            cmd.Add(((int)logLevel).ToString());
+            cmd.Add(((int)_logLevel).ToString());
         }
 
-        if (maxLogFileSize != null)
+        if (_maxLogFileSize != null)
         {
             cmd.Add("--max-log-file-size");
-            cmd.Add(((int)maxLogFileSize).ToString());
+            cmd.Add(((int)_maxLogFileSize).ToString());
         }
 
-        if (maxLogFiles != null)
+        if (_maxLogFiles != null)
         {
             cmd.Add("--max-log-files");
-            cmd.Add(((int)maxLogFiles).ToString());
+            cmd.Add(((int)_maxLogFiles).ToString());
         }
 
-        if (!string.IsNullOrEmpty(dataDir))
+        if (!string.IsNullOrEmpty(_dataDir))
         {
             cmd.Add("--data-dir");
-            cmd.Add(dataDir);
+            cmd.Add(_dataDir);
         }
 
-        if (!string.IsNullOrEmpty(pidFile))
+        if (!string.IsNullOrEmpty(_pidFile))
         {
             cmd.Add("--pid-file");
-            cmd.Add(pidFile);
+            cmd.Add(_pidFile);
         }
 
-        if (detach == true)
+        if (_detach == true)
         {
             cmd.Add("--detach");
         }
 
-        if (nonInteractive == true)
+        if (_nonInteractive == true)
         {
             cmd.Add("--non-interactive");
         }
 
-        if (maxTxPoolWeight != null)
+        if (_maxTxPoolWeight != null)
         {
             cmd.Add("--max-txpool-weight");
-            cmd.Add(((int)maxTxPoolWeight).ToString());
+            cmd.Add(((int)_maxTxPoolWeight).ToString());
         }
 
-        if (enforceDnsCheckpointing == true)
+        if (_enforceDnsCheckpointing == true)
         {
             cmd.Add("--enforce-dns-checkpointing");
         }
 
-        if (disableDnsCheckpoints == true)
+        if (_disableDnsCheckpoints == true)
         {
             cmd.Add("--disable-dns-checkpoints");
         }
 
-        if (!string.IsNullOrEmpty(banList))
+        if (!string.IsNullOrEmpty(_banList))
         {
             cmd.Add("--ban-list");
-            cmd.Add(banList);
+            cmd.Add(_banList);
         }
 
-        if (enableDnsBlocklist == true)
+        if (_enableDnsBlocklist == true)
         {
             cmd.Add("--enable-dns-blocklist");
         }
 
-        if (!string.IsNullOrEmpty(p2pBindIp))
+        if (!string.IsNullOrEmpty(_p2PBindIp))
         {
             cmd.Add("--p2p-bind-ip");
-            cmd.Add(p2pBindIp);
+            cmd.Add(_p2PBindIp);
         }
 
-        if (p2pBindPort != null && p2pBindPort >= 0)
+        if (_p2PBindPort != null && _p2PBindPort >= 0)
         {
             cmd.Add("--p2p-bind-port");
-            cmd.Add(((int)p2pBindPort).ToString());
+            cmd.Add(((int)_p2PBindPort).ToString());
         }
 
-        if (p2pExternalPort != null && p2pExternalPort >= 0)
+        if (_p2PExternalPort != null && _p2PExternalPort >= 0)
         {
             cmd.Add("--p2p-external-port");
-            cmd.Add(((int)p2pExternalPort).ToString());
+            cmd.Add(((int)_p2PExternalPort).ToString());
         }
 
-        if (p2pUseIpv6 == true)
+        if (_p2PUseIpv6 == true)
         {
             cmd.Add("--p2p-use-ipv6");
         }
 
-        if (!string.IsNullOrEmpty(p2pBindIpv6Address))
+        if (!string.IsNullOrEmpty(_p2PBindIpv6Address))
         {
             cmd.Add("--p2p-bind-ipv6-address");
-            cmd.Add(p2pBindIpv6Address);
+            cmd.Add(_p2PBindIpv6Address);
         }
 
-        if (p2pBindPortIpv6 != null && p2pBindPortIpv6 >= 0)
+        if (_p2PBindPortIpv6 != null && _p2PBindPortIpv6 >= 0)
         {
             cmd.Add("--p2p-bind-port-ipv6");
-            cmd.Add(((int)p2pBindPortIpv6).ToString());
+            cmd.Add(((int)_p2PBindPortIpv6).ToString());
         }
 
-        if (p2pIgnoreIpv4 == true)
+        if (_p2PIgnoreIpv4 == true)
         {
             cmd.Add("--p2p-ignore-ipv4");
         }
 
-        if (noIgd == true)
+        if (_noIgd == true)
         {
             cmd.Add("--no-igd");
         }
 
-        if (!string.IsNullOrEmpty(igd))
+        if (!string.IsNullOrEmpty(_igd))
         {
             cmd.Add("--igd");
-            cmd.Add(igd);
+            cmd.Add(_igd);
         }
 
-        if (hideMyPort == true)
+        if (_hideMyPort == true)
         {
             cmd.Add("--hide-my-port");
         }
 
-        if (!string.IsNullOrEmpty(seedNode))
+        if (!string.IsNullOrEmpty(_seedNode))
         {
             cmd.Add("--seed-node");
-            cmd.Add(seedNode);
+            cmd.Add(_seedNode);
         }
 
-        if (peers.Count > 0)
+        if (_peers.Count > 0)
         {
-            foreach (string peer in peers)
+            foreach (string peer in _peers)
             {
                 cmd.Add("--peer");
                 cmd.Add(peer);
             }
         }
 
-        if (priorityNodes.Count > 0)
+        if (_priorityNodes.Count > 0)
         {
-            foreach (string priorityNode in priorityNodes)
+            foreach (string priorityNode in _priorityNodes)
             {
                 cmd.Add("--priority-node");
                 cmd.Add(priorityNode);
             }
         }
 
-        if (exclusiveNodes.Count > 0)
+        if (_exclusiveNodes.Count > 0)
         {
-            foreach (string exclusiveNode in exclusiveNodes)
+            foreach (string exclusiveNode in _exclusiveNodes)
             {
                 cmd.Add("--exclusive-node");
                 cmd.Add(exclusiveNode);
             }
         }
 
-        if (outPeers.Count > 0)
+        if (_outPeers.Count > 0)
         {
-            foreach (string outPeer in outPeers)
+            foreach (string outPeer in _outPeers)
             {
                 cmd.Add("--out-peers");
                 cmd.Add(outPeer);
             }
         }
 
-        if (inPeers.Count > 0)
+        if (_inPeers.Count > 0)
         {
-            foreach (string inPeer in inPeers)
+            foreach (string inPeer in _inPeers)
             {
                 cmd.Add("--in-peers");
                 cmd.Add(inPeer);
             }
         }
 
-        if (limitRateUp != null && limitRateUp >= 0)
+        if (_limitRateUp != null && _limitRateUp >= 0)
         {
             cmd.Add("--limit-rate-up");
-            cmd.Add(((int)limitRateUp).ToString());
+            cmd.Add(((int)_limitRateUp).ToString());
         }
 
-        if (limitRateDown != null && limitRateDown >= 0)
+        if (_limitRateDown != null && _limitRateDown >= 0)
         {
             cmd.Add("--limit-rate-down");
-            cmd.Add(((int)limitRateDown).ToString());
+            cmd.Add(((int)_limitRateDown).ToString());
         }
 
-        if (limitRate != null && limitRate >= 0)
+        if (_limitRate != null && _limitRate >= 0)
         {
             cmd.Add("--limit-rate");
-            cmd.Add(((int)limitRate).ToString());
+            cmd.Add(((int)_limitRate).ToString());
         }
 
-        if (offline == true)
+        if (_offline == true)
         {
             cmd.Add("--offline");
         }
 
-        if (allowLocalIp == true)
+        if (_allowLocalIp == true)
         {
             cmd.Add("--allow-local-ip");
         }
 
-        if (maxConnectionsPerIp != null && maxConnectionsPerIp >= 0)
+        if (_maxConnectionsPerIp != null && _maxConnectionsPerIp >= 0)
         {
             cmd.Add("--max-connections-per-ip");
-            cmd.Add(((int)maxConnectionsPerIp).ToString());
+            cmd.Add(((int)_maxConnectionsPerIp).ToString());
         }
 
-        if (!string.IsNullOrEmpty(torTxProxy))
+        if (!string.IsNullOrEmpty(_torTxProxy))
         {
             cmd.Add("--tx-proxy");
-            cmd.Add(torTxProxy);
+            cmd.Add(_torTxProxy);
         }
 
-        if (!string.IsNullOrEmpty(torAnonymousInbound))
+        if (!string.IsNullOrEmpty(_torAnonymousInbound))
         {
             cmd.Add("--anonymous-inbound");
-            cmd.Add(torAnonymousInbound);
+            cmd.Add(_torAnonymousInbound);
         }
 
-        if (!string.IsNullOrEmpty(i2pTxProxy))
+        if (!string.IsNullOrEmpty(_i2PTxProxy))
         {
             cmd.Add("--tx-proxy");
-            cmd.Add(i2pTxProxy);
+            cmd.Add(_i2PTxProxy);
         }
 
-        if (!string.IsNullOrEmpty(i2pAnonymousInbound))
+        if (!string.IsNullOrEmpty(_i2PAnonymousInbound))
         {
             cmd.Add("--anonymous-inbound");
-            cmd.Add(i2pAnonymousInbound);
+            cmd.Add(_i2PAnonymousInbound);
         }
 
-        if (padTransactions == true)
+        if (_padTransactions == true)
         {
             cmd.Add("--pad-transactions");
         }
 
-        if (!string.IsNullOrEmpty(proxy))
+        if (!string.IsNullOrEmpty(_proxy))
         {
             cmd.Add("--proxy");
-            cmd.Add(proxy);
+            cmd.Add(_proxy);
         }
 
-        if (publicNode == true)
+        if (_publicNode == true)
         {
             cmd.Add("--public-node");
         }
 
-        if (!string.IsNullOrEmpty(rpcBindIp))
+        if (!string.IsNullOrEmpty(_rpcBindIp))
         {
             cmd.Add("--rpc-bind-ip");
-            cmd.Add(rpcBindIp);
+            cmd.Add(_rpcBindIp);
         }
 
-        if (rpcBindPort != null && rpcBindPort >= 0)
+        if (_rpcBindPort != null && _rpcBindPort >= 0)
         {
             cmd.Add("--rpc-bind-port");
-            cmd.Add(((int)rpcBindPort).ToString());
+            cmd.Add(((int)_rpcBindPort).ToString());
         }
 
-        if (!string.IsNullOrEmpty(rpcBindIpv6Address))
+        if (!string.IsNullOrEmpty(_rpcBindIpv6Address))
         {
             cmd.Add("--rpc-bind-ipv6-address");
-            cmd.Add(rpcBindIpv6Address);
+            cmd.Add(_rpcBindIpv6Address);
         }
 
-        if (rpcUseIpv6 == true)
+        if (_rpcUseIpv6 == true)
         {
             cmd.Add("--rpc-use-ipv6");
         }
 
-        if (rpcIgnoreIpv4 == true)
+        if (_rpcIgnoreIpv4 == true)
         {
             cmd.Add("--rpc-ignore-ipv4");
         }
 
-        if (!string.IsNullOrEmpty(rpcRestrictedBindIp))
+        if (!string.IsNullOrEmpty(_rpcRestrictedBindIp))
         {
             cmd.Add("--rpc-restricted-bind-ip");
-            cmd.Add(rpcRestrictedBindIp);
+            cmd.Add(_rpcRestrictedBindIp);
         }
 
-        if (rpcRestrictedBindPort != null && rpcRestrictedBindPort >= 0)
+        if (_rpcRestrictedBindPort != null && _rpcRestrictedBindPort >= 0)
         {
             cmd.Add("--rpc-restricted-bind-port");
-            cmd.Add(((int)rpcRestrictedBindPort).ToString());
+            cmd.Add(((int)_rpcRestrictedBindPort).ToString());
         }
 
-        if (!string.IsNullOrEmpty(rpcRestrictedBindIpv6Address))
+        if (!string.IsNullOrEmpty(_rpcRestrictedBindIpv6Address))
         {
             cmd.Add("--rpc-restricted-bind-ipv6-address");
-            cmd.Add(rpcRestrictedBindIpv6Address);
+            cmd.Add(_rpcRestrictedBindIpv6Address);
         }
 
-        if (rpcMaxConnections != null && rpcMaxConnections >= 0)
+        if (_rpcMaxConnections != null && _rpcMaxConnections >= 0)
         {
             cmd.Add("--rpc-max-connections");
-            cmd.Add(((int)rpcMaxConnections).ToString());
+            cmd.Add(((int)_rpcMaxConnections).ToString());
         }
 
-        if (rpcMaxConnectionsPerPublicIp != null && rpcMaxConnectionsPerPublicIp >= 0)
+        if (_rpcMaxConnectionsPerPublicIp != null && _rpcMaxConnectionsPerPublicIp >= 0)
         {
             cmd.Add("--rpc-max-connections-per-public-ip");
-            cmd.Add(((int)rpcMaxConnectionsPerPublicIp).ToString());
+            cmd.Add(((int)_rpcMaxConnectionsPerPublicIp).ToString());
         }
 
-        if (rpcMacConnectionsPerPrivateIp != null && rpcMacConnectionsPerPrivateIp >= 0)
+        if (_rpcMacConnectionsPerPrivateIp != null && _rpcMacConnectionsPerPrivateIp >= 0)
         {
             cmd.Add("--rpc-max-connections-per-private-ip");
-            cmd.Add(((int)rpcMacConnectionsPerPrivateIp).ToString());
+            cmd.Add(((int)_rpcMacConnectionsPerPrivateIp).ToString());
         }
 
-        if (rpcMaxResponseSoftLimit != null && rpcMaxResponseSoftLimit >= 0)
+        if (_rpcMaxResponseSoftLimit != null && _rpcMaxResponseSoftLimit >= 0)
         {
             cmd.Add("--rpc-max-response-soft-limit");
-            cmd.Add(((int)rpcMaxResponseSoftLimit).ToString());
+            cmd.Add(((int)_rpcMaxResponseSoftLimit).ToString());
         }
 
-        if (!string.IsNullOrEmpty(rpcSsl))
+        if (!string.IsNullOrEmpty(_rpcSsl))
         {
             cmd.Add("--rpc-ssl");
-            cmd.Add(rpcSsl);
+            cmd.Add(_rpcSsl);
         }
 
-        if (!string.IsNullOrEmpty(rpcSslPrivateKey))
+        if (!string.IsNullOrEmpty(_rpcSslPrivateKey))
         {
             cmd.Add("--rpc-ssl-private-key");
-            cmd.Add(rpcSslPrivateKey);
+            cmd.Add(_rpcSslPrivateKey);
         }
 
-        if (!string.IsNullOrEmpty(rpcSslCertificate))
+        if (!string.IsNullOrEmpty(_rpcSslCertificate))
         {
             cmd.Add("--rpc-ssl-certificate");
-            cmd.Add(rpcSslCertificate);
+            cmd.Add(_rpcSslCertificate);
         }
 
-        if (rpcSslAllowedFingerprints.Count > 0)
+        if (_rpcSslAllowedFingerprints.Count > 0)
         {
-            foreach (string fingerprint in rpcSslAllowedFingerprints)
+            foreach (string fingerprint in _rpcSslAllowedFingerprints)
             {
                 cmd.Add("--rpc-ssl-allowed-fingerprint");
                 cmd.Add(fingerprint);
             }
         }
 
-        if (rpcSslAllowAnyCert == true)
+        if (_rpcSslAllowAnyCert == true)
         {
             cmd.Add("--rpc-ssl-allow-any-cert");
         }
 
-        if (!string.IsNullOrEmpty(rpcSslCaCertificates))
+        if (!string.IsNullOrEmpty(_rpcSslCaCertificates))
         {
             cmd.Add("--rpc-ssl-ca-certificates");
-            cmd.Add(rpcSslCaCertificates);
+            cmd.Add(_rpcSslCaCertificates);
         }
 
-        if (rpcSslAllowChained == true)
+        if (_rpcSslAllowChained == true)
         {
             cmd.Add("--rpc-ssl-allow-chained");
         }
 
-        if (!string.IsNullOrEmpty(rpcLogin))
+        if (!string.IsNullOrEmpty(_rpcLogin))
         {
             cmd.Add("--rpc-login");
-            cmd.Add(rpcLogin);
+            cmd.Add(_rpcLogin);
         }
 
-        if (!string.IsNullOrEmpty(rpcAccessControlOrigins))
+        if (!string.IsNullOrEmpty(_rpcAccessControlOrigins))
         {
             cmd.Add("--rpc-access-control-origins");
-            cmd.Add(rpcAccessControlOrigins);
+            cmd.Add(_rpcAccessControlOrigins);
         }
 
-        if (disableRpcBan == true)
+        if (_disableRpcBan == true)
         {
             cmd.Add("--disable-rpc-ban");
         }
 
-        if (!string.IsNullOrEmpty(zmqRpcBindIp))
+        if (!string.IsNullOrEmpty(_zmqRpcBindIp))
         {
             cmd.Add("--zmq-rpc-bind-ip");
-            cmd.Add(zmqRpcBindIp);
+            cmd.Add(_zmqRpcBindIp);
         }
 
-        if (zmqRpcBindPort != null && zmqRpcBindPort >= 0)
+        if (_zmqRpcBindPort != null && _zmqRpcBindPort >= 0)
         {
             cmd.Add("--zmq-rpc-bind-port");
-            cmd.Add(((int)zmqRpcBindPort).ToString());
+            cmd.Add(((int)_zmqRpcBindPort).ToString());
         }
 
-        if (!string.IsNullOrEmpty(zmqPub))
+        if (!string.IsNullOrEmpty(_zmqPub))
         {
             cmd.Add("--zmq-pub");
-            cmd.Add(zmqPub);
+            cmd.Add(_zmqPub);
         }
 
-        if (noZmq == true)
+        if (_noZmq == true)
         {
             cmd.Add("--no-zmq");
         }
 
-        if (confirmExternalBind == true)
+        if (_confirmExternalBind == true)
         {
             cmd.Add("--confirm-external-bind");
         }
 
-        if (restrictedRpc == true)
+        if (_restrictedRpc == true)
         {
             cmd.Add("--restricted-rpc");
         }
 
-        if (pruneBlockchain == true)
+        if (_pruneBlockchain == true)
         {
             cmd.Add("--prune-blockchain");
         }
 
-        if (syncPrunedBlocks == true)
+        if (_syncPrunedBlocks == true)
         {
             cmd.Add("--sync-pruned-blocks");
         }
 
-        if (!string.IsNullOrEmpty(dbSyncMode))
+        if (!string.IsNullOrEmpty(_dbSyncMode))
         {
             cmd.Add("--db-sync-mode");
-            cmd.Add(dbSyncMode);
+            cmd.Add(_dbSyncMode);
         }
 
-        if (maxConcurrency != null && maxConcurrency >= 0)
+        if (_maxConcurrency != null && _maxConcurrency >= 0)
         {
             cmd.Add("--max-concurrency");
-            cmd.Add(((int)maxConcurrency).ToString());
+            cmd.Add(((int)_maxConcurrency).ToString());
         }
 
-        if (prepBlocksThreads != null && prepBlocksThreads >= 0)
+        if (_prepBlocksThreads != null && _prepBlocksThreads >= 0)
         {
             cmd.Add("--prep-blocks-threads");
-            cmd.Add(((int)prepBlocksThreads).ToString());
+            cmd.Add(((int)_prepBlocksThreads).ToString());
         }
 
-        if (fastBlockSync == true)
+        if (_fastBlockSync == true)
         {
             cmd.Add("--fast-block-sync");
         }
 
-        if (blockSyncSize != null && blockSyncSize >= 0)
+        if (_blockSyncSize != null && _blockSyncSize >= 0)
         {
             cmd.Add("--block-sync-size");
-            cmd.Add(((int)blockSyncSize).ToString());
+            cmd.Add(((int)_blockSyncSize).ToString());
         }
 
-        if (!string.IsNullOrEmpty(bootstrapDaemonAddress))
+        if (!string.IsNullOrEmpty(_bootstrapDaemonAddress))
         {
             cmd.Add("--bootstrap-daemon-address");
-            cmd.Add(bootstrapDaemonAddress);
+            cmd.Add(_bootstrapDaemonAddress);
         }
 
-        if (!string.IsNullOrEmpty(booststrapDaemonLogin))
+        if (!string.IsNullOrEmpty(_booststrapDaemonLogin))
         {
             cmd.Add("--bootstrap-daemon-login");
-            cmd.Add(booststrapDaemonLogin);
+            cmd.Add(_booststrapDaemonLogin);
         }
 
-        if (noSync == true)
+        if (_noSync == true)
         {
             cmd.Add("--no-sync");
         }

--- a/Monero/Daemon/Common/MoneroDaemonInfo.cs
+++ b/Monero/Daemon/Common/MoneroDaemonInfo.cs
@@ -4,368 +4,368 @@ namespace Monero.Daemon.Common;
 
 public class MoneroDaemonInfo
 {
-    private ulong? adjustedTimestamp;
-    private ulong? blockSizeLimit;
-    private ulong? blockSizeMedian;
-    private ulong? blockWeightLimit;
-    private ulong? blockWeightMedian;
-    private string? bootstrapDaemonAddress;
-    private ulong? credits;
-    private ulong? cumulativeDifficulty;
-    private ulong? databaseSize;
-    private ulong? difficulty;
-    private ulong? freeSpace;
-    private ulong? height;
-    private ulong? heightWithoutBootstrap;
-    private bool? isBusySyncing;
-    private bool? isOffline;
-    private bool? isRestricted;
-    private bool? isSynchronized;
-    private MoneroNetworkType? networkType;
-    private ulong? numAltBlocks;
-    private uint? numIncomingConnections;
-    private uint? numOfflinePeers;
-    private uint? numOnlinePeers;
-    private uint? numOutgoingConnections;
-    private uint? numRpcConnections;
-    private uint? numTxs;
-    private uint? numTxsPool;
-    private ulong? startTimestamp;
-    private ulong? target;
-    private ulong? targetHeight;
-    private string? topBlockHash;
-    private bool? updateAvailable;
-    private string? version;
-    private bool? wasBootstrapEverUsed;
+    private ulong? _adjustedTimestamp;
+    private ulong? _blockSizeLimit;
+    private ulong? _blockSizeMedian;
+    private ulong? _blockWeightLimit;
+    private ulong? _blockWeightMedian;
+    private string? _bootstrapDaemonAddress;
+    private ulong? _credits;
+    private ulong? _cumulativeDifficulty;
+    private ulong? _databaseSize;
+    private ulong? _difficulty;
+    private ulong? _freeSpace;
+    private ulong? _height;
+    private ulong? _heightWithoutBootstrap;
+    private bool? _isBusySyncing;
+    private bool? _isOffline;
+    private bool? _isRestricted;
+    private bool? _isSynchronized;
+    private MoneroNetworkType? _networkType;
+    private ulong? _numAltBlocks;
+    private uint? _numIncomingConnections;
+    private uint? _numOfflinePeers;
+    private uint? _numOnlinePeers;
+    private uint? _numOutgoingConnections;
+    private uint? _numRpcConnections;
+    private uint? _numTxs;
+    private uint? _numTxsPool;
+    private ulong? _startTimestamp;
+    private ulong? _target;
+    private ulong? _targetHeight;
+    private string? _topBlockHash;
+    private bool? _updateAvailable;
+    private string? _version;
+    private bool? _wasBootstrapEverUsed;
 
     public string? GetVersion()
     {
-        return version;
+        return _version;
     }
 
     public void SetVersion(string? version)
     {
-        this.version = version;
+        this._version = version;
     }
 
     public ulong? GetNumAltBlocks()
     {
-        return numAltBlocks;
+        return _numAltBlocks;
     }
 
     public void SetNumAltBlocks(ulong? numAltBlocks)
     {
-        this.numAltBlocks = numAltBlocks;
+        this._numAltBlocks = numAltBlocks;
     }
 
     public ulong? GetBlockSizeLimit()
     {
-        return blockSizeLimit;
+        return _blockSizeLimit;
     }
 
     public void SetBlockSizeLimit(ulong? blockSizeLimit)
     {
-        this.blockSizeLimit = blockSizeLimit;
+        this._blockSizeLimit = blockSizeLimit;
     }
 
     public ulong? GetBlockSizeMedian()
     {
-        return blockSizeMedian;
+        return _blockSizeMedian;
     }
 
     public void SetBlockSizeMedian(ulong? blockSizeMedian)
     {
-        this.blockSizeMedian = blockSizeMedian;
+        this._blockSizeMedian = blockSizeMedian;
     }
 
     public ulong? GetBlockWeightLimit()
     {
-        return blockWeightLimit;
+        return _blockWeightLimit;
     }
 
     public MoneroDaemonInfo SetBlockWeightLimit(ulong? blockWeightLimit)
     {
-        this.blockWeightLimit = blockWeightLimit;
+        this._blockWeightLimit = blockWeightLimit;
         return this;
     }
 
     public ulong? GetBlockWeightMedian()
     {
-        return blockWeightMedian;
+        return _blockWeightMedian;
     }
 
     public void SetBlockWeightMedian(ulong? blockWeightMedian)
     {
-        this.blockWeightMedian = blockWeightMedian;
+        this._blockWeightMedian = blockWeightMedian;
     }
 
     public string? GetBootstrapDaemonAddress()
     {
-        return bootstrapDaemonAddress;
+        return _bootstrapDaemonAddress;
     }
 
     public void SetBootstrapDaemonAddress(string? bootstrapDaemonAddress)
     {
-        this.bootstrapDaemonAddress = bootstrapDaemonAddress;
+        this._bootstrapDaemonAddress = bootstrapDaemonAddress;
     }
 
     public ulong? GetDifficulty()
     {
-        return difficulty;
+        return _difficulty;
     }
 
     public void SetDifficulty(ulong? difficulty)
     {
-        this.difficulty = difficulty;
+        this._difficulty = difficulty;
     }
 
     public ulong? GetCumulativeDifficulty()
     {
-        return cumulativeDifficulty;
+        return _cumulativeDifficulty;
     }
 
     public void SetCumulativeDifficulty(ulong? cumulativeDifficulty)
     {
-        this.cumulativeDifficulty = cumulativeDifficulty;
+        this._cumulativeDifficulty = cumulativeDifficulty;
     }
 
     public ulong? GetFreeSpace()
     {
-        return freeSpace;
+        return _freeSpace;
     }
 
     public void SetFreeSpace(ulong? freeSpace)
     {
-        this.freeSpace = freeSpace;
+        this._freeSpace = freeSpace;
     }
 
     public uint? GetNumOfflinePeers()
     {
-        return numOfflinePeers;
+        return _numOfflinePeers;
     }
 
     public void SetNumOfflinePeers(uint? numOfflinePeers)
     {
-        this.numOfflinePeers = numOfflinePeers;
+        this._numOfflinePeers = numOfflinePeers;
     }
 
     public uint? GetNumOnlinePeers()
     {
-        return numOnlinePeers;
+        return _numOnlinePeers;
     }
 
     public void SetNumOnlinePeers(uint? numOnlinePeers)
     {
-        this.numOnlinePeers = numOnlinePeers;
+        this._numOnlinePeers = numOnlinePeers;
     }
 
     public ulong? GetHeight()
     {
-        return height;
+        return _height;
     }
 
     public void SetHeight(ulong? height)
     {
-        this.height = height;
+        this._height = height;
     }
 
     public ulong? GetHeightWithoutBootstrap()
     {
-        return heightWithoutBootstrap;
+        return _heightWithoutBootstrap;
     }
 
     public void SetHeightWithoutBootstrap(ulong? heightWithoutBootstrap)
     {
-        this.heightWithoutBootstrap = heightWithoutBootstrap;
+        this._heightWithoutBootstrap = heightWithoutBootstrap;
     }
 
     public MoneroNetworkType? GetNetworkType()
     {
-        return networkType;
+        return _networkType;
     }
 
     public void SetNetworkType(MoneroNetworkType? networkType)
     {
-        this.networkType = networkType;
+        this._networkType = networkType;
     }
 
     public bool? IsOffline()
     {
-        return isOffline;
+        return _isOffline;
     }
 
     public void SetIsOffline(bool? isOffline)
     {
-        this.isOffline = isOffline;
+        this._isOffline = isOffline;
     }
 
     public uint? GetNumIncomingConnections()
     {
-        return numIncomingConnections;
+        return _numIncomingConnections;
     }
 
     public void SetNumIncomingConnections(uint? numIncomingConnections)
     {
-        this.numIncomingConnections = numIncomingConnections;
+        this._numIncomingConnections = numIncomingConnections;
     }
 
     public uint? GetNumOutgoingConnections()
     {
-        return numOutgoingConnections;
+        return _numOutgoingConnections;
     }
 
     public void SetNumOutgoingConnections(uint? numOutgoingConnections)
     {
-        this.numOutgoingConnections = numOutgoingConnections;
+        this._numOutgoingConnections = numOutgoingConnections;
     }
 
     public uint? GetNumRpcConnections()
     {
-        return numRpcConnections;
+        return _numRpcConnections;
     }
 
     public void SetNumRpcConnections(uint? numRpcConnections)
     {
-        this.numRpcConnections = numRpcConnections;
+        this._numRpcConnections = numRpcConnections;
     }
 
     public ulong? GetStartTimestamp()
     {
-        return startTimestamp;
+        return _startTimestamp;
     }
 
     public void SetStartTimestamp(ulong? startTimestamp)
     {
-        this.startTimestamp = startTimestamp;
+        this._startTimestamp = startTimestamp;
     }
 
     public ulong? GetAdjustedTimestamp()
     {
-        return adjustedTimestamp;
+        return _adjustedTimestamp;
     }
 
     public void SetAdjustedTimestamp(ulong? adjustedTimestamp)
     {
-        this.adjustedTimestamp = adjustedTimestamp;
+        this._adjustedTimestamp = adjustedTimestamp;
     }
 
     public ulong? GetTarget()
     {
-        return target;
+        return _target;
     }
 
     public void SetTarget(ulong? target)
     {
-        this.target = target;
+        this._target = target;
     }
 
     public ulong? GetTargetHeight()
     {
-        return targetHeight;
+        return _targetHeight;
     }
 
     public void SetTargetHeight(ulong? targetHeight)
     {
-        this.targetHeight = targetHeight;
+        this._targetHeight = targetHeight;
     }
 
     public string? GetTopBlockHash()
     {
-        return topBlockHash;
+        return _topBlockHash;
     }
 
     public void SetTopBlockHash(string? topBlockHash)
     {
-        this.topBlockHash = topBlockHash;
+        this._topBlockHash = topBlockHash;
     }
 
     public uint? GetNumTxs()
     {
-        return numTxs;
+        return _numTxs;
     }
 
     public void SetNumTxs(uint? numTxs)
     {
-        this.numTxs = numTxs;
+        this._numTxs = numTxs;
     }
 
     public uint? GetNumTxsPool()
     {
-        return numTxsPool;
+        return _numTxsPool;
     }
 
     public void SetNumTxsPool(uint? numTxsPool)
     {
-        this.numTxsPool = numTxsPool;
+        this._numTxsPool = numTxsPool;
     }
 
     public bool? GetWasBootstrapEverUsed()
     {
-        return wasBootstrapEverUsed;
+        return _wasBootstrapEverUsed;
     }
 
     public void SetWasBootstrapEverUsed(bool? wasBootstrapEverUsed)
     {
-        this.wasBootstrapEverUsed = wasBootstrapEverUsed;
+        this._wasBootstrapEverUsed = wasBootstrapEverUsed;
     }
 
     public ulong? GetDatabaseSize()
     {
-        return databaseSize;
+        return _databaseSize;
     }
 
     public void SetDatabaseSize(ulong? databaseSize)
     {
-        this.databaseSize = databaseSize;
+        this._databaseSize = databaseSize;
     }
 
     public bool? GetUpdateAvailable()
     {
-        return updateAvailable;
+        return _updateAvailable;
     }
 
     public void SetUpdateAvailable(bool? updateAvailable)
     {
-        this.updateAvailable = updateAvailable;
+        this._updateAvailable = updateAvailable;
     }
 
     public ulong? GetCredits()
     {
-        return credits;
+        return _credits;
     }
 
     public void SetCredits(ulong? credits)
     {
-        this.credits = credits;
+        this._credits = credits;
     }
 
     public bool? IsBusySyncing()
     {
-        return isBusySyncing;
+        return _isBusySyncing;
     }
 
     public void SetIsBusySyncing(bool? isBusySyncing)
     {
-        this.isBusySyncing = isBusySyncing;
+        this._isBusySyncing = isBusySyncing;
     }
 
     public bool? IsSynchronized()
     {
-        return isSynchronized;
+        return _isSynchronized;
     }
 
     public void SetIsSynchronized(bool? isSynchronized)
     {
-        this.isSynchronized = isSynchronized;
+        this._isSynchronized = isSynchronized;
     }
 
     public bool? IsRestricted()
     {
-        return isRestricted;
+        return _isRestricted;
     }
 
     public void SetIsRestricted(bool? isRestricted)
     {
-        this.isRestricted = isRestricted;
+        this._isRestricted = isRestricted;
     }
 }

--- a/Monero/Daemon/Common/MoneroDaemonSyncInfo.cs
+++ b/Monero/Daemon/Common/MoneroDaemonSyncInfo.cs
@@ -2,92 +2,92 @@ namespace Monero.Daemon.Common;
 
 public class MoneroDaemonSyncInfo
 {
-    private ulong? credits;
-    private ulong? height;
-    private uint? nextNeededPruningSeed;
-    private string? overview;
-    private List<MoneroPeer>? peers;
-    private List<MoneroConnectionSpan>? spans;
-    private ulong? targetHeight;
-    private string? topBlockHash;
+    private ulong? _credits;
+    private ulong? _height;
+    private uint? _nextNeededPruningSeed;
+    private string? _overview;
+    private List<MoneroPeer>? _peers;
+    private List<MoneroConnectionSpan>? _spans;
+    private ulong? _targetHeight;
+    private string? _topBlockHash;
 
     public ulong? GetHeight()
     {
-        return height;
+        return _height;
     }
 
     public void SetHeight(ulong? height)
     {
-        this.height = height;
+        this._height = height;
     }
 
     public List<MoneroPeer>? GetPeers()
     {
-        return peers;
+        return _peers;
     }
 
     public void SetPeers(List<MoneroPeer>? peers)
     {
-        this.peers = peers;
+        this._peers = peers;
     }
 
     public List<MoneroConnectionSpan>? GetSpans()
     {
-        return spans;
+        return _spans;
     }
 
     public void SetSpans(List<MoneroConnectionSpan>? spans)
     {
-        this.spans = spans;
+        this._spans = spans;
     }
 
     public ulong? GetTargetHeight()
     {
-        return targetHeight;
+        return _targetHeight;
     }
 
     public void SetTargetHeight(ulong? targetHeight)
     {
-        this.targetHeight = targetHeight;
+        this._targetHeight = targetHeight;
     }
 
     public uint? GetNextNeededPruningSeed()
     {
-        return nextNeededPruningSeed;
+        return _nextNeededPruningSeed;
     }
 
     public void SetNextNeededPruningSeed(uint? nextNeededPruningSeed)
     {
-        this.nextNeededPruningSeed = nextNeededPruningSeed;
+        this._nextNeededPruningSeed = nextNeededPruningSeed;
     }
 
     public string? GetOverview()
     {
-        return overview;
+        return _overview;
     }
 
     public void SetOverview(string? overview)
     {
-        this.overview = overview;
+        this._overview = overview;
     }
 
     public ulong? GetCredits()
     {
-        return credits;
+        return _credits;
     }
 
     public void SetCredits(ulong? credits)
     {
-        this.credits = credits;
+        this._credits = credits;
     }
 
     public string? GetTopBlockHash()
     {
-        return topBlockHash;
+        return _topBlockHash;
     }
 
     public void SetTopBlockHash(string? topBlockHash)
     {
-        this.topBlockHash = topBlockHash;
+        this._topBlockHash = topBlockHash;
     }
 }

--- a/Monero/Daemon/Common/MoneroDaemonUpdateCheckResult.cs
+++ b/Monero/Daemon/Common/MoneroDaemonUpdateCheckResult.cs
@@ -2,11 +2,11 @@ namespace Monero.Daemon.Common;
 
 public class MoneroDaemonUpdateCheckResult
 {
-    private string? autoUri;
-    private string? hash;
-    private bool? isUpdateAvailable;
-    private string? userUri;
-    private string? version;
+    private string? _autoUri;
+    private string? _hash;
+    private bool? _isUpdateAvailable;
+    private string? _userUri;
+    private string? _version;
 
     public MoneroDaemonUpdateCheckResult()
     {
@@ -15,11 +15,11 @@ public class MoneroDaemonUpdateCheckResult
 
     public MoneroDaemonUpdateCheckResult(MoneroDaemonUpdateCheckResult checkResult)
     {
-        isUpdateAvailable = checkResult.isUpdateAvailable;
-        version = checkResult.version;
-        hash = checkResult.hash;
-        autoUri = checkResult.autoUri;
-        userUri = checkResult.userUri;
+        _isUpdateAvailable = checkResult._isUpdateAvailable;
+        _version = checkResult._version;
+        _hash = checkResult._hash;
+        _autoUri = checkResult._autoUri;
+        _userUri = checkResult._userUri;
     }
 
     public MoneroDaemonUpdateCheckResult Clone()
@@ -29,51 +29,51 @@ public class MoneroDaemonUpdateCheckResult
 
     public bool? IsUpdateAvailable()
     {
-        return isUpdateAvailable;
+        return _isUpdateAvailable;
     }
 
     public void SetIsUpdateAvailable(bool? isUpdateAvailable)
     {
-        this.isUpdateAvailable = isUpdateAvailable;
+        this._isUpdateAvailable = isUpdateAvailable;
     }
 
     public string? GetVersion()
     {
-        return version;
+        return _version;
     }
 
     public void SetVersion(string? version)
     {
-        this.version = version;
+        this._version = version;
     }
 
     public string? GetHash()
     {
-        return hash;
+        return _hash;
     }
 
     public void SetHash(string? hash)
     {
-        this.hash = hash;
+        this._hash = hash;
     }
 
     public string? GetAutoUri()
     {
-        return autoUri;
+        return _autoUri;
     }
 
     public void SetAutoUri(string? autoUri)
     {
-        this.autoUri = autoUri;
+        this._autoUri = autoUri;
     }
 
     public string? GetUserUri()
     {
-        return userUri;
+        return _userUri;
     }
 
     public void SetUserUri(string? userUri)
     {
-        this.userUri = userUri;
+        this._userUri = userUri;
     }
 }

--- a/Monero/Daemon/Common/MoneroDaemonUpdateDownloadResult.cs
+++ b/Monero/Daemon/Common/MoneroDaemonUpdateDownloadResult.cs
@@ -2,7 +2,7 @@ namespace Monero.Daemon.Common;
 
 public class MoneroDaemonUpdateDownloadResult : MoneroDaemonUpdateCheckResult
 {
-    private string? downloadPath;
+    private string? _downloadPath;
 
     public MoneroDaemonUpdateDownloadResult(MoneroDaemonUpdateCheckResult checkResult) : base(checkResult)
     {
@@ -10,16 +10,16 @@ public class MoneroDaemonUpdateDownloadResult : MoneroDaemonUpdateCheckResult
 
     public MoneroDaemonUpdateDownloadResult(MoneroDaemonUpdateDownloadResult checkResult) : base(checkResult)
     {
-        downloadPath = checkResult.downloadPath;
+        _downloadPath = checkResult._downloadPath;
     }
 
     public string? GetDownloadPath()
     {
-        return downloadPath;
+        return _downloadPath;
     }
 
     public void SetDownloadPath(string? downloadPath)
     {
-        this.downloadPath = downloadPath;
+        this._downloadPath = downloadPath;
     }
 }

--- a/Monero/Daemon/Common/MoneroFeeEstimate.cs
+++ b/Monero/Daemon/Common/MoneroFeeEstimate.cs
@@ -2,59 +2,59 @@ namespace Monero.Daemon.Common;
 
 public class MoneroFeeEstimate
 {
-    private ulong? fee;
-    private List<ulong> fees;
-    private ulong? quantizationMask;
+    private ulong? _fee;
+    private List<ulong> _fees;
+    private ulong? _quantizationMask;
 
     public MoneroFeeEstimate()
     {
-        fees = [];
+        _fees = [];
     }
 
     public MoneroFeeEstimate(ulong? fee, List<ulong> fees, ulong? quantizationMask)
     {
-        this.fee = fee;
-        this.fees = fees;
-        this.quantizationMask = quantizationMask;
+        this._fee = fee;
+        this._fees = fees;
+        this._quantizationMask = quantizationMask;
     }
 
     public MoneroFeeEstimate(MoneroFeeEstimate feeEstimate)
     {
-        fee = feeEstimate.fee;
-        fees = new List<ulong>(feeEstimate.fees);
-        quantizationMask = feeEstimate.quantizationMask;
+        _fee = feeEstimate._fee;
+        _fees = new List<ulong>(feeEstimate._fees);
+        _quantizationMask = feeEstimate._quantizationMask;
     }
 
     public ulong? GetFee()
     {
-        return fee;
+        return _fee;
     }
 
     public MoneroFeeEstimate SetFee(ulong? fee)
     {
-        this.fee = fee;
+        this._fee = fee;
         return this;
     }
 
     public List<ulong> GetFees()
     {
-        return fees;
+        return _fees;
     }
 
     public MoneroFeeEstimate SetFees(List<ulong> fees)
     {
-        this.fees = fees;
+        this._fees = fees;
         return this;
     }
 
     public ulong? GetQuantizationMask()
     {
-        return quantizationMask;
+        return _quantizationMask;
     }
 
     public MoneroFeeEstimate SetQuantizationMask(ulong? quantizationMask)
     {
-        this.quantizationMask = quantizationMask;
+        this._quantizationMask = quantizationMask;
         return this;
     }
 

--- a/Monero/Daemon/Common/MoneroHardForkInfo.cs
+++ b/Monero/Daemon/Common/MoneroHardForkInfo.cs
@@ -2,114 +2,114 @@ namespace Monero.Daemon.Common;
 
 public class MoneroHardForkInfo
 {
-    private ulong? credits;
-    private ulong? earliestHeight;
-    private bool? isEnabled;
-    private uint? numVotes;
-    private uint? state;
-    private uint? threshold;
-    private string? topBlockHash;
-    private uint? version;
-    private uint? voting;
-    private uint? window;
+    private ulong? _credits;
+    private ulong? _earliestHeight;
+    private bool? _isEnabled;
+    private uint? _numVotes;
+    private uint? _state;
+    private uint? _threshold;
+    private string? _topBlockHash;
+    private uint? _version;
+    private uint? _voting;
+    private uint? _window;
 
     public ulong? GetEarliestHeight()
     {
-        return earliestHeight;
+        return _earliestHeight;
     }
 
     public void SetEarliestHeight(ulong? earliestHeight)
     {
-        this.earliestHeight = earliestHeight;
+        this._earliestHeight = earliestHeight;
     }
 
     public bool? IsEnabled()
     {
-        return isEnabled;
+        return _isEnabled;
     }
 
     public void SetIsEnabled(bool? isEnabled)
     {
-        this.isEnabled = isEnabled;
+        this._isEnabled = isEnabled;
     }
 
     public uint? GetState()
     {
-        return state;
+        return _state;
     }
 
     public void SetState(uint? state)
     {
-        this.state = state;
+        this._state = state;
     }
 
     public uint? GetThreshold()
     {
-        return threshold;
+        return _threshold;
     }
 
     public void SetThreshold(uint? threshold)
     {
-        this.threshold = threshold;
+        this._threshold = threshold;
     }
 
     public uint? GetVersion()
     {
-        return version;
+        return _version;
     }
 
     public void SetVersion(uint? version)
     {
-        this.version = version;
+        this._version = version;
     }
 
     public uint? GetNumVotes()
     {
-        return numVotes;
+        return _numVotes;
     }
 
     public void SetNumVotes(uint? numVotes)
     {
-        this.numVotes = numVotes;
+        this._numVotes = numVotes;
     }
 
     public uint? GetWindow()
     {
-        return window;
+        return _window;
     }
 
     public void SetWindow(uint? window)
     {
-        this.window = window;
+        this._window = window;
     }
 
     public uint? GetVoting()
     {
-        return voting;
+        return _voting;
     }
 
     public void SetVoting(uint? voting)
     {
-        this.voting = voting;
+        this._voting = voting;
     }
 
     public ulong? GetCredits()
     {
-        return credits;
+        return _credits;
     }
 
     public void SetCredits(ulong? credits)
     {
-        this.credits = credits;
+        this._credits = credits;
     }
 
     public string? GetTopBlockHash()
     {
-        return topBlockHash;
+        return _topBlockHash;
     }
 
     public void SetTopBlockHash(string? topBlockHash)
     {
-        this.topBlockHash = topBlockHash;
+        this._topBlockHash = topBlockHash;
     }
 }

--- a/Monero/Daemon/Common/MoneroMinerTxSum.cs
+++ b/Monero/Daemon/Common/MoneroMinerTxSum.cs
@@ -2,26 +2,26 @@ namespace Monero.Daemon.Common;
 
 public class MoneroMinerTxSum
 {
-    private ulong? emissionSum;
-    private ulong? feeSum;
+    private ulong? _emissionSum;
+    private ulong? _feeSum;
 
     public ulong? GetEmissionSum()
     {
-        return emissionSum;
+        return _emissionSum;
     }
 
     public void SetEmissionSum(ulong? emissionSum)
     {
-        this.emissionSum = emissionSum;
+        this._emissionSum = emissionSum;
     }
 
     public ulong? GetFeeSum()
     {
-        return feeSum;
+        return _feeSum;
     }
 
     public void SetFeeSum(ulong? feeSum)
     {
-        this.feeSum = feeSum;
+        this._feeSum = feeSum;
     }
 }

--- a/Monero/Daemon/Common/MoneroMiningStatus.cs
+++ b/Monero/Daemon/Common/MoneroMiningStatus.cs
@@ -2,59 +2,59 @@ namespace Monero.Daemon.Common;
 
 public class MoneroMiningStatus
 {
-    private string? address;
-    private bool? isActive;
-    private bool? isBackground;
-    private uint? numThreads;
-    private ulong? speed;
+    private string? _address;
+    private bool? _isActive;
+    private bool? _isBackground;
+    private uint? _numThreads;
+    private ulong? _speed;
 
     public bool? IsActive()
     {
-        return isActive;
+        return _isActive;
     }
 
     public void SetIsActive(bool? isActive)
     {
-        this.isActive = isActive;
+        this._isActive = isActive;
     }
 
     public bool? IsBackground()
     {
-        return isBackground;
+        return _isBackground;
     }
 
     public void SetIsBackground(bool? isBackground)
     {
-        this.isBackground = isBackground;
+        this._isBackground = isBackground;
     }
 
     public string? GetAddress()
     {
-        return address;
+        return _address;
     }
 
     public void SetAddress(string? address)
     {
-        this.address = address;
+        this._address = address;
     }
 
     public ulong? GetSpeed()
     {
-        return speed;
+        return _speed;
     }
 
     public void SetSpeed(ulong? speed)
     {
-        this.speed = speed;
+        this._speed = speed;
     }
 
     public uint? GetNumThreads()
     {
-        return numThreads;
+        return _numThreads;
     }
 
     public void SetNumThreads(uint? numThreads)
     {
-        this.numThreads = numThreads;
+        this._numThreads = numThreads;
     }
 }

--- a/Monero/Daemon/Common/MoneroOutputDistributionEntry.cs
+++ b/Monero/Daemon/Common/MoneroOutputDistributionEntry.cs
@@ -3,18 +3,18 @@ namespace Monero.Daemon.Common;
 public class MoneroOutputDistributionEntry
 {
     private uint? _base;
-    private ulong? amount;
-    private List<uint>? distribution;
-    private ulong? startHeight;
+    private ulong? _amount;
+    private List<uint>? _distribution;
+    private ulong? _startHeight;
 
     public ulong? GetAmount()
     {
-        return amount;
+        return _amount;
     }
 
     public void SetAmount(ulong? amount)
     {
-        this.amount = amount;
+        this._amount = amount;
     }
 
     public uint? GetBase()
@@ -22,28 +22,28 @@ public class MoneroOutputDistributionEntry
         return _base;
     }
 
-    public void SetBase(uint? _base)
+    public void SetBase(uint? entryBase)
     {
-        this._base = _base;
+        this._base = entryBase;
     }
 
     public List<uint>? GetDistribution()
     {
-        return distribution;
+        return _distribution;
     }
 
     public void SetDistribution(List<uint> distribution)
     {
-        this.distribution = distribution;
+        this._distribution = distribution;
     }
 
     public ulong? GetStartHeight()
     {
-        return startHeight;
+        return _startHeight;
     }
 
     public void SetStartHeight(ulong? startHeight)
     {
-        this.startHeight = startHeight;
+        this._startHeight = startHeight;
     }
 }

--- a/Monero/Daemon/Common/MoneroOutputHistogramEntry.cs
+++ b/Monero/Daemon/Common/MoneroOutputHistogramEntry.cs
@@ -2,48 +2,48 @@ namespace Monero.Daemon.Common;
 
 public class MoneroOutputHistogramEntry
 {
-    private ulong? amount;
-    private ulong? numInstances;
-    private ulong? numRecentInstances;
-    private ulong? numUnlockedInstances;
+    private ulong? _amount;
+    private ulong? _numInstances;
+    private ulong? _numRecentInstances;
+    private ulong? _numUnlockedInstances;
 
     public ulong? GetAmount()
     {
-        return amount;
+        return _amount;
     }
 
     public void SetAmount(ulong? amount)
     {
-        this.amount = amount;
+        this._amount = amount;
     }
 
     public ulong? GetNumInstances()
     {
-        return numInstances;
+        return _numInstances;
     }
 
     public void SetNumInstances(ulong? numInstances)
     {
-        this.numInstances = numInstances;
+        this._numInstances = numInstances;
     }
 
     public ulong? GetNumUnlockedInstances()
     {
-        return numUnlockedInstances;
+        return _numUnlockedInstances;
     }
 
     public void SetNumUnlockedInstances(ulong? numUnlockedInstances)
     {
-        this.numUnlockedInstances = numUnlockedInstances;
+        this._numUnlockedInstances = numUnlockedInstances;
     }
 
     public ulong? GetNumRecentInstances()
     {
-        return numRecentInstances;
+        return _numRecentInstances;
     }
 
     public void SetNumRecentInstances(ulong? numRecentInstances)
     {
-        this.numRecentInstances = numRecentInstances;
+        this._numRecentInstances = numRecentInstances;
     }
 }

--- a/Monero/Daemon/Common/MoneroPeer.cs
+++ b/Monero/Daemon/Common/MoneroPeer.cs
@@ -4,299 +4,299 @@ namespace Monero.Daemon.Common;
 
 public class MoneroPeer
 {
-    private string? address;
-    private ulong? avgDownload;
-    private ulong? avgUpload;
-    private ulong? currentDownload;
-    private ulong? currentUpload;
-    private string? hash;
-    private ulong? height;
-    private string? host;
-    private string? id;
-    private bool isIncoming;
-    private bool isLocalHost;
-    private bool isLocalIp;
-    private bool isOnline;
-    private ulong? lastSeenTimestamp;
-    private ulong? liveTime;
-    private int? numReceives;
-    private int? numSends;
-    private int? numSupportFlags;
-    private int? port;
-    private int? pruningSeed;
-    private ulong? receiveIdleTime;
-    private ulong? rpcCreditsPerHash;
-    private int? rpcPort;
-    private ulong? sendIdleTime;
-    private string? state;
-    private MoneroConnectionType? type;
+    private string? _address;
+    private ulong? _avgDownload;
+    private ulong? _avgUpload;
+    private ulong? _currentDownload;
+    private ulong? _currentUpload;
+    private string? _hash;
+    private ulong? _height;
+    private string? _host;
+    private string? _id;
+    private bool _isIncoming;
+    private bool _isLocalHost;
+    private bool _isLocalIp;
+    private bool _isOnline;
+    private ulong? _lastSeenTimestamp;
+    private ulong? _liveTime;
+    private int? _numReceives;
+    private int? _numSends;
+    private int? _numSupportFlags;
+    private int? _port;
+    private int? _pruningSeed;
+    private ulong? _receiveIdleTime;
+    private ulong? _rpcCreditsPerHash;
+    private int? _rpcPort;
+    private ulong? _sendIdleTime;
+    private string? _state;
+    private MoneroConnectionType? _type;
 
     public string? GetId()
     {
-        return id;
+        return _id;
     }
 
     public MoneroPeer SetId(string? id)
     {
-        this.id = id;
+        this._id = id;
         return this;
     }
 
     public string? GetAddress()
     {
-        return address;
+        return _address;
     }
 
     public MoneroPeer SetAddress(string? address)
     {
-        this.address = address;
+        this._address = address;
         return this;
     }
 
     public string? GetHost()
     {
-        return host;
+        return _host;
     }
 
     public MoneroPeer SetHost(string? host)
     {
-        this.host = host;
+        this._host = host;
         return this;
     }
 
     public int? GetPort()
     {
-        return port;
+        return _port;
     }
 
     public MoneroPeer SetPort(int? port)
     {
-        this.port = port;
+        this._port = port;
         return this;
     }
 
     public bool IsOnline()
     {
-        return isOnline;
+        return _isOnline;
     }
 
     public MoneroPeer SetIsOnline(bool isOnline)
     {
-        this.isOnline = isOnline;
+        this._isOnline = isOnline;
         return this;
     }
 
     public ulong? GetLastSeenTimestamp()
     {
-        return lastSeenTimestamp;
+        return _lastSeenTimestamp;
     }
 
     public MoneroPeer SetLastSeenTimestamp(ulong? lastSeenTimestamp)
     {
-        this.lastSeenTimestamp = lastSeenTimestamp;
+        this._lastSeenTimestamp = lastSeenTimestamp;
         return this;
     }
 
     public int? GetPruningSeed()
     {
-        return pruningSeed;
+        return _pruningSeed;
     }
 
     public MoneroPeer SetPruningSeed(int? pruningSeed)
     {
-        this.pruningSeed = pruningSeed;
+        this._pruningSeed = pruningSeed;
         return this;
     }
 
     public int? GetRpcPort()
     {
-        return rpcPort;
+        return _rpcPort;
     }
 
     public MoneroPeer SetRpcPort(int? rpcPort)
     {
-        this.rpcPort = rpcPort;
+        this._rpcPort = rpcPort;
         return this;
     }
 
     public ulong? GetRpcCreditsPerHash()
     {
-        return rpcCreditsPerHash;
+        return _rpcCreditsPerHash;
     }
 
     public MoneroPeer SetRpcCreditsPerHash(ulong? rpcCreditsPerHash)
     {
-        this.rpcCreditsPerHash = rpcCreditsPerHash;
+        this._rpcCreditsPerHash = rpcCreditsPerHash;
         return this;
     }
 
     public string? GetHash()
     {
-        return hash;
+        return _hash;
     }
 
     public void SetHash(string? hash)
     {
-        this.hash = hash;
+        this._hash = hash;
     }
 
     public ulong? GetAvgDownload()
     {
-        return avgDownload;
+        return _avgDownload;
     }
 
     public void SetAvgDownload(ulong? avgDownload)
     {
-        this.avgDownload = avgDownload;
+        this._avgDownload = avgDownload;
     }
 
     public ulong? GetAvgUpload()
     {
-        return avgUpload;
+        return _avgUpload;
     }
 
     public void SetAvgUpload(ulong? avgUpload)
     {
-        this.avgUpload = avgUpload;
+        this._avgUpload = avgUpload;
     }
 
     public ulong? GetCurrentDownload()
     {
-        return currentDownload;
+        return _currentDownload;
     }
 
     public void SetCurrentDownload(ulong? currentDownload)
     {
-        this.currentDownload = currentDownload;
+        this._currentDownload = currentDownload;
     }
 
     public ulong? GetCurrentUpload()
     {
-        return currentUpload;
+        return _currentUpload;
     }
 
     public void SetCurrentUpload(ulong? currentUpload)
     {
-        this.currentUpload = currentUpload;
+        this._currentUpload = currentUpload;
     }
 
     public ulong? GetHeight()
     {
-        return height;
+        return _height;
     }
 
     public void SetHeight(ulong? height)
     {
-        this.height = height;
+        this._height = height;
     }
 
     public bool IsIncoming()
     {
-        return isIncoming;
+        return _isIncoming;
     }
 
     public void SetIsIncoming(bool isIncoming)
     {
-        this.isIncoming = isIncoming;
+        this._isIncoming = isIncoming;
     }
 
     public ulong? GetLiveTime()
     {
-        return liveTime;
+        return _liveTime;
     }
 
     public void SetLiveTime(ulong? liveTime)
     {
-        this.liveTime = liveTime;
+        this._liveTime = liveTime;
     }
 
     public bool IsLocalIp()
     {
-        return isLocalIp;
+        return _isLocalIp;
     }
 
     public void SetIsLocalIp(bool isLocalIp)
     {
-        this.isLocalIp = isLocalIp;
+        this._isLocalIp = isLocalIp;
     }
 
     public bool IsLocalHost()
     {
-        return isLocalHost;
+        return _isLocalHost;
     }
 
     public void SetIsLocalHost(bool isLocalHost)
     {
-        this.isLocalHost = isLocalHost;
+        this._isLocalHost = isLocalHost;
     }
 
     public int? GetNumReceives()
     {
-        return numReceives;
+        return _numReceives;
     }
 
     public void SetNumReceives(int? numReceives)
     {
-        this.numReceives = numReceives;
+        this._numReceives = numReceives;
     }
 
     public int? GetNumSends()
     {
-        return numSends;
+        return _numSends;
     }
 
     public void SetNumSends(int? numSends)
     {
-        this.numSends = numSends;
+        this._numSends = numSends;
     }
 
     public ulong? GetReceiveIdleTime()
     {
-        return receiveIdleTime;
+        return _receiveIdleTime;
     }
 
     public void SetReceiveIdleTime(ulong? receiveIdleTime)
     {
-        this.receiveIdleTime = receiveIdleTime;
+        this._receiveIdleTime = receiveIdleTime;
     }
 
     public ulong? GetSendIdleTime()
     {
-        return sendIdleTime;
+        return _sendIdleTime;
     }
 
     public void SetSendIdleTime(ulong? sendIdleTime)
     {
-        this.sendIdleTime = sendIdleTime;
+        this._sendIdleTime = sendIdleTime;
     }
 
     public string? GetState()
     {
-        return state;
+        return _state;
     }
 
     public void SetState(string? state)
     {
-        this.state = state;
+        this._state = state;
     }
 
     public int? GetNumSupportFlags()
     {
-        return numSupportFlags;
+        return _numSupportFlags;
     }
 
     public void SetNumSupportFlags(int? numSupportFlags)
     {
-        this.numSupportFlags = numSupportFlags;
+        this._numSupportFlags = numSupportFlags;
     }
 
     public MoneroConnectionType? GetConnectionType()
     {
-        return type;
+        return _type;
     }
 
     public void SetConnectionType(MoneroConnectionType? type)
     {
-        this.type = type;
+        this._type = type;
     }
 }

--- a/Monero/Daemon/Common/MoneroPruneResult.cs
+++ b/Monero/Daemon/Common/MoneroPruneResult.cs
@@ -2,26 +2,26 @@ namespace Monero.Daemon.Common;
 
 public class MoneroPruneResult
 {
-    private bool? isPruned;
-    private int? pruningSeed;
+    private bool? _isPruned;
+    private int? _pruningSeed;
 
     public bool? IsPruned()
     {
-        return isPruned;
+        return _isPruned;
     }
 
     public void SetIsPruned(bool? isPruned)
     {
-        this.isPruned = isPruned;
+        this._isPruned = isPruned;
     }
 
     public int? GetPruningSeed()
     {
-        return pruningSeed;
+        return _pruningSeed;
     }
 
     public void SetPruningSeed(int? pruningSeed)
     {
-        this.pruningSeed = pruningSeed;
+        this._pruningSeed = pruningSeed;
     }
 }

--- a/Monero/Daemon/Common/MoneroSubmitTxResult.cs
+++ b/Monero/Daemon/Common/MoneroSubmitTxResult.cs
@@ -2,196 +2,196 @@ namespace Monero.Daemon.Common;
 
 public class MoneroSubmitTxResult
 {
-    private ulong? credits;
-    private bool? hasInvalidInput;
-    private bool? hasInvalidOutput;
-    private bool? hasTooFewOutputs;
-    private bool? isDoubleSpend;
-    private bool? isFeeTooLow;
-    private bool? isGood;
-    private bool? isMixinTooLow;
-    private bool? isNonzeroUnlockTime;
-    private bool? isOverspend;
-    private bool? isRelayed;
-    private bool? isTooBig;
-    private bool? isTxExtraTooBig;
-    private string? reason;
-    private bool? sanityCheckFailed;
-    private string? topBlockHash;
+    private ulong? _credits;
+    private bool? _hasInvalidInput;
+    private bool? _hasInvalidOutput;
+    private bool? _hasTooFewOutputs;
+    private bool? _isDoubleSpend;
+    private bool? _isFeeTooLow;
+    private bool? _isGood;
+    private bool? _isMixinTooLow;
+    private bool? _isNonzeroUnlockTime;
+    private bool? _isOverspend;
+    private bool? _isRelayed;
+    private bool? _isTooBig;
+    private bool? _isTxExtraTooBig;
+    private string? _reason;
+    private bool? _sanityCheckFailed;
+    private string? _topBlockHash;
 
     public bool? IsGood()
     {
-        return isGood;
+        return _isGood;
     }
 
     public MoneroSubmitTxResult SetIsGood(bool? isGood)
     {
-        this.isGood = isGood;
+        this._isGood = isGood;
         return this;
     }
 
     public bool? IsRelayed()
     {
-        return isRelayed;
+        return _isRelayed;
     }
 
     public MoneroSubmitTxResult SetIsRelayed(bool? isRelayed)
     {
-        this.isRelayed = isRelayed;
+        this._isRelayed = isRelayed;
         return this;
     }
 
     public bool? IsDoubleSpend()
     {
-        return isDoubleSpend;
+        return _isDoubleSpend;
     }
 
     public MoneroSubmitTxResult SetIsDoubleSpend(bool? isDoubleSpend)
     {
-        this.isDoubleSpend = isDoubleSpend;
+        this._isDoubleSpend = isDoubleSpend;
         return this;
     }
 
     public bool? IsFeeTooLow()
     {
-        return isFeeTooLow;
+        return _isFeeTooLow;
     }
 
     public MoneroSubmitTxResult SetIsFeeTooLow(bool? isFeeTooLow)
     {
-        this.isFeeTooLow = isFeeTooLow;
+        this._isFeeTooLow = isFeeTooLow;
         return this;
     }
 
     public bool? IsMixinTooLow()
     {
-        return isMixinTooLow;
+        return _isMixinTooLow;
     }
 
     public MoneroSubmitTxResult SetIsMixinTooLow(bool? isMixinTooLow)
     {
-        this.isMixinTooLow = isMixinTooLow;
+        this._isMixinTooLow = isMixinTooLow;
         return this;
     }
 
     public bool? HasInvalidInput()
     {
-        return hasInvalidInput;
+        return _hasInvalidInput;
     }
 
     public MoneroSubmitTxResult SetHasInvalidInput(bool? hasInvalidInput)
     {
-        this.hasInvalidInput = hasInvalidInput;
+        this._hasInvalidInput = hasInvalidInput;
         return this;
     }
 
     public bool? HasInvalidOutput()
     {
-        return hasInvalidOutput;
+        return _hasInvalidOutput;
     }
 
     public MoneroSubmitTxResult SetHasInvalidOutput(bool? hasInvalidOutput)
     {
-        this.hasInvalidOutput = hasInvalidOutput;
+        this._hasInvalidOutput = hasInvalidOutput;
         return this;
     }
 
     public bool? HasTooFewOutputs()
     {
-        return hasTooFewOutputs;
+        return _hasTooFewOutputs;
     }
 
     public MoneroSubmitTxResult SetHasTooFewOutputs(bool? hasTooFewOutputs)
     {
-        this.hasTooFewOutputs = hasTooFewOutputs;
+        this._hasTooFewOutputs = hasTooFewOutputs;
         return this;
     }
 
     public bool? IsOverspend()
     {
-        return isOverspend;
+        return _isOverspend;
     }
 
     public MoneroSubmitTxResult SetIsOverspend(bool? isOverspend)
     {
-        this.isOverspend = isOverspend;
+        this._isOverspend = isOverspend;
         return this;
     }
 
     public bool? IsTooBig()
     {
-        return isTooBig;
+        return _isTooBig;
     }
 
     public MoneroSubmitTxResult SetIsTooBig(bool? isTooBig)
     {
-        this.isTooBig = isTooBig;
+        this._isTooBig = isTooBig;
         return this;
     }
 
     public bool? GetSanityCheckFailed()
     {
-        return sanityCheckFailed;
+        return _sanityCheckFailed;
     }
 
     public MoneroSubmitTxResult SetSanityCheckFailed(bool? sanityCheckFailed)
     {
-        this.sanityCheckFailed = sanityCheckFailed;
+        this._sanityCheckFailed = sanityCheckFailed;
         return this;
     }
 
     public string? GetReason()
     {
-        return reason;
+        return _reason;
     }
 
     public MoneroSubmitTxResult SetReason(string? reason)
     {
-        this.reason = reason;
+        this._reason = reason;
         return this;
     }
 
     public ulong? GetCredits()
     {
-        return credits;
+        return _credits;
     }
 
     public MoneroSubmitTxResult SetCredits(ulong? credits)
     {
-        this.credits = credits;
+        this._credits = credits;
         return this;
     }
 
     public string? GetTopBlockHash()
     {
-        return topBlockHash;
+        return _topBlockHash;
     }
 
     public MoneroSubmitTxResult SetTopBlockHash(string? topBlockHash)
     {
-        this.topBlockHash = topBlockHash;
+        this._topBlockHash = topBlockHash;
         return this;
     }
 
     public bool? IsTxExtraTooBig()
     {
-        return isTxExtraTooBig;
+        return _isTxExtraTooBig;
     }
 
     public MoneroSubmitTxResult SetIsTxExtraTooBig(bool? isTxExtraTooBig)
     {
-        this.isTxExtraTooBig = isTxExtraTooBig;
+        this._isTxExtraTooBig = isTxExtraTooBig;
         return this;
     }
 
     public bool? IsNonzeroUnlockTime()
     {
-        return isNonzeroUnlockTime;
+        return _isNonzeroUnlockTime;
     }
 
     public MoneroSubmitTxResult SetIsNonzeroUnlockTime(bool? isNonzeroUnlockTime)
     {
-        this.isNonzeroUnlockTime = isNonzeroUnlockTime;
+        this._isNonzeroUnlockTime = isNonzeroUnlockTime;
         return this;
     }
 }

--- a/Monero/Daemon/Common/MoneroTxPoolStats.cs
+++ b/Monero/Daemon/Common/MoneroTxPoolStats.cs
@@ -2,147 +2,147 @@ namespace Monero.Daemon.Common;
 
 public class MoneroTxPoolStats
 {
-    private ulong? bytesMax;
-    private ulong? bytesMed;
-    private ulong? bytesMin;
-    private ulong? bytesTotal;
-    private ulong? feeTotal;
-    private Dictionary<ulong, int>? histo;
-    private ulong? histo98pc;
-    private int? num10m;
-    private int? numDoubleSpends;
-    private int? numFailing;
-    private int? numNotRelayed;
-    private int? numTxs;
-    private ulong? oldestTimestamp;
+    private ulong? _bytesMax;
+    private ulong? _bytesMed;
+    private ulong? _bytesMin;
+    private ulong? _bytesTotal;
+    private ulong? _feeTotal;
+    private Dictionary<ulong, int>? _histo;
+    private ulong? _histo98Pc;
+    private int? _num10M;
+    private int? _numDoubleSpends;
+    private int? _numFailing;
+    private int? _numNotRelayed;
+    private int? _numTxs;
+    private ulong? _oldestTimestamp;
 
     public int? GetNumTxs()
     {
-        return numTxs;
+        return _numTxs;
     }
 
     public void SetNumTxs(int? numTxs)
     {
-        this.numTxs = numTxs;
+        this._numTxs = numTxs;
     }
 
     public int? GetNumNotRelayed()
     {
-        return numNotRelayed;
+        return _numNotRelayed;
     }
 
     public void SetNumNotRelayed(int? numNotRelayed)
     {
-        this.numNotRelayed = numNotRelayed;
+        this._numNotRelayed = numNotRelayed;
     }
 
     public int? GetNumFailing()
     {
-        return numFailing;
+        return _numFailing;
     }
 
     public void SetNumFailing(int? numFailing)
     {
-        this.numFailing = numFailing;
+        this._numFailing = numFailing;
     }
 
     public int? GetNumDoubleSpends()
     {
-        return numDoubleSpends;
+        return _numDoubleSpends;
     }
 
     public void SetNumDoubleSpends(int? numDoubleSpends)
     {
-        this.numDoubleSpends = numDoubleSpends;
+        this._numDoubleSpends = numDoubleSpends;
     }
 
-    public int? GetNum10m()
+    public int? GetNum10M()
     {
-        return num10m;
+        return _num10M;
     }
 
-    public void SetNum10m(int? num10m)
+    public void SetNum10M(int? num10M)
     {
-        this.num10m = num10m;
+        this._num10M = num10M;
     }
 
     public ulong? GetFeeTotal()
     {
-        return feeTotal;
+        return _feeTotal;
     }
 
     public void SetFeeTotal(ulong? feeTotal)
     {
-        this.feeTotal = feeTotal;
+        this._feeTotal = feeTotal;
     }
 
     public ulong? GetBytesMax()
     {
-        return bytesMax;
+        return _bytesMax;
     }
 
     public void SetBytesMax(ulong? bytesMax)
     {
-        this.bytesMax = bytesMax;
+        this._bytesMax = bytesMax;
     }
 
     public ulong? GetBytesMed()
     {
-        return bytesMed;
+        return _bytesMed;
     }
 
     public void SetBytesMed(ulong? bytesMed)
     {
-        this.bytesMed = bytesMed;
+        this._bytesMed = bytesMed;
     }
 
     public ulong? GetBytesMin()
     {
-        return bytesMin;
+        return _bytesMin;
     }
 
     public void SetBytesMin(ulong? bytesMin)
     {
-        this.bytesMin = bytesMin;
+        this._bytesMin = bytesMin;
     }
 
     public ulong? GetBytesTotal()
     {
-        return bytesTotal;
+        return _bytesTotal;
     }
 
     public void SetBytesTotal(ulong? bytesTotal)
     {
-        this.bytesTotal = bytesTotal;
+        this._bytesTotal = bytesTotal;
     }
 
     public Dictionary<ulong, int>? GetHisto()
     {
-        return histo;
+        return _histo;
     }
 
     public void SetHisto(Dictionary<ulong, int> histo)
     {
-        this.histo = histo;
+        this._histo = histo;
     }
 
-    public ulong? GetHisto98pc()
+    public ulong? GetHisto98Pc()
     {
-        return histo98pc;
+        return _histo98Pc;
     }
 
-    public void SetHisto98pc(ulong? histo98pc)
+    public void SetHisto98Pc(ulong? histo98Pc)
     {
-        this.histo98pc = histo98pc;
+        this._histo98Pc = histo98Pc;
     }
 
     public ulong? GetOldestTimestamp()
     {
-        return oldestTimestamp;
+        return _oldestTimestamp;
     }
 
     public void SetOldestTimestamp(ulong? oldestTimestamp)
     {
-        this.oldestTimestamp = oldestTimestamp;
+        this._oldestTimestamp = oldestTimestamp;
     }
 }

--- a/Monero/Daemon/MoneroDaemonRpc.cs
+++ b/Monero/Daemon/MoneroDaemonRpc.cs
@@ -1950,11 +1950,11 @@ public class MoneroDaemonRpc : MoneroDaemonDefault
             }
             else if (key.Equals("histo_98pc"))
             {
-                stats.SetHisto98pc(Convert.ToUInt64(val));
+                stats.SetHisto98Pc(Convert.ToUInt64(val));
             }
             else if (key.Equals("num_10m"))
             {
-                stats.SetNum10m(Convert.ToInt32(val));
+                stats.SetNum10M(Convert.ToInt32(val));
             }
             else if (key.Equals("num_double_spends"))
             {
@@ -1995,9 +1995,9 @@ public class MoneroDaemonRpc : MoneroDaemonDefault
         }
 
         // uninitialize some stats if not applicable
-        if (stats.GetHisto98pc() == 0)
+        if (stats.GetHisto98Pc() == 0)
         {
-            stats.SetHisto98pc(null);
+            stats.SetHisto98Pc(null);
         }
 
         if (stats.GetNumTxs() == 0)
@@ -2005,7 +2005,7 @@ public class MoneroDaemonRpc : MoneroDaemonDefault
             stats.SetBytesMin(null);
             stats.SetBytesMed(null);
             stats.SetBytesMax(null);
-            stats.SetHisto98pc(null);
+            stats.SetHisto98Pc(null);
             stats.SetOldestTimestamp(null);
         }
 

--- a/Monero/Wallet/Common/MoneroAccount.cs
+++ b/Monero/Wallet/Common/MoneroAccount.cs
@@ -2,112 +2,112 @@ namespace Monero.Wallet.Common;
 
 public class MoneroAccount
 {
-    private ulong balance;
-    private uint? index;
-    private string? primaryAddress;
-    private List<MoneroSubaddress>? subaddresses;
-    private string? tag;
-    private ulong unlockedBalance;
+    private ulong _balance;
+    private uint? _index;
+    private string? _primaryAddress;
+    private List<MoneroSubaddress>? _subaddresses;
+    private string? _tag;
+    private ulong _unlockedBalance;
 
     public MoneroAccount()
     {
-        balance = 0;
-        unlockedBalance = 0;
+        _balance = 0;
+        _unlockedBalance = 0;
     }
 
     public MoneroAccount(uint? index)
     {
-        this.index = index;
-        balance = 0;
-        unlockedBalance = 0;
+        this._index = index;
+        _balance = 0;
+        _unlockedBalance = 0;
     }
 
     public MoneroAccount(uint? index, string? primaryAddress)
     {
-        this.index = index;
-        this.primaryAddress = primaryAddress;
-        balance = 0;
-        unlockedBalance = 0;
+        this._index = index;
+        this._primaryAddress = primaryAddress;
+        _balance = 0;
+        _unlockedBalance = 0;
     }
 
     public MoneroAccount(uint? index, string? primaryAddress, ulong? balance, ulong? unlockedBalance,
         List<MoneroSubaddress>? subaddresses)
     {
-        this.index = index;
-        this.primaryAddress = primaryAddress;
-        this.balance = balance ?? 0;
-        this.unlockedBalance = unlockedBalance ?? 0;
-        this.subaddresses = subaddresses;
+        this._index = index;
+        this._primaryAddress = primaryAddress;
+        this._balance = balance ?? 0;
+        this._unlockedBalance = unlockedBalance ?? 0;
+        this._subaddresses = subaddresses;
     }
 
     public uint? GetIndex()
     {
-        return index;
+        return _index;
     }
 
     public MoneroAccount SetIndex(uint? index)
     {
-        this.index = index;
+        this._index = index;
         return this;
     }
 
     public string? GetPrimaryAddress()
     {
-        return primaryAddress;
+        return _primaryAddress;
     }
 
     public MoneroAccount SetPrimaryAddress(string? primaryAddress)
     {
-        this.primaryAddress = primaryAddress;
+        this._primaryAddress = primaryAddress;
         return this;
     }
 
     public ulong GetBalance()
     {
-        return balance;
+        return _balance;
     }
 
     public MoneroAccount SetBalance(ulong balance)
     {
-        this.balance = balance;
+        this._balance = balance;
         return this;
     }
 
     public ulong GetUnlockedBalance()
     {
-        return unlockedBalance;
+        return _unlockedBalance;
     }
 
     public MoneroAccount SetUnlockedBalance(ulong unlockedBalance)
     {
-        this.unlockedBalance = unlockedBalance;
+        this._unlockedBalance = unlockedBalance;
         return this;
     }
 
     public string? GetTag()
     {
-        return tag;
+        return _tag;
     }
 
     public MoneroAccount SetTag(string? tag)
     {
-        this.tag = tag;
+        this._tag = tag;
         return this;
     }
 
     public List<MoneroSubaddress>? GetSubaddresses()
     {
-        return subaddresses;
+        return _subaddresses;
     }
 
     public MoneroAccount SetSubaddresses(List<MoneroSubaddress>? subaddresses)
     {
-        this.subaddresses = subaddresses;
+        this._subaddresses = subaddresses;
         if (subaddresses != null)
         {
             foreach (MoneroSubaddress subaddress in subaddresses)
             {
-                subaddress.SetAccountIndex(index);
+                subaddress.SetAccountIndex(_index);
             }
         }
 

--- a/Monero/Wallet/Common/MoneroAddressBookEntry.cs
+++ b/Monero/Wallet/Common/MoneroAddressBookEntry.cs
@@ -2,10 +2,10 @@ namespace Monero.Wallet.Common;
 
 public class MoneroAddressBookEntry
 {
-    private string? address;
-    private string? description;
-    private uint? index;
-    private string? paymentId;
+    private string? _address;
+    private string? _description;
+    private uint? _index;
+    private string? _paymentId;
 
     public MoneroAddressBookEntry()
     {
@@ -14,73 +14,73 @@ public class MoneroAddressBookEntry
 
     public MoneroAddressBookEntry(uint? index)
     {
-        this.index = index;
+        this._index = index;
     }
 
     public MoneroAddressBookEntry(uint? index, string? address)
     {
-        this.index = index;
-        this.address = address;
+        this._index = index;
+        this._address = address;
     }
 
     public MoneroAddressBookEntry(uint? index, string? address, string? description)
     {
-        this.index = index;
-        this.address = address;
-        this.description = description;
+        this._index = index;
+        this._address = address;
+        this._description = description;
     }
 
     public MoneroAddressBookEntry(uint? index, string? address, string? description,
         string? paymentId)
     {
-        this.index = index;
-        this.address = address;
-        this.paymentId = paymentId;
-        this.description = description;
+        this._index = index;
+        this._address = address;
+        this._paymentId = paymentId;
+        this._description = description;
     }
 
 
     public uint? GetIndex()
     {
-        return index;
+        return _index;
     }
 
     public MoneroAddressBookEntry SetIndex(uint? index)
     {
-        this.index = index;
+        this._index = index;
         return this;
     }
 
     public string? GetAddress()
     {
-        return address;
+        return _address;
     }
 
     public MoneroAddressBookEntry SetAddress(string? address)
     {
-        this.address = address;
+        this._address = address;
         return this;
     }
 
     public string? GetPaymentId()
     {
-        return paymentId;
+        return _paymentId;
     }
 
     public MoneroAddressBookEntry SetPaymentId(string? paymentId)
     {
-        this.paymentId = paymentId;
+        this._paymentId = paymentId;
         return this;
     }
 
     public string? GetDescription()
     {
-        return description;
+        return _description;
     }
 
     public MoneroAddressBookEntry SetDescription(string? description)
     {
-        this.description = description;
+        this._description = description;
         return this;
     }
 }

--- a/Monero/Wallet/Common/MoneroCheckReserve.cs
+++ b/Monero/Wallet/Common/MoneroCheckReserve.cs
@@ -4,8 +4,8 @@ namespace Monero.Wallet.Common;
 
 public class MoneroCheckReserve : MoneroCheck
 {
-    private ulong? totalAmount;
-    private ulong? unconfirmedSpentAmount;
+    private ulong? _totalAmount;
+    private ulong? _unconfirmedSpentAmount;
 
     public MoneroCheckReserve()
         : base(false)
@@ -16,29 +16,29 @@ public class MoneroCheckReserve : MoneroCheck
     public MoneroCheckReserve(bool isGood, ulong? totalAmount, ulong? unconfirmedSpentAmount)
         : base(isGood)
     {
-        this.totalAmount = totalAmount;
-        this.unconfirmedSpentAmount = unconfirmedSpentAmount;
+        this._totalAmount = totalAmount;
+        this._unconfirmedSpentAmount = unconfirmedSpentAmount;
     }
 
     public ulong? GetTotalAmount()
     {
-        return totalAmount;
+        return _totalAmount;
     }
 
     public MoneroCheckReserve SetTotalAmount(ulong? totalAmount)
     {
-        this.totalAmount = totalAmount;
+        this._totalAmount = totalAmount;
         return this;
     }
 
     public ulong? GetUnconfirmedSpentAmount()
     {
-        return unconfirmedSpentAmount;
+        return _unconfirmedSpentAmount;
     }
 
     public MoneroCheckReserve SetUnconfirmedSpentAmount(ulong? unconfirmedSpentAmount)
     {
-        this.unconfirmedSpentAmount = unconfirmedSpentAmount;
+        this._unconfirmedSpentAmount = unconfirmedSpentAmount;
         return this;
     }
 }

--- a/Monero/Wallet/Common/MoneroCheckTx.cs
+++ b/Monero/Wallet/Common/MoneroCheckTx.cs
@@ -4,40 +4,40 @@ namespace Monero.Wallet.Common;
 
 public class MoneroCheckTx : MoneroCheck
 {
-    private bool? inTxPool;
-    private ulong? numConfirmations;
-    private ulong? receivedAmount;
+    private bool? _inTxPool;
+    private ulong? _numConfirmations;
+    private ulong? _receivedAmount;
 
     public bool? InTxPool()
     {
-        return inTxPool;
+        return _inTxPool;
     }
 
     public MoneroCheckTx SetInTxPool(bool? inTxPool)
     {
-        this.inTxPool = inTxPool;
+        this._inTxPool = inTxPool;
         return this;
     }
 
     public ulong? GetNumConfirmations()
     {
-        return numConfirmations;
+        return _numConfirmations;
     }
 
     public MoneroCheckTx SetNumConfirmations(ulong? numConfirmations)
     {
-        this.numConfirmations = numConfirmations;
+        this._numConfirmations = numConfirmations;
         return this;
     }
 
     public ulong? GetReceivedAmount()
     {
-        return receivedAmount;
+        return _receivedAmount;
     }
 
     public MoneroCheckTx SetReceivedAmount(ulong? receivedAmount)
     {
-        this.receivedAmount = receivedAmount;
+        this._receivedAmount = receivedAmount;
         return this;
     }
 }

--- a/Monero/Wallet/Common/MoneroIncomingTransfer.cs
+++ b/Monero/Wallet/Common/MoneroIncomingTransfer.cs
@@ -2,9 +2,9 @@ namespace Monero.Wallet.Common;
 
 public class MoneroIncomingTransfer : MoneroTransfer
 {
-    private string? address;
-    private ulong? numSuggestedConfirmations;
-    private uint? subaddressIndex;
+    private string? _address;
+    private ulong? _numSuggestedConfirmations;
+    private uint? _subaddressIndex;
 
     public MoneroIncomingTransfer()
     {
@@ -13,9 +13,9 @@ public class MoneroIncomingTransfer : MoneroTransfer
 
     public MoneroIncomingTransfer(MoneroIncomingTransfer transfer) : base(transfer)
     {
-        subaddressIndex = transfer.subaddressIndex;
-        address = transfer.address;
-        numSuggestedConfirmations = transfer.numSuggestedConfirmations;
+        _subaddressIndex = transfer._subaddressIndex;
+        _address = transfer._address;
+        _numSuggestedConfirmations = transfer._numSuggestedConfirmations;
     }
 
     public override MoneroIncomingTransfer Clone()
@@ -36,34 +36,34 @@ public class MoneroIncomingTransfer : MoneroTransfer
 
     public uint? GetSubaddressIndex()
     {
-        return subaddressIndex;
+        return _subaddressIndex;
     }
 
     public MoneroIncomingTransfer SetSubaddressIndex(uint? subaddressIndex)
     {
-        this.subaddressIndex = subaddressIndex;
+        this._subaddressIndex = subaddressIndex;
         return this;
     }
 
     public string? GetAddress()
     {
-        return address;
+        return _address;
     }
 
     public MoneroIncomingTransfer SetAddress(string? address)
     {
-        this.address = address;
+        this._address = address;
         return this;
     }
 
     public ulong? GetNumSuggestedConfirmations()
     {
-        return numSuggestedConfirmations;
+        return _numSuggestedConfirmations;
     }
 
     public MoneroIncomingTransfer SetNumSuggestedConfirmations(ulong? numSuggestedConfirmations)
     {
-        this.numSuggestedConfirmations = numSuggestedConfirmations;
+        this._numSuggestedConfirmations = numSuggestedConfirmations;
         return this;
     }
 }

--- a/Monero/Wallet/Common/MoneroIncomingTransferComparer.cs
+++ b/Monero/Wallet/Common/MoneroIncomingTransferComparer.cs
@@ -2,7 +2,7 @@ namespace Monero.Wallet.Common;
 
 internal class MoneroIncomingTransferComparer : Comparer<MoneroIncomingTransfer>
 {
-    private static readonly MoneroTxHeightComparer TX_HEIGHT_COMPARATOR = new();
+    private static readonly MoneroTxHeightComparer TxHeightComparator = new();
 
     public override int Compare(MoneroIncomingTransfer? t1, MoneroIncomingTransfer? t2)
     {
@@ -22,7 +22,7 @@ internal class MoneroIncomingTransferComparer : Comparer<MoneroIncomingTransfer>
             return -1;
         }
 
-        int heightComparison = TX_HEIGHT_COMPARATOR.Compare(t1.GetTx(), t2.GetTx());
+        int heightComparison = TxHeightComparator.Compare(t1.GetTx(), t2.GetTx());
         if (heightComparison != 0)
         {
             return heightComparison;

--- a/Monero/Wallet/Common/MoneroMessageSignatureType.cs
+++ b/Monero/Wallet/Common/MoneroMessageSignatureType.cs
@@ -2,6 +2,6 @@ namespace Monero.Wallet.Common;
 
 public enum MoneroMessageSignatureType
 {
-    SIGN_WITH_SPEND_KEY = 0,
-    SIGN_WITH_VIEW_KEY = 1
+    SignWithSpendKey = 0,
+    SignWithViewKey = 1
 }

--- a/Monero/Wallet/Common/MoneroOutgoingTransfer.cs
+++ b/Monero/Wallet/Common/MoneroOutgoingTransfer.cs
@@ -2,9 +2,9 @@ namespace Monero.Wallet.Common;
 
 public class MoneroOutgoingTransfer : MoneroTransfer
 {
-    private List<string>? addresses;
-    private List<MoneroDestination>? destinations;
-    private List<uint>? subaddressIndices;
+    private List<string>? _addresses;
+    private List<MoneroDestination>? _destinations;
+    private List<uint>? _subaddressIndices;
 
     public MoneroOutgoingTransfer()
     {
@@ -13,22 +13,22 @@ public class MoneroOutgoingTransfer : MoneroTransfer
 
     public MoneroOutgoingTransfer(MoneroOutgoingTransfer transfer) : base(transfer)
     {
-        if (transfer.subaddressIndices != null)
+        if (transfer._subaddressIndices != null)
         {
-            subaddressIndices = new List<uint>(transfer.subaddressIndices);
+            _subaddressIndices = new List<uint>(transfer._subaddressIndices);
         }
 
-        if (transfer.addresses != null)
+        if (transfer._addresses != null)
         {
-            addresses = new List<string>(transfer.addresses);
+            _addresses = new List<string>(transfer._addresses);
         }
 
-        if (transfer.destinations != null)
+        if (transfer._destinations != null)
         {
-            destinations = [];
-            foreach (MoneroDestination destination in transfer.destinations)
+            _destinations = [];
+            foreach (MoneroDestination destination in transfer._destinations)
             {
-                destinations.Add(destination.Clone());
+                _destinations.Add(destination.Clone());
             }
         }
     }
@@ -51,34 +51,34 @@ public class MoneroOutgoingTransfer : MoneroTransfer
 
     public List<uint>? GetSubaddressIndices()
     {
-        return subaddressIndices;
+        return _subaddressIndices;
     }
 
     public MoneroOutgoingTransfer SetSubaddressIndices(List<uint> subaddressIndices)
     {
-        this.subaddressIndices = subaddressIndices;
+        this._subaddressIndices = subaddressIndices;
         return this;
     }
 
     public List<string>? GetAddresses()
     {
-        return addresses;
+        return _addresses;
     }
 
     public MoneroOutgoingTransfer SetAddresses(List<string> addresses)
     {
-        this.addresses = addresses;
+        this._addresses = addresses;
         return this;
     }
 
     public List<MoneroDestination>? GetDestinations()
     {
-        return destinations;
+        return _destinations;
     }
 
     public MoneroOutgoingTransfer SetDestinations(List<MoneroDestination>? destinations)
     {
-        this.destinations = destinations;
+        this._destinations = destinations;
         return this;
     }
 }

--- a/Monero/Wallet/Common/MoneroOutputComparer.cs
+++ b/Monero/Wallet/Common/MoneroOutputComparer.cs
@@ -4,7 +4,7 @@ namespace Monero.Wallet.Common;
 
 internal class MoneroOutputComparer : Comparer<MoneroOutput>
 {
-    private static readonly MoneroTxHeightComparer TX_HEIGHT_COMPARATOR = new();
+    private static readonly MoneroTxHeightComparer TxHeightComparator = new();
 
     public override int Compare(MoneroOutput? o1, MoneroOutput? o2)
     {
@@ -27,7 +27,7 @@ internal class MoneroOutputComparer : Comparer<MoneroOutput>
         }
 
         // compare by height
-        int heightComparison = TX_HEIGHT_COMPARATOR.Compare(ow1.GetTx(), ow2.GetTx());
+        int heightComparison = TxHeightComparator.Compare(ow1.GetTx(), ow2.GetTx());
         if (heightComparison != 0)
         {
             return heightComparison;
@@ -143,6 +143,6 @@ internal class MoneroOutputComparer : Comparer<MoneroOutput>
             return 1; // output 2 has no key image hex
         }
 
-        return ow1KeyImageHex.CompareTo(ow2KeyImageHex);
+        return String.Compare(ow1KeyImageHex, ow2KeyImageHex, StringComparison.Ordinal);
     }
 }

--- a/Monero/Wallet/Common/MoneroOutputQuery.cs
+++ b/Monero/Wallet/Common/MoneroOutputQuery.cs
@@ -2,10 +2,10 @@ namespace Monero.Wallet.Common;
 
 public class MoneroOutputQuery : MoneroOutputWallet
 {
-    private ulong? maxAmount;
-    private ulong? minAmount;
-    private List<uint>? subaddressIndices;
-    protected MoneroTxQuery? txQuery;
+    private ulong? _maxAmount;
+    private ulong? _minAmount;
+    private List<uint>? _subaddressIndices;
+    protected MoneroTxQuery? _txQuery;
 
     public MoneroOutputQuery() { }
 
@@ -13,21 +13,21 @@ public class MoneroOutputQuery : MoneroOutputWallet
     {
         if (query.GetMinAmount() != null)
         {
-            minAmount = query.GetMinAmount();
+            _minAmount = query.GetMinAmount();
         }
 
         if (query.GetMaxAmount() != null)
         {
-            maxAmount = query.GetMaxAmount();
+            _maxAmount = query.GetMaxAmount();
         }
 
-        if (query.subaddressIndices != null)
+        if (query._subaddressIndices != null)
         {
-            subaddressIndices = new List<uint>(query.subaddressIndices);
+            _subaddressIndices = new List<uint>(query._subaddressIndices);
         }
 
-        txQuery =
-            query.txQuery; // reference original by default, MoneroTxQuery's deep copy will Set this to itself
+        _txQuery =
+            query._txQuery; // reference original by default, MoneroTxQuery's deep copy will Set this to itself
     }
 
     public override MoneroOutputQuery Clone()
@@ -37,34 +37,34 @@ public class MoneroOutputQuery : MoneroOutputWallet
 
     public ulong? GetMinAmount()
     {
-        return minAmount;
+        return _minAmount;
     }
 
     public MoneroOutputQuery SetMinAmount(ulong minAmount)
     {
-        this.minAmount = minAmount;
+        this._minAmount = minAmount;
         return this;
     }
 
     public ulong? GetMaxAmount()
     {
-        return maxAmount;
+        return _maxAmount;
     }
 
     public MoneroOutputQuery SetMaxAmount(ulong maxAmount)
     {
-        this.maxAmount = maxAmount;
+        this._maxAmount = maxAmount;
         return this;
     }
 
     public MoneroTxQuery? GetTxQuery()
     {
-        return txQuery;
+        return _txQuery;
     }
 
     public MoneroOutputQuery SetTxQuery(MoneroTxQuery? txQuery)
     {
-        this.txQuery = txQuery;
+        this._txQuery = txQuery;
         if (txQuery != null)
         {
             txQuery.SetOutputQuery(this);
@@ -75,12 +75,12 @@ public class MoneroOutputQuery : MoneroOutputWallet
 
     public List<uint>? GetSubaddressIndices()
     {
-        return subaddressIndices;
+        return _subaddressIndices;
     }
 
     public MoneroOutputQuery SetSubaddressIndices(List<uint>? subaddressIndices)
     {
-        this.subaddressIndices = subaddressIndices;
+        this._subaddressIndices = subaddressIndices;
         return this;
     }
 

--- a/Monero/Wallet/Common/MoneroOutputWallet.cs
+++ b/Monero/Wallet/Common/MoneroOutputWallet.cs
@@ -4,10 +4,10 @@ namespace Monero.Wallet.Common;
 
 public class MoneroOutputWallet : MoneroOutput
 {
-    private uint? accountIndex;
-    private bool isFrozen;
-    private bool isSpent;
-    private uint? subaddressIndex;
+    private uint? _accountIndex;
+    private bool? _isFrozen;
+    private bool? _isSpent;
+    private uint? _subaddressIndex;
 
     public MoneroOutputWallet()
     {
@@ -15,10 +15,10 @@ public class MoneroOutputWallet : MoneroOutput
 
     public MoneroOutputWallet(MoneroOutputWallet output) : base(output)
     {
-        accountIndex = output.accountIndex;
-        subaddressIndex = output.subaddressIndex;
-        isSpent = output.isSpent;
-        isFrozen = output.isFrozen;
+        _accountIndex = output._accountIndex;
+        _subaddressIndex = output._subaddressIndex;
+        _isSpent = output._isSpent;
+        _isFrozen = output._isFrozen;
     }
 
     public override MoneroOutputWallet Clone()
@@ -47,23 +47,23 @@ public class MoneroOutputWallet : MoneroOutput
 
     public uint? GetAccountIndex()
     {
-        return accountIndex;
+        return _accountIndex;
     }
 
     public MoneroOutputWallet SetAccountIndex(uint? accountIndex)
     {
-        this.accountIndex = accountIndex;
+        this._accountIndex = accountIndex;
         return this;
     }
 
     public uint? GetSubaddressIndex()
     {
-        return subaddressIndex;
+        return _subaddressIndex;
     }
 
     public MoneroOutputWallet SetSubaddressIndex(uint? subaddressIndex)
     {
-        this.subaddressIndex = subaddressIndex;
+        this._subaddressIndex = subaddressIndex;
         return this;
     }
 
@@ -73,25 +73,25 @@ public class MoneroOutputWallet : MoneroOutput
         return this;
     }
 
-    public bool IsSpent()
+    public bool? IsSpent()
     {
-        return isSpent;
+        return _isSpent;
     }
 
-    public MoneroOutputWallet SetIsSpent(bool isSpent)
+    public MoneroOutputWallet SetIsSpent(bool? isSpent)
     {
-        this.isSpent = isSpent;
+        this._isSpent = isSpent;
         return this;
     }
 
-    public bool IsFrozen()
+    public bool? IsFrozen()
     {
-        return isFrozen;
+        return _isFrozen;
     }
 
-    public MoneroOutputWallet SetIsFrozen(bool isFrozen)
+    public MoneroOutputWallet SetIsFrozen(bool? isFrozen)
     {
-        this.isFrozen = isFrozen;
+        this._isFrozen = isFrozen;
         return this;
     }
 

--- a/Monero/Wallet/Common/MoneroSubaddress.cs
+++ b/Monero/Wallet/Common/MoneroSubaddress.cs
@@ -2,125 +2,125 @@ namespace Monero.Wallet.Common;
 
 public class MoneroSubaddress
 {
-    private uint? accountIndex;
-    private string? address;
-    private ulong? balance;
-    private uint? index;
-    private bool? isUsed;
-    private string? label;
-    private ulong? numBlocksToUnlock;
-    private ulong? numUnspentOutputs;
-    private ulong? unlockedBalance;
+    private uint? _accountIndex;
+    private string? _address;
+    private ulong? _balance;
+    private uint? _index;
+    private bool? _isUsed;
+    private string? _label;
+    private ulong? _numBlocksToUnlock;
+    private ulong? _numUnspentOutputs;
+    private ulong? _unlockedBalance;
 
     public MoneroSubaddress() { }
 
     public MoneroSubaddress(string address)
     {
-        this.address = address;
+        this._address = address;
     }
 
     public MoneroSubaddress(uint accountIndex, uint index)
     {
-        this.accountIndex = accountIndex;
-        this.index = index;
+        this._accountIndex = accountIndex;
+        this._index = index;
     }
 
     public uint? GetAccountIndex()
     {
-        return accountIndex;
+        return _accountIndex;
     }
 
     public MoneroSubaddress SetAccountIndex(uint? accountIndex)
     {
-        this.accountIndex = accountIndex;
+        this._accountIndex = accountIndex;
         return this;
     }
 
     public uint? GetIndex()
     {
-        return index;
+        return _index;
     }
 
     public MoneroSubaddress SetIndex(uint? index)
     {
-        this.index = index;
+        this._index = index;
         return this;
     }
 
     public string? GetAddress()
     {
-        return address;
+        return _address;
     }
 
     public MoneroSubaddress SetAddress(string? address)
     {
-        this.address = address;
+        this._address = address;
         return this;
     }
 
     public string? GetLabel()
     {
-        return label;
+        return _label;
     }
 
     public MoneroSubaddress SetLabel(string? label)
     {
-        this.label = label;
+        this._label = label;
         return this;
     }
 
     public ulong? GetBalance()
     {
-        return balance;
+        return _balance;
     }
 
     public MoneroSubaddress SetBalance(ulong? balance)
     {
-        this.balance = balance;
+        this._balance = balance;
         return this;
     }
 
     public ulong? GetUnlockedBalance()
     {
-        return unlockedBalance;
+        return _unlockedBalance;
     }
 
     public MoneroSubaddress SetUnlockedBalance(ulong? unlockedBalance)
     {
-        this.unlockedBalance = unlockedBalance;
+        this._unlockedBalance = unlockedBalance;
         return this;
     }
 
     public ulong? GetNumUnspentOutputs()
     {
-        return numUnspentOutputs;
+        return _numUnspentOutputs;
     }
 
     public MoneroSubaddress SetNumUnspentOutputs(ulong? numUnspentOutputs)
     {
-        this.numUnspentOutputs = numUnspentOutputs;
+        this._numUnspentOutputs = numUnspentOutputs;
         return this;
     }
 
     public bool? IsUsed()
     {
-        return isUsed;
+        return _isUsed;
     }
 
     public MoneroSubaddress SetIsUsed(bool? isUsed)
     {
-        this.isUsed = isUsed;
+        this._isUsed = isUsed;
         return this;
     }
 
     public ulong? GetNumBlocksToUnlock()
     {
-        return numBlocksToUnlock;
+        return _numBlocksToUnlock;
     }
 
     public MoneroSubaddress SetNumBlocksToUnlock(ulong? numBlocksToUnlock)
     {
-        this.numBlocksToUnlock = numBlocksToUnlock;
+        this._numBlocksToUnlock = numBlocksToUnlock;
         return this;
     }
 }

--- a/Monero/Wallet/Common/MoneroTransferQuery.cs
+++ b/Monero/Wallet/Common/MoneroTransferQuery.cs
@@ -2,14 +2,14 @@ namespace Monero.Wallet.Common;
 
 public class MoneroTransferQuery : MoneroTransfer
 {
-    private string? address;
-    private List<string>? addresses;
-    private List<MoneroDestination>? destinations;
-    private bool? hasDestinations;
-    private bool? isIncoming;
-    private uint? subaddressIndex;
-    private List<uint>? subaddressIndices;
-    protected MoneroTxQuery? txQuery;
+    private string? _address;
+    private List<string>? _addresses;
+    private List<MoneroDestination>? _destinations;
+    private bool? _hasDestinations;
+    private bool? _isIncoming;
+    private uint? _subaddressIndex;
+    private List<uint>? _subaddressIndices;
+    protected MoneroTxQuery? _txQuery;
 
     public MoneroTransferQuery()
     {
@@ -17,31 +17,31 @@ public class MoneroTransferQuery : MoneroTransfer
 
     public MoneroTransferQuery(MoneroTransferQuery query) : base(query)
     {
-        isIncoming = query.isIncoming;
-        address = query.address;
-        if (query.addresses != null)
+        _isIncoming = query._isIncoming;
+        _address = query._address;
+        if (query._addresses != null)
         {
-            addresses = new List<string>(query.addresses);
+            _addresses = new List<string>(query._addresses);
         }
 
-        subaddressIndex = query.subaddressIndex;
-        if (query.subaddressIndices != null)
+        _subaddressIndex = query._subaddressIndex;
+        if (query._subaddressIndices != null)
         {
-            subaddressIndices = new List<uint>(query.subaddressIndices);
+            _subaddressIndices = new List<uint>(query._subaddressIndices);
         }
 
-        if (query.destinations != null)
+        if (query._destinations != null)
         {
-            destinations = [];
-            foreach (MoneroDestination destination in query.destinations)
+            _destinations = [];
+            foreach (MoneroDestination destination in query._destinations)
             {
-                destinations.Add(destination.Clone());
+                _destinations.Add(destination.Clone());
             }
         }
 
-        hasDestinations = query.hasDestinations;
-        txQuery =
-            query.txQuery; // reference original by default, MoneroTxQuery's deep copy will Set this to itself
+        _hasDestinations = query._hasDestinations;
+        _txQuery =
+            query._txQuery; // reference original by default, MoneroTxQuery's deep copy will Set this to itself
     }
 
     public override MoneroTransferQuery Clone()
@@ -51,12 +51,12 @@ public class MoneroTransferQuery : MoneroTransfer
 
     public MoneroTxQuery? GetTxQuery()
     {
-        return txQuery;
+        return _txQuery;
     }
 
     public MoneroTransferQuery SetTxQuery(MoneroTxQuery? txQuery)
     {
-        this.txQuery = txQuery;
+        this._txQuery = txQuery;
         if (txQuery != null)
         {
             txQuery.SetTransferQuery(this);
@@ -67,45 +67,45 @@ public class MoneroTransferQuery : MoneroTransfer
 
     public override bool? IsIncoming()
     {
-        return isIncoming;
+        return _isIncoming;
     }
 
     public MoneroTransferQuery SetIsIncoming(bool? isIncoming)
     {
-        this.isIncoming = isIncoming;
+        this._isIncoming = isIncoming;
         return this;
     }
 
     public override bool? IsOutgoing()
     {
-        return isIncoming == null ? null : !isIncoming;
+        return _isIncoming == null ? null : !_isIncoming;
     }
 
     public MoneroTransferQuery SetIsOutgoing(bool? isOutgoing)
     {
-        isIncoming = isOutgoing == null ? null : !isOutgoing;
+        _isIncoming = isOutgoing == null ? null : !isOutgoing;
         return this;
     }
 
     public string? GetAddress()
     {
-        return address;
+        return _address;
     }
 
     public MoneroTransferQuery SetAddress(string? address)
     {
-        this.address = address;
+        this._address = address;
         return this;
     }
 
     public List<string>? GetAddresses()
     {
-        return addresses;
+        return _addresses;
     }
 
     public MoneroTransferQuery SetAddresses(List<string>? addresses)
     {
-        this.addresses = addresses;
+        this._addresses = addresses;
         return this;
     }
 
@@ -117,45 +117,45 @@ public class MoneroTransferQuery : MoneroTransfer
 
     public uint? GetSubaddressIndex()
     {
-        return subaddressIndex;
+        return _subaddressIndex;
     }
 
     public MoneroTransferQuery SetSubaddressIndex(uint? subaddressIndex)
     {
-        this.subaddressIndex = subaddressIndex;
+        this._subaddressIndex = subaddressIndex;
         return this;
     }
 
     public List<uint>? GetSubaddressIndices()
     {
-        return subaddressIndices;
+        return _subaddressIndices;
     }
 
     public MoneroTransferQuery SetSubaddressIndices(List<uint>? subaddressIndices)
     {
-        this.subaddressIndices = subaddressIndices;
+        this._subaddressIndices = subaddressIndices;
         return this;
     }
 
     public List<MoneroDestination>? GetDestinations()
     {
-        return destinations;
+        return _destinations;
     }
 
     public MoneroTransferQuery SetDestinations(List<MoneroDestination>? destinations)
     {
-        this.destinations = destinations;
+        this._destinations = destinations;
         return this;
     }
 
     public bool? HasDestinations()
     {
-        return hasDestinations;
+        return _hasDestinations;
     }
 
     public MoneroTransferQuery SetHasDestinations(bool? hasDestinations)
     {
-        this.hasDestinations = hasDestinations;
+        this._hasDestinations = hasDestinations;
         return this;
     }
 

--- a/Monero/Wallet/Common/MoneroTxConfig.cs
+++ b/Monero/Wallet/Common/MoneroTxConfig.cs
@@ -7,49 +7,49 @@ namespace Monero.Wallet.Common;
 
 public class MoneroTxConfig
 {
-    private uint? accountIndex;
-    private ulong? belowAmount;
-    private bool? canSplit;
-    private List<MoneroDestination>? destinations;
-    private ulong? fee;
-    private string? keyImage;
-    private string? note;
-    private string? paymentId;
-    private MoneroTxPriority? priority;
-    private string? recipientName;
-    private bool? relay;
-    private List<uint>? subaddressIndices;
-    private List<uint>? subtractFeeFrom;
-    private bool? sweepEachSubaddress;
+    private uint? _accountIndex;
+    private ulong? _belowAmount;
+    private bool? _canSplit;
+    private List<MoneroDestination>? _destinations;
+    private ulong? _fee;
+    private string? _keyImage;
+    private string? _note;
+    private string? _paymentId;
+    private MoneroTxPriority? _priority;
+    private string? _recipientName;
+    private bool? _relay;
+    private List<uint>? _subaddressIndices;
+    private List<uint>? _subtractFeeFrom;
+    private bool? _sweepEachSubaddress;
 
     public MoneroTxConfig() { }
 
     public MoneroTxConfig(MoneroTxConfig config)
     {
-        if (config.destinations != null)
+        if (config._destinations != null)
         {
-            destinations = [.. config.destinations];
+            _destinations = [.. config._destinations];
         }
 
-        if (config.subtractFeeFrom != null)
+        if (config._subtractFeeFrom != null)
         {
-            subtractFeeFrom = [.. config.subtractFeeFrom];
+            _subtractFeeFrom = [.. config._subtractFeeFrom];
         }
-        paymentId = config.paymentId;
-        priority = config.priority;
-        fee = config.fee;
-        accountIndex = config.accountIndex;
-        if (config.subaddressIndices != null)
+        _paymentId = config._paymentId;
+        _priority = config._priority;
+        _fee = config._fee;
+        _accountIndex = config._accountIndex;
+        if (config._subaddressIndices != null)
         {
-            subaddressIndices = [.. config.subaddressIndices];
+            _subaddressIndices = [.. config._subaddressIndices];
         }
-        canSplit = config.canSplit;
-        relay = config.relay;
-        note = config.note;
-        recipientName = config.recipientName;
-        belowAmount = config.belowAmount;
-        sweepEachSubaddress = config.sweepEachSubaddress;
-        keyImage = config.keyImage;
+        _canSplit = config._canSplit;
+        _relay = config._relay;
+        _note = config._note;
+        _recipientName = config._recipientName;
+        _belowAmount = config._belowAmount;
+        _sweepEachSubaddress = config._sweepEachSubaddress;
+        _keyImage = config._keyImage;
     }
 
     public string GetPaymentUri()
@@ -111,45 +111,45 @@ public class MoneroTxConfig
 
     public MoneroTxConfig SetAddress(string? address)
     {
-        if (destinations == null)
+        if (_destinations == null)
         {
-            destinations = [];
+            _destinations = [];
         }
 
-        if (destinations.Count > 1)
+        if (_destinations.Count > 1)
         {
             throw new MoneroError("Cannot Set address when multiple destinations are specified.");
         }
 
-        destinations.Clear();
-        destinations.Add(new MoneroDestination(address, 0));
+        _destinations.Clear();
+        _destinations.Add(new MoneroDestination(address, 0));
         return this;
     }
 
     public string? GetAddress()
     {
-        if (destinations == null || destinations.Count != 1)
+        if (_destinations == null || _destinations.Count != 1)
         {
             throw new MoneroError("Cannot Get address because MoneroTxConfig does not have exactly one destination");
         }
 
-        return destinations[0].GetAddress();
+        return _destinations[0].GetAddress();
     }
 
     public MoneroTxConfig SetAmount(ulong? amount)
     {
-        if (destinations != null && destinations.Count > 1)
+        if (_destinations != null && _destinations.Count > 1)
         {
             throw new MoneroError("Cannot Set amount because MoneroTxConfig already has multiple destinations");
         }
 
-        if (destinations == null || destinations.Count == 0)
+        if (_destinations == null || _destinations.Count == 0)
         {
             AddDestination(new MoneroDestination(null, amount));
         }
         else
         {
-            destinations[0].SetAmount(amount);
+            _destinations[0].SetAmount(amount);
         }
 
         return this;
@@ -163,12 +163,12 @@ public class MoneroTxConfig
 
     public ulong? GetAmount()
     {
-        if (destinations == null || destinations.Count != 1)
+        if (_destinations == null || _destinations.Count != 1)
         {
             throw new MoneroError("Cannot Get amount because MoneroTxConfig does not have exactly one destination");
         }
 
-        return destinations[0].GetAmount();
+        return _destinations[0].GetAmount();
     }
 
     public MoneroTxConfig AddDestination(string address, ulong amount)
@@ -178,84 +178,84 @@ public class MoneroTxConfig
 
     public MoneroTxConfig AddDestination(MoneroDestination destination)
     {
-        if (destinations == null)
+        if (_destinations == null)
         {
-            destinations = [];
+            _destinations = [];
         }
 
-        destinations.Add(destination);
+        _destinations.Add(destination);
         return this;
     }
 
     public List<MoneroDestination>? GetDestinations()
     {
-        return destinations;
+        return _destinations;
     }
 
     public MoneroTxConfig SetDestinations(List<MoneroDestination> destinations)
     {
-        this.destinations = destinations;
+        this._destinations = destinations;
         return this;
     }
 
     public List<uint>? GetSubtractFeeFrom()
     {
-        return subtractFeeFrom;
+        return _subtractFeeFrom;
     }
 
     public MoneroTxConfig SetSubtractFeeFrom(List<uint> destinationIndices)
     {
-        subtractFeeFrom = destinationIndices;
+        _subtractFeeFrom = destinationIndices;
         return this;
     }
 
     public string? GetPaymentId()
     {
-        return paymentId;
+        return _paymentId;
     }
 
     public MoneroTxConfig SetPaymentId(string? paymentId)
     {
-        this.paymentId = paymentId;
+        this._paymentId = paymentId;
         return this;
     }
 
     public MoneroTxPriority? GetPriority()
     {
-        return priority;
+        return _priority;
     }
 
     public MoneroTxConfig SetPriority(MoneroTxPriority priority)
     {
-        this.priority = priority;
+        this._priority = priority;
         return this;
     }
 
     public ulong? GetFee()
     {
-        return fee;
+        return _fee;
     }
 
     public MoneroTxConfig SetFee(ulong? fee)
     {
-        this.fee = fee;
+        this._fee = fee;
         return this;
     }
 
     public uint? GetAccountIndex()
     {
-        return accountIndex;
+        return _accountIndex;
     }
 
     public MoneroTxConfig SetAccountIndex(uint? accountIndex)
     {
-        this.accountIndex = accountIndex;
+        this._accountIndex = accountIndex;
         return this;
     }
 
     public List<uint>? GetSubaddressIndices()
     {
-        return subaddressIndices;
+        return _subaddressIndices;
     }
 
     public MoneroTxConfig SetSubaddressIndex(uint subaddressIndex)
@@ -266,90 +266,90 @@ public class MoneroTxConfig
 
     public MoneroTxConfig SetSubaddressIndices(List<uint>? subaddressIndicesList)
     {
-        this.subaddressIndices = subaddressIndicesList;
+        this._subaddressIndices = subaddressIndicesList;
         return this;
     }
 
     public MoneroTxConfig SetSubaddressIndices(uint subaddressIndex)
     {
-        subaddressIndices = [subaddressIndex];
+        _subaddressIndices = [subaddressIndex];
         return this;
     }
 
     public bool? GetCanSplit()
     {
-        return canSplit;
+        return _canSplit;
     }
 
     public MoneroTxConfig SetCanSplit(bool? canSplit)
     {
-        this.canSplit = canSplit;
+        this._canSplit = canSplit;
         return this;
     }
 
     public bool? GetRelay()
     {
-        return relay;
+        return _relay;
     }
 
     public MoneroTxConfig SetRelay(bool? relay)
     {
-        this.relay = relay;
+        this._relay = relay;
         return this;
     }
 
     public string? GetNote()
     {
-        return note;
+        return _note;
     }
 
     public MoneroTxConfig SetNote(string? note)
     {
-        this.note = note;
+        this._note = note;
         return this;
     }
 
     public string? GetRecipientName()
     {
-        return recipientName;
+        return _recipientName;
     }
 
     public MoneroTxConfig SetRecipientName(string? recipientName)
     {
-        this.recipientName = recipientName;
+        this._recipientName = recipientName;
         return this;
     }
 
     public ulong? GetBelowAmount()
     {
-        return belowAmount;
+        return _belowAmount;
     }
 
     public MoneroTxConfig SetBelowAmount(ulong? belowAmount)
     {
-        this.belowAmount = belowAmount;
+        this._belowAmount = belowAmount;
         return this;
     }
 
     public bool? GetSweepEachSubaddress()
     {
-        return sweepEachSubaddress;
+        return _sweepEachSubaddress;
     }
 
     public MoneroTxConfig SetSweepEachSubaddress(bool? sweepEachSubaddress)
     {
-        this.sweepEachSubaddress = sweepEachSubaddress;
+        this._sweepEachSubaddress = sweepEachSubaddress;
         return this;
     }
 
     public string? GetKeyImage()
     {
-        return keyImage;
+        return _keyImage;
     }
 
     public MoneroTxConfig SetKeyImage(string keyImage)
     {
-        this.keyImage = keyImage;
+        this._keyImage = keyImage;
         return this;
     }
 }

--- a/Monero/Wallet/Common/MoneroTxPriority.cs
+++ b/Monero/Wallet/Common/MoneroTxPriority.cs
@@ -2,8 +2,8 @@ namespace Monero.Wallet.Common;
 
 public enum MoneroTxPriority
 {
-    DEFAULT,
-    UNIMPORTANT,
-    NORMAL,
-    ELEVATED
+    Default,
+    Unimportant,
+    Normal,
+    Elevated
 }

--- a/Monero/Wallet/Common/MoneroTxQuery.cs
+++ b/Monero/Wallet/Common/MoneroTxQuery.cs
@@ -4,18 +4,18 @@ namespace Monero.Wallet.Common;
 
 public class MoneroTxQuery : MoneroTxWallet
 {
-    private List<string>? hashes;
-    private bool? hasPaymentId;
-    private ulong? height;
-    private bool? includeOutputs;
-    protected MoneroOutputQuery? inputQuery;
-    private bool? isIncoming;
-    private bool? isOutgoing;
-    private ulong? maxHeight;
-    private ulong? minHeight;
-    protected MoneroOutputQuery? outputQuery;
-    private List<string>? paymentIds;
-    protected MoneroTransferQuery? transferQuery;
+    private List<string>? _hashes;
+    private bool? _hasPaymentId;
+    private ulong? _height;
+    private bool? _includeOutputs;
+    private MoneroOutputQuery? _inputQuery;
+    private bool? _isIncoming;
+    private bool? _isOutgoing;
+    private ulong? _maxHeight;
+    private ulong? _minHeight;
+    private MoneroOutputQuery? _outputQuery;
+    private List<string>? _paymentIds;
+    private MoneroTransferQuery? _transferQuery;
 
     public MoneroTxQuery()
     {
@@ -23,36 +23,36 @@ public class MoneroTxQuery : MoneroTxWallet
 
     public MoneroTxQuery(MoneroTxQuery query) : base(query)
     {
-        isOutgoing = query.isOutgoing;
-        isIncoming = query.isIncoming;
-        if (query.hashes != null)
+        _isOutgoing = query._isOutgoing;
+        _isIncoming = query._isIncoming;
+        if (query._hashes != null)
         {
-            hashes = new List<string>(query.hashes);
+            _hashes = new List<string>(query._hashes);
         }
 
-        hasPaymentId = query.hasPaymentId;
-        if (query.paymentIds != null)
+        _hasPaymentId = query._hasPaymentId;
+        if (query._paymentIds != null)
         {
-            paymentIds = new List<string>(query.paymentIds);
+            _paymentIds = new List<string>(query._paymentIds);
         }
 
-        height = query.height;
-        minHeight = query.minHeight;
-        maxHeight = query.maxHeight;
-        includeOutputs = query.includeOutputs;
-        if (query.transferQuery != null)
+        _height = query._height;
+        _minHeight = query._minHeight;
+        _maxHeight = query._maxHeight;
+        _includeOutputs = query._includeOutputs;
+        if (query._transferQuery != null)
         {
-            SetTransferQuery(new MoneroTransferQuery(query.transferQuery));
+            SetTransferQuery(new MoneroTransferQuery(query._transferQuery));
         }
 
-        if (query.inputQuery != null)
+        if (query._inputQuery != null)
         {
-            SetInputQuery(new MoneroOutputQuery(query.inputQuery));
+            SetInputQuery(new MoneroOutputQuery(query._inputQuery));
         }
 
-        if (query.outputQuery != null)
+        if (query._outputQuery != null)
         {
-            SetOutputQuery(new MoneroOutputQuery(query.outputQuery));
+            SetOutputQuery(new MoneroOutputQuery(query._outputQuery));
         }
     }
 
@@ -69,23 +69,23 @@ public class MoneroTxQuery : MoneroTxWallet
 
     public override bool? IsOutgoing()
     {
-        return isOutgoing;
+        return _isOutgoing;
     }
 
     public override MoneroTxQuery SetIsOutgoing(bool? isOutgoing)
     {
-        this.isOutgoing = isOutgoing;
+        this._isOutgoing = isOutgoing;
         return this;
     }
 
     public override bool? IsIncoming()
     {
-        return isIncoming;
+        return _isIncoming;
     }
 
     public override MoneroTxQuery SetIsIncoming(bool? isIncoming)
     {
-        this.isIncoming = isIncoming;
+        this._isIncoming = isIncoming;
         return this;
     }
 
@@ -107,34 +107,34 @@ public class MoneroTxQuery : MoneroTxWallet
 
     public List<string>? GetHashes()
     {
-        return hashes;
+        return _hashes;
     }
 
     public MoneroTxQuery SetHashes(List<string>? hashes)
     {
-        this.hashes = hashes;
+        this._hashes = hashes;
         return this;
     }
 
     public bool? HasPaymentId()
     {
-        return hasPaymentId;
+        return _hasPaymentId;
     }
 
     public MoneroTxQuery SetHasPaymentId(bool? hasPaymentId)
     {
-        this.hasPaymentId = hasPaymentId;
+        this._hasPaymentId = hasPaymentId;
         return this;
     }
 
     public List<string>? GetPaymentIds()
     {
-        return paymentIds;
+        return _paymentIds;
     }
 
     public MoneroTxQuery SetPaymentIds(List<string>? paymentIds)
     {
-        this.paymentIds = paymentIds;
+        this._paymentIds = paymentIds;
         return this;
     }
 
@@ -154,34 +154,34 @@ public class MoneroTxQuery : MoneroTxWallet
 
     public override ulong? GetHeight()
     {
-        return height;
+        return _height;
     }
 
     public MoneroTxQuery SetHeight(ulong? height)
     {
-        this.height = height;
+        this._height = height;
         return this;
     }
 
     public ulong? GetMinHeight()
     {
-        return minHeight;
+        return _minHeight;
     }
 
     public MoneroTxQuery SetMinHeight(ulong? minHeight)
     {
-        this.minHeight = minHeight;
+        this._minHeight = minHeight;
         return this;
     }
 
     public ulong? GetMaxHeight()
     {
-        return maxHeight;
+        return _maxHeight;
     }
 
     public MoneroTxQuery SetMaxHeight(ulong? maxHeight)
     {
-        this.maxHeight = maxHeight;
+        this._maxHeight = maxHeight;
         return this;
     }
 
@@ -193,23 +193,23 @@ public class MoneroTxQuery : MoneroTxWallet
 
     public bool? GetIncludeOutputs()
     {
-        return includeOutputs;
+        return _includeOutputs;
     }
 
     public MoneroTxQuery SetIncludeOutputs(bool? includeOutputs)
     {
-        this.includeOutputs = includeOutputs;
+        this._includeOutputs = includeOutputs;
         return this;
     }
 
     public MoneroTransferQuery? GetTransferQuery()
     {
-        return transferQuery;
+        return _transferQuery;
     }
 
     public MoneroTxQuery SetTransferQuery(MoneroTransferQuery? transferQuery)
     {
-        this.transferQuery = transferQuery;
+        this._transferQuery = transferQuery;
         if (transferQuery != null)
         {
             transferQuery.SetTxQuery(this);
@@ -220,12 +220,12 @@ public class MoneroTxQuery : MoneroTxWallet
 
     public MoneroOutputQuery? GetInputQuery()
     {
-        return inputQuery;
+        return _inputQuery;
     }
 
     public MoneroTxQuery SetInputQuery(MoneroOutputQuery? inputQuery)
     {
-        this.inputQuery = inputQuery;
+        this._inputQuery = inputQuery;
         if (inputQuery != null)
         {
             inputQuery.SetTxQuery(this);
@@ -236,12 +236,12 @@ public class MoneroTxQuery : MoneroTxWallet
 
     public MoneroOutputQuery? GetOutputQuery()
     {
-        return outputQuery;
+        return _outputQuery;
     }
 
     public MoneroTxQuery SetOutputQuery(MoneroOutputQuery? outputQuery)
     {
-        this.outputQuery = outputQuery;
+        this._outputQuery = outputQuery;
         if (outputQuery != null)
         {
             outputQuery.SetTxQuery(this);

--- a/Monero/Wallet/Common/MoneroTxWallet.cs
+++ b/Monero/Wallet/Common/MoneroTxWallet.cs
@@ -4,19 +4,19 @@ namespace Monero.Wallet.Common;
 
 public class MoneroTxWallet : MoneroTx
 {
-    private string? changeAddress;
-    private ulong? changeAmount;
-    private string? extraHex; // TODO: refactor MoneroTx to only use extra as hex string
-    private List<MoneroIncomingTransfer>? incomingTransfers;
-    private ulong? inputSum;
-    private bool? isIncoming;
-    private bool? isLocked;
-    private bool? isOutgoing;
-    private string? note;
-    private uint? numDummyOutputs;
-    private MoneroOutgoingTransfer? outgoingTransfer;
-    private ulong? outputSum;
-    private MoneroTxSet? txSet;
+    private string? _changeAddress;
+    private ulong? _changeAmount;
+    private string? _extraHex; // TODO: refactor MoneroTx to only use extra as hex string
+    private List<MoneroIncomingTransfer>? _incomingTransfers;
+    private ulong? _inputSum;
+    private bool? _isIncoming;
+    private bool? _isLocked;
+    private bool? _isOutgoing;
+    private string? _note;
+    private uint? _numDummyOutputs;
+    private MoneroOutgoingTransfer? _outgoingTransfer;
+    private ulong? _outputSum;
+    private MoneroTxSet? _txSet;
 
     public MoneroTxWallet()
     {
@@ -25,31 +25,31 @@ public class MoneroTxWallet : MoneroTx
 
     public MoneroTxWallet(MoneroTxWallet tx) : base(tx)
     {
-        txSet = tx.txSet;
-        isIncoming = tx.isIncoming;
-        isOutgoing = tx.isOutgoing;
-        if (tx.incomingTransfers != null)
+        _txSet = tx._txSet;
+        _isIncoming = tx._isIncoming;
+        _isOutgoing = tx._isOutgoing;
+        if (tx._incomingTransfers != null)
         {
-            incomingTransfers = [];
-            foreach (MoneroIncomingTransfer transfer in tx.incomingTransfers)
+            _incomingTransfers = [];
+            foreach (MoneroIncomingTransfer transfer in tx._incomingTransfers)
             {
-                incomingTransfers.Add(transfer.Clone().SetTx(this));
+                _incomingTransfers.Add(transfer.Clone().SetTx(this));
             }
         }
 
-        if (tx.outgoingTransfer != null)
+        if (tx._outgoingTransfer != null)
         {
-            outgoingTransfer = tx.outgoingTransfer.Clone().SetTx(this);
+            _outgoingTransfer = tx._outgoingTransfer.Clone().SetTx(this);
         }
 
-        note = tx.note;
-        isLocked = tx.isLocked;
-        inputSum = tx.inputSum;
-        outputSum = tx.outputSum;
-        changeAddress = tx.changeAddress;
-        changeAmount = tx.changeAmount;
-        numDummyOutputs = tx.numDummyOutputs;
-        extraHex = tx.extraHex;
+        _note = tx._note;
+        _isLocked = tx._isLocked;
+        _inputSum = tx._inputSum;
+        _outputSum = tx._outputSum;
+        _changeAddress = tx._changeAddress;
+        _changeAmount = tx._changeAmount;
+        _numDummyOutputs = tx._numDummyOutputs;
+        _extraHex = tx._extraHex;
     }
 
     public override MoneroTxWallet Clone()
@@ -59,34 +59,34 @@ public class MoneroTxWallet : MoneroTx
 
     public MoneroTxSet? GetTxSet()
     {
-        return txSet;
+        return _txSet;
     }
 
     public virtual MoneroTxWallet SetTxSet(MoneroTxSet? txSet)
     {
-        this.txSet = txSet;
+        this._txSet = txSet;
         return this;
     }
 
     public virtual bool? IsIncoming()
     {
-        return isIncoming;
+        return _isIncoming;
     }
 
     public virtual MoneroTxWallet SetIsIncoming(bool? isIncoming)
     {
-        this.isIncoming = isIncoming;
+        this._isIncoming = isIncoming;
         return this;
     }
 
     public virtual bool? IsOutgoing()
     {
-        return isOutgoing;
+        return _isOutgoing;
     }
 
     public virtual MoneroTxWallet SetIsOutgoing(bool? isOutgoing)
     {
-        this.isOutgoing = isOutgoing;
+        this._isOutgoing = isOutgoing;
         return this;
     }
 
@@ -193,23 +193,23 @@ public class MoneroTxWallet : MoneroTx
 
     public List<MoneroIncomingTransfer>? GetIncomingTransfers()
     {
-        return incomingTransfers;
+        return _incomingTransfers;
     }
 
     public virtual MoneroTxWallet SetIncomingTransfers(List<MoneroIncomingTransfer>? incomingTransfers)
     {
-        this.incomingTransfers = incomingTransfers;
+        this._incomingTransfers = incomingTransfers;
         return this;
     }
 
     public MoneroOutgoingTransfer? GetOutgoingTransfer()
     {
-        return outgoingTransfer;
+        return _outgoingTransfer;
     }
 
     public virtual MoneroTxWallet SetOutgoingTransfer(MoneroOutgoingTransfer? outgoingTransfer)
     {
-        this.outgoingTransfer = outgoingTransfer;
+        this._outgoingTransfer = outgoingTransfer;
         return this;
     }
 
@@ -343,69 +343,69 @@ public class MoneroTxWallet : MoneroTx
 
     public string? GetNote()
     {
-        return note;
+        return _note;
     }
 
     public virtual MoneroTxWallet SetNote(string? note)
     {
-        this.note = note;
+        this._note = note;
         return this;
     }
 
     public bool? IsLocked()
     {
-        return isLocked;
+        return _isLocked;
     }
 
     public virtual MoneroTxWallet SetIsLocked(bool? isLocked)
     {
-        this.isLocked = isLocked;
+        this._isLocked = isLocked;
         return this;
     }
 
     public virtual MoneroTxWallet SetInputSum(ulong? inputSum)
     {
-        this.inputSum = inputSum;
+        this._inputSum = inputSum;
         return this;
     }
 
     public virtual MoneroTxWallet SetOutputSum(ulong? outputSum)
     {
-        this.outputSum = outputSum;
+        this._outputSum = outputSum;
         return this;
     }
 
     public string? GetChangeAddress()
     {
-        return changeAddress;
+        return _changeAddress;
     }
 
     public virtual MoneroTxWallet SetChangeAddress(string? changeAddress)
     {
-        this.changeAddress = changeAddress;
+        this._changeAddress = changeAddress;
         return this;
     }
 
     public virtual MoneroTxWallet SetChangeAmount(ulong? changeAmount)
     {
-        this.changeAmount = changeAmount;
+        this._changeAmount = changeAmount;
         return this;
     }
 
     public virtual MoneroTxWallet SetNumDummyOutputs(uint? numDummyOutputs)
     {
-        this.numDummyOutputs = numDummyOutputs;
+        this._numDummyOutputs = numDummyOutputs;
         return this;
     }
 
     public string? GetExtraHex()
     {
-        return extraHex;
+        return _extraHex;
     }
 
     public virtual MoneroTxWallet SetExtraHex(string? extraHex)
     {
-        this.extraHex = extraHex;
+        this._extraHex = extraHex;
         return this;
     }
 }

--- a/Monero/Wallet/Common/MoneroWalletConfig.cs
+++ b/Monero/Wallet/Common/MoneroWalletConfig.cs
@@ -9,21 +9,21 @@ public class MoneroWalletConfig
     private string? _password;
     private string? _path;
     private MoneroRpcConnection? _server;
-    private int? accountLookahead; // number of accounts to scan
-    private byte[]? cacheData;
-    private MoneroConnectionManager? connectionManager;
-    private byte[]? keysData;
-    private string? language;
-    private string? primaryAddress;
-    private string? privateSpendKey;
-    private string? privateViewKey;
-    private ulong? restoreHeight;
-    private bool? saveCurrent;
-    private string? seed;
-    private string? seedOffset;
-    private string? serverPassword;
-    private string? serverUsername;
-    private int? subaddressLookahead; // number of subaddresses to scan per account
+    private int? _accountLookahead; // number of accounts to scan
+    private byte[]? _cacheData;
+    private MoneroConnectionManager? _connectionManager;
+    private byte[]? _keysData;
+    private string? _language;
+    private string? _primaryAddress;
+    private string? _privateSpendKey;
+    private string? _privateViewKey;
+    private ulong? _restoreHeight;
+    private bool? _saveCurrent;
+    private string? _seed;
+    private string? _seedOffset;
+    private string? _serverPassword;
+    private string? _serverUsername;
+    private int? _subaddressLookahead; // number of subaddresses to scan per account
 
     public MoneroWalletConfig() { }
 
@@ -33,19 +33,19 @@ public class MoneroWalletConfig
         _password = config.GetPassword();
         _networkType = config.GetNetworkType();
         _server = config.GetServer();
-        connectionManager = config.GetConnectionManager();
-        seed = config.GetSeed();
-        seedOffset = config.GetSeedOffset();
-        primaryAddress = config.GetPrimaryAddress();
-        privateViewKey = config.GetPrivateViewKey();
-        privateSpendKey = config.GetPrivateSpendKey();
-        restoreHeight = config.GetRestoreHeight();
-        language = config.GetLanguage();
-        saveCurrent = config.GetSaveCurrent();
-        accountLookahead = config.GetAccountLookahead();
-        subaddressLookahead = config.GetSubaddressLookahead();
-        keysData = config.GetKeysData();
-        cacheData = config.GetCacheData();
+        _connectionManager = config.GetConnectionManager();
+        _seed = config.GetSeed();
+        _seedOffset = config.GetSeedOffset();
+        _primaryAddress = config.GetPrimaryAddress();
+        _privateViewKey = config.GetPrivateViewKey();
+        _privateSpendKey = config.GetPrivateSpendKey();
+        _restoreHeight = config.GetRestoreHeight();
+        _language = config.GetLanguage();
+        _saveCurrent = config.GetSaveCurrent();
+        _accountLookahead = config.GetAccountLookahead();
+        _subaddressLookahead = config.GetSubaddressLookahead();
+        _keysData = config.GetKeysData();
+        _cacheData = config.GetCacheData();
         _isMultisig = config.IsMultisig();
     }
 
@@ -97,11 +97,11 @@ public class MoneroWalletConfig
         return _server;
     }
 
-    public MoneroWalletConfig SetServer(MoneroRpcConnection server)
+    public MoneroWalletConfig SetServer(MoneroRpcConnection? server)
     {
         _server = server;
-        serverUsername = server == null ? null : server.GetUsername();
-        serverPassword = server == null ? null : server.GetPassword();
+        _serverUsername = server == null ? null : server.GetUsername();
+        _serverPassword = server == null ? null : server.GetPassword();
         return this;
     }
 
@@ -112,7 +112,7 @@ public class MoneroWalletConfig
 
     public MoneroWalletConfig SetServerUri(string? serverUri)
     {
-        if (serverUri == null || serverUri == "")
+        if (string.IsNullOrEmpty(serverUri))
         {
             _server = null;
             return this;
@@ -127,9 +127,9 @@ public class MoneroWalletConfig
             _server.SetUri(serverUri);
         }
 
-        if (serverUsername != null && serverPassword != null)
+        if (_serverUsername != null && _serverPassword != null)
         {
-            _server.SetCredentials(serverUsername, serverPassword);
+            _server.SetCredentials(_serverUsername, _serverPassword);
         }
 
         return this;
@@ -142,10 +142,10 @@ public class MoneroWalletConfig
 
     public MoneroWalletConfig SetServerUsername(string? serverUsernameInput)
     {
-        this.serverUsername = serverUsernameInput;
-        if (_server != null && serverUsernameInput != null && serverPassword != null)
+        this._serverUsername = serverUsernameInput;
+        if (_server != null && serverUsernameInput != null && _serverPassword != null)
         {
-            _server.SetCredentials(serverUsernameInput, serverPassword);
+            _server.SetCredentials(serverUsernameInput, _serverPassword);
         }
 
         return this;
@@ -158,10 +158,10 @@ public class MoneroWalletConfig
 
     public MoneroWalletConfig SetServerPassword(string? serverPassword)
     {
-        this.serverPassword = serverPassword;
-        if (_server != null && serverUsername != null && serverPassword != null)
+        this._serverPassword = serverPassword;
+        if (_server != null && _serverUsername != null && serverPassword != null)
         {
-            _server.SetCredentials(serverUsername, serverPassword);
+            _server.SetCredentials(_serverUsername, serverPassword);
         }
 
         return this;
@@ -169,144 +169,144 @@ public class MoneroWalletConfig
 
     public MoneroConnectionManager? GetConnectionManager()
     {
-        return connectionManager;
+        return _connectionManager;
     }
 
     public MoneroWalletConfig SetConnectionManager(MoneroConnectionManager connectionManager)
     {
-        this.connectionManager = connectionManager;
+        this._connectionManager = connectionManager;
         return this;
     }
 
     public string? GetSeed()
     {
-        return seed;
+        return _seed;
     }
 
     public MoneroWalletConfig SetSeed(string? seed)
     {
-        this.seed = seed;
+        this._seed = seed;
         return this;
     }
 
     public string? GetSeedOffset()
     {
-        return seedOffset;
+        return _seedOffset;
     }
 
     public MoneroWalletConfig SetSeedOffset(string? seedOffset)
     {
-        this.seedOffset = seedOffset;
+        this._seedOffset = seedOffset;
         return this;
     }
 
     public string? GetPrimaryAddress()
     {
-        return primaryAddress;
+        return _primaryAddress;
     }
 
     public MoneroWalletConfig SetPrimaryAddress(string? primaryAddress)
     {
-        this.primaryAddress = primaryAddress;
+        this._primaryAddress = primaryAddress;
         return this;
     }
 
     public string? GetPrivateViewKey()
     {
-        return privateViewKey;
+        return _privateViewKey;
     }
 
     public MoneroWalletConfig SetPrivateViewKey(string? privateViewKey)
     {
-        this.privateViewKey = privateViewKey;
+        this._privateViewKey = privateViewKey;
         return this;
     }
 
     public string? GetPrivateSpendKey()
     {
-        return privateSpendKey;
+        return _privateSpendKey;
     }
 
     public MoneroWalletConfig SetPrivateSpendKey(string? privateSpendKey)
     {
-        this.privateSpendKey = privateSpendKey;
+        this._privateSpendKey = privateSpendKey;
         return this;
     }
 
     public ulong? GetRestoreHeight()
     {
-        return restoreHeight;
+        return _restoreHeight;
     }
 
     public MoneroWalletConfig SetRestoreHeight(ulong? restoreHeight)
     {
-        this.restoreHeight = restoreHeight;
+        this._restoreHeight = restoreHeight;
         return this;
     }
 
     public string? GetLanguage()
     {
-        return language;
+        return _language;
     }
 
     public MoneroWalletConfig SetLanguage(string? language)
     {
-        this.language = language;
+        this._language = language;
         return this;
     }
 
     public bool? GetSaveCurrent()
     {
-        return saveCurrent;
+        return _saveCurrent;
     }
 
     public MoneroWalletConfig SetSaveCurrent(bool? saveCurrent)
     {
-        this.saveCurrent = saveCurrent;
+        this._saveCurrent = saveCurrent;
         return this;
     }
 
     public MoneroWalletConfig SetAccountLookahead(int? accountLookahead)
     {
-        this.accountLookahead = accountLookahead;
+        this._accountLookahead = accountLookahead;
         return this;
     }
 
     public int? GetAccountLookahead()
     {
-        return accountLookahead;
+        return _accountLookahead;
     }
 
     public MoneroWalletConfig SetSubaddressLookahead(int? subaddressLookahead)
     {
-        this.subaddressLookahead = subaddressLookahead;
+        this._subaddressLookahead = subaddressLookahead;
         return this;
     }
 
     public int? GetSubaddressLookahead()
     {
-        return subaddressLookahead;
+        return _subaddressLookahead;
     }
 
     public byte[]? GetKeysData()
     {
-        return keysData;
+        return _keysData;
     }
 
     public MoneroWalletConfig SetKeysData(byte[]? keysData)
     {
-        this.keysData = keysData;
+        this._keysData = keysData;
         return this;
     }
 
     public byte[]? GetCacheData()
     {
-        return cacheData;
+        return _cacheData;
     }
 
     public MoneroWalletConfig SetCacheData(byte[]? cacheData)
     {
-        this.cacheData = cacheData;
+        this._cacheData = cacheData;
         return this;
     }
 

--- a/Monero/Wallet/MoneroWallet.cs
+++ b/Monero/Wallet/MoneroWallet.cs
@@ -5,7 +5,7 @@ namespace Monero.Wallet;
 
 public interface MoneroWallet
 {
-    static readonly string DEFAULT_LANGUAGE = "English";
+    static readonly string DefaultLanguage = "English";
 
     MoneroWalletType GetWalletType();
 

--- a/Monero/Wallet/MoneroWalletDefault.cs
+++ b/Monero/Wallet/MoneroWalletDefault.cs
@@ -5,10 +5,10 @@ namespace Monero.Wallet;
 
 public abstract class MoneroWalletDefault : MoneroWallet
 {
-    protected MoneroConnectionManager? connectionManager;
-    protected MoneroConnectionManagerListener? connectionManagerListener;
-    protected bool isClosed;
-    protected List<MoneroWalletListener> listeners = [];
+    protected MoneroConnectionManager? _connectionManager;
+    protected MoneroConnectionManagerListener? _connectionManagerListener;
+    protected bool _isClosed;
+    protected readonly List<MoneroWalletListener> _listeners = [];
 
     public abstract MoneroWalletType GetWalletType();
 
@@ -18,14 +18,14 @@ public abstract class MoneroWalletDefault : MoneroWallet
 
     public virtual void AddListener(MoneroWalletListener listener)
     {
-        lock (listeners)
+        lock (_listeners)
         {
             if (listener == null)
             {
                 throw new MoneroError("Cannot add null listener");
             }
 
-            listeners.Add(listener);
+            _listeners.Add(listener);
         }
     }
 
@@ -46,15 +46,15 @@ public abstract class MoneroWalletDefault : MoneroWallet
 
     public virtual void Close(bool save)
     {
-        if (connectionManager != null && connectionManagerListener != null)
+        if (_connectionManager != null && _connectionManagerListener != null)
         {
-            connectionManager.RemoveListener(connectionManagerListener);
+            _connectionManager.RemoveListener(_connectionManagerListener);
         }
 
-        connectionManager = null;
-        connectionManagerListener = null;
-        listeners.Clear();
-        isClosed = true;
+        _connectionManager = null;
+        _connectionManagerListener = null;
+        _listeners.Clear();
+        _isClosed = true;
     }
 
     public MoneroAccount CreateAccount()
@@ -183,7 +183,7 @@ public abstract class MoneroWalletDefault : MoneroWallet
 
     public virtual MoneroConnectionManager? GetConnectionManager()
     {
-        return connectionManager;
+        return _connectionManager;
     }
 
     public abstract MoneroRpcConnection? GetDaemonConnection();
@@ -236,7 +236,7 @@ public abstract class MoneroWalletDefault : MoneroWallet
 
     public virtual List<MoneroWalletListener> GetListeners()
     {
-        return [.. listeners];
+        return [.. _listeners];
     }
 
     public abstract MoneroMultisigInfo GetMultisigInfo();
@@ -415,7 +415,7 @@ public abstract class MoneroWalletDefault : MoneroWallet
 
     public virtual bool IsClosed()
     {
-        return isClosed;
+        return _isClosed;
     }
 
     public abstract bool IsConnectedToDaemon();
@@ -483,9 +483,9 @@ public abstract class MoneroWalletDefault : MoneroWallet
 
     public virtual void RemoveListener(MoneroWalletListener listener)
     {
-        lock (listeners)
+        lock (_listeners)
         {
-            listeners.Remove(listener);
+            _listeners.Remove(listener);
         }
     }
 
@@ -508,23 +508,23 @@ public abstract class MoneroWalletDefault : MoneroWallet
 
     public virtual void SetConnectionManager(MoneroConnectionManager? connectionManager)
     {
-        if (this.connectionManager != null && connectionManagerListener != null)
+        if (this._connectionManager != null && _connectionManagerListener != null)
         {
-            this.connectionManager.RemoveListener(connectionManagerListener);
+            this._connectionManager.RemoveListener(_connectionManagerListener);
         }
 
-        this.connectionManager = connectionManager;
+        this._connectionManager = connectionManager;
         if (connectionManager == null)
         {
             return;
         }
 
-        if (connectionManagerListener == null)
+        if (_connectionManagerListener == null)
         {
-            connectionManagerListener = new MoneroWalletConnectionManagerListener(this);
+            _connectionManagerListener = new MoneroWalletConnectionManagerListener(this);
         }
 
-        connectionManager.AddListener(connectionManagerListener);
+        connectionManager.AddListener(_connectionManagerListener);
         SetDaemonConnection(connectionManager.GetConnection());
     }
 
@@ -560,7 +560,7 @@ public abstract class MoneroWalletDefault : MoneroWallet
 
     public virtual string SignMessage(string message)
     {
-        return SignMessage(message, MoneroMessageSignatureType.SIGN_WITH_SPEND_KEY, 0, 0);
+        return SignMessage(message, MoneroMessageSignatureType.SignWithSpendKey, 0, 0);
     }
 
     public virtual string SignMessage(string message, MoneroMessageSignatureType signatureType)
@@ -676,15 +676,15 @@ public abstract class MoneroWalletDefault : MoneroWallet
 
 internal class MoneroWalletConnectionManagerListener : MoneroConnectionManagerListener
 {
-    private readonly MoneroWalletDefault wallet;
+    private readonly MoneroWalletDefault _wallet;
 
     public MoneroWalletConnectionManagerListener(MoneroWalletDefault wallet)
     {
-        this.wallet = wallet;
+        this._wallet = wallet;
     }
 
     public void OnConnectionChanged(MoneroRpcConnection? connection)
     {
-        wallet.SetDaemonConnection(connection);
+        _wallet.SetDaemonConnection(connection);
     }
 }

--- a/Monero/Wallet/MoneroWalletType.cs
+++ b/Monero/Wallet/MoneroWalletType.cs
@@ -2,6 +2,6 @@ namespace Monero.Wallet;
 
 public enum MoneroWalletType
 {
-    FULL = 0, // full wallet
-    RPC = 1 // rpc wallet
+    Full = 0, // full wallet
+    Rpc = 1 // rpc wallet
 }


### PR DESCRIPTION
This PR fixes all inconsistent naming warnings applying:

1. _camelcase to private fields
2. camelcase to static fields