### PR TITLE
Implement Basic TestMoneroWalletRpc.TestGetTransfers

### DIFF
--- a/Monero.IntegrationTests/TestMoneroDaemonRpc.cs
+++ b/Monero.IntegrationTests/TestMoneroDaemonRpc.cs
@@ -69,11 +69,6 @@ public class TestMoneroDaemonRpc : IClassFixture<MoneroDaemonRpcFixture>
         MoneroRpcConnection rpcConnection = _daemon.GetRpcConnection();
 
         Assert.True(rpcConnection.IsConnected(), "Daemon offline");
-        ulong daemonHeight = _daemon.GetHeight().GetAwaiter().GetResult();
-        if (daemonHeight == 1)
-        {
-            MineBlocks();
-        }
     }
 
     #region Notification Tests
@@ -1390,21 +1385,6 @@ public class TestMoneroDaemonRpc : IClassFixture<MoneroDaemonRpcFixture>
     #endregion
 
     #region Test Helpers
-
-    private static void MineBlocks()
-    {
-        try
-        {
-            StartMining.Start();
-            GenUtils.WaitFor(10000);
-            StopMining.Stop();
-            GenUtils.WaitFor(10000);
-        }
-        catch (Exception e)
-        {
-            MoneroUtils.Log(0, e.Message);
-        }
-    }
 
     private static void TestBlockHeader(MoneroBlockHeader? header, bool isFull)
     {

--- a/Monero.IntegrationTests/TestMoneroWalletRpc.cs
+++ b/Monero.IntegrationTests/TestMoneroWalletRpc.cs
@@ -10,16 +10,104 @@ public class TestMoneroWalletRpc
 {
     // test constants
     private static readonly bool TestNonRelays = true;
-
+    private static readonly ulong AmountRequiredAu = MoneroUtils.XmrToAtomicUnits(1);
+    private static bool Funded;
     private readonly MoneroDaemonRpc daemon; // daemon instance to test
+    private static readonly ulong MinBlockchainHeight = 640;
 
     // instance variables
     private readonly MoneroWalletRpc wallet; // wallet instance to test
+
+    private static void SetFunded()
+    {
+        Funded = true;
+    }
 
     public TestMoneroWalletRpc()
     {
         daemon = TestUtils.GetDaemonRpc();
         wallet = TestUtils.GetWalletRpcSync();
+        FundTestWalletSync();
+    }
+
+    private MoneroWalletRpc CreateWalletSync(MoneroWalletConfig? config)
+    {
+        return (MoneroWalletRpc)CreateWallet(config).GetAwaiter().GetResult();
+    }
+
+    private void FundTestWalletSync()
+    {
+        FundTestWallet().GetAwaiter().GetResult();
+    }
+
+    private async Task FundTestWallet()
+    {
+        if (Funded)
+        {
+            return;
+        }
+
+        ulong balance = await wallet.GetBalance();
+
+        if (balance > 0)
+        {
+            SetFunded();
+            return;
+        }
+
+        while (await daemon.GetHeight() < MinBlockchainHeight)
+        {
+            // wait for blockchain height
+            Thread.Sleep(10000);
+        }
+
+        MoneroWalletRpc miningWallet = (MoneroWalletRpc)await CreateWallet(new MoneroWalletConfig().SetSeed(TestUtils.MINING_SEED));
+        MoneroTxConfig txConfig = await GetFundTxConfig();
+        List<MoneroTxWallet> txs = await miningWallet.CreateTxs(txConfig);
+        await CloseWallet(miningWallet);
+        // wait for confirmations
+
+        Thread.Sleep(10000);
+
+        Assert.True(await wallet.GetBalance() > 0);
+        SetFunded();
+    }
+
+    private async Task<MoneroTxConfig> GetFundTxConfig()
+    {
+        List<MoneroDestination> destinations = await this.GetFundDestinations();
+        MoneroTxConfig config = new();
+
+        config.SetDestinations(destinations);
+        config.SetAccountIndex(0);
+        config.SetCanSplit(true);
+
+        return config;
+    }
+
+    private async Task<List<MoneroDestination>> GetFundDestinations()
+    {
+        List<MoneroDestination> dests = [];
+
+        for (uint accountIndex = 0; accountIndex < 2; accountIndex++)
+        {
+            if (accountIndex > 0)
+            {
+                await wallet.CreateAccount();
+            }
+
+            for (uint subaddressIndex = 0; subaddressIndex < 10; subaddressIndex++)
+            {
+                MoneroSubaddress subaddress = await wallet.CreateSubaddress(accountIndex);
+
+                MoneroDestination dest = new();
+                dest.SetAddress(subaddress.GetAddress());
+                dest.SetAmount(MoneroUtils.XmrToAtomicUnits(1));
+                dests.Add(dest);
+            }
+        }
+
+        return dests;
     }
 
     private async Task<IMoneroWallet> OpenWallet(MoneroWalletConfig? config)
@@ -1040,6 +1128,118 @@ public class TestMoneroWalletRpc
         await CloseWallet(moneroWallet);
     }
 
+    // Can get transfers in the wallet, accounts, and subaddresses
+    [Fact]
+    public virtual async Task TestGetTransfers()
+    {
+        // get all transfers
+        await GetAndTestTransfers(wallet, null, null, true);
+
+        // get transfers by account index
+        bool nonDefaultIncoming = false;
+        foreach (MoneroAccount account in await wallet.GetAccounts(true))
+        {
+            List<MoneroTransfer> accountTransfers = await GetAndTestTransfers(wallet, new MoneroTransferQuery().SetAccountIndex(account.GetIndex()), null, null);
+            foreach (MoneroTransfer transfer in accountTransfers)
+            {
+                Assert.Equal(transfer.GetAccountIndex(), account.GetIndex());
+            }
+
+            // get transfers by subaddress index
+            List<MoneroTransfer> subaddressTransfers = new List<MoneroTransfer>();
+            foreach (MoneroSubaddress subaddress in account.GetSubaddresses()!)
+            {
+                List<MoneroTransfer> _transfers = await GetAndTestTransfers(wallet, new MoneroTransferQuery().SetAccountIndex(subaddress.GetAccountIndex()).SetSubaddressIndex(subaddress.GetIndex()), null, null);
+                foreach (MoneroTransfer transfer in _transfers)
+                {
+
+                    // test account and subaddress indices
+                    Assert.Equal(subaddress.GetAccountIndex(), transfer.GetAccountIndex());
+                    if (transfer.IsIncoming() == true)
+                    {
+                        MoneroIncomingTransfer inTransfer = (MoneroIncomingTransfer)transfer;
+                        Assert.Equal(subaddress.GetIndex(), inTransfer.GetSubaddressIndex());
+                        if (transfer.GetAccountIndex() != 0 && inTransfer.GetSubaddressIndex() != 0)
+                        {
+                            nonDefaultIncoming = true;
+                        }
+                    }
+                    else
+                    {
+                        MoneroOutgoingTransfer outTransfer = (MoneroOutgoingTransfer)transfer;
+                        Assert.Contains((uint)subaddress.GetIndex()!, outTransfer.GetSubaddressIndices()!);
+                        if (transfer.GetAccountIndex() != 0)
+                        {
+                            foreach (int subaddrIdx in outTransfer.GetSubaddressIndices()!)
+                            {
+                                if (subaddrIdx > 0)
+                                {
+                                    nonDefaultIncoming = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+
+                    // don't add duplicates TODO monero-wallet-rpc: duplicate outgoing transfers returned foreach different subaddress indices, way to return outgoing subaddress indices?
+                    bool found = false;
+                    foreach (MoneroTransfer subaddressTransfer in subaddressTransfers)
+                    {
+                        if (transfer.ToString().Equals(subaddressTransfer.ToString()) && transfer.GetTx()!.GetHash()!.Equals(subaddressTransfer.GetTx()!.GetHash()))
+                        {
+                            found = true;
+                            break;
+                        }
+                    }
+
+                    if (!found)
+                    {
+                        subaddressTransfers.Add(transfer);
+                    }
+                }
+            }
+            Assert.Equal(accountTransfers.Count, subaddressTransfers.Count);
+
+            // collect unique subaddress indices
+            HashSet<uint> subaddressIndices = new HashSet<uint>();
+            foreach (MoneroTransfer transfer in subaddressTransfers)
+            {
+                if (transfer.IsIncoming() == true)
+                {
+                    subaddressIndices.Add((uint)((MoneroIncomingTransfer)transfer).GetSubaddressIndex()!);
+                }
+                else
+                {
+                    foreach (var subIdx in ((MoneroOutgoingTransfer)transfer).GetSubaddressIndices()!)
+                    {
+                        subaddressIndices.Add(subIdx);
+                    }
+                }
+            }
+
+            // get and test transfers by subaddress indices
+            List<MoneroTransfer> transfers = await GetAndTestTransfers(wallet, new MoneroTransferQuery().SetAccountIndex(account.GetIndex()).SetSubaddressIndices(new List<uint>(subaddressIndices)), null, null);
+            Assert.Equal(subaddressTransfers.Count, transfers.Count); // TODO monero-wallet-rpc: these may not be equal because outgoing transfers are always from subaddress 0 (#5171) and/or incoming transfers from/to same account are occluded (#4500)
+            foreach (MoneroTransfer transfer in transfers)
+            {
+                Assert.Equal(transfer.GetAccountIndex(), account.GetIndex());
+                if (transfer.IsIncoming() == true)
+                {
+                    Assert.Contains((uint)((MoneroIncomingTransfer)transfer).GetSubaddressIndex()!, subaddressIndices);
+                }
+                else
+                {
+                    HashSet<uint> intersections = new HashSet<uint>(subaddressIndices);
+                    intersections.IntersectWith(((MoneroOutgoingTransfer)transfer).GetSubaddressIndices()!);
+                    Assert.True(intersections.Count > 0, "Subaddresses must overlap");
+                }
+            }
+        }
+
+        // ensure transfer found with non-zero account and subaddress indices
+        Assert.True(nonDefaultIncoming, "No transfers found in non-default account and subaddress; run send-to-multiple tests");
+    }
+
     #region Test Utils
 
     private static void TestSubaddress(MoneroSubaddress? subaddress)
@@ -1099,6 +1299,681 @@ public class TestMoneroWalletRpc
         // tag must be undefined or non-empty
         string? tag = account.GetTag();
         Assert.True(tag == null || tag.Length > 0);
+    }
+
+    protected virtual void TestTxWallet(MoneroTxWallet? tx)
+    {
+        TestTxWallet(tx, null);
+    }
+
+    protected virtual void TestTxWallet(MoneroTxWallet? tx, TxContext? txCtx)
+    {
+        // validate / sanitize inputs
+        TxContext ctx = new(txCtx);
+        ctx.Wallet = null;  // TODO: re-enable
+
+        if (tx == null)
+        {
+            throw new MoneroError("Tx is null");
+        }
+
+        if (ctx.IsSendResponse == null || ctx.Config == null)
+        {
+            if (ctx.IsSendResponse != null)
+            {
+                throw new Exception("if either sendRequest or isSendResponse is defined, they must both be defined");
+            }
+
+            if (ctx.Config != null)
+            {
+                throw new Exception("if either sendRequest or isSendResponse is defined, they must both be defined");
+            }
+        }
+
+        // test common field types
+        Assert.NotNull(tx.GetHash());
+        Assert.NotNull(tx.IsConfirmed());
+        Assert.NotNull(tx.IsMinerTx());
+        Assert.NotNull(tx.IsFailed());
+        Assert.NotNull(tx.IsRelayed());
+        Assert.NotNull(tx.InTxPool());
+        Assert.NotNull(tx.IsLocked());
+        TestUtils.TestUnsignedBigInteger(tx.GetFee());
+        if (tx.GetPaymentId() != null)
+        {
+            Assert.NotEqual(MoneroTx.DefaultPaymentId, tx.GetPaymentId()); // default payment id converted to null
+        }
+        if (tx.GetNote() != null)
+        {
+            Assert.True(tx.GetNote()!.Length > 0);  // empty notes converted to undefined
+        }
+        Assert.True(tx.GetUnlockTime() >= 0);
+        Assert.Null(tx.GetSize());   // TODO monero-wallet-rpc: add tx_size to get_transfers and get_transfer_by_txid
+        Assert.Null(tx.GetReceivedTimestamp());  // TODO monero-wallet-rpc: return received timestamp (asked to file issue if wanted)
+
+        // test send _tx
+        if (ctx.IsSendResponse == true)
+        {
+            Assert.True(tx.GetWeight() > 0);
+            Assert.NotNull(tx.GetInputs());
+            Assert.True(tx.GetInputs()!.Count > 0);
+            foreach (MoneroOutput input in tx.GetInputs()!)
+            {
+                Assert.True(input.GetTx() == tx);
+            }
+        }
+        else
+        {
+            Assert.Null(tx.GetWeight());
+            Assert.Null(tx.GetInputs());
+        }
+
+        // test confirmed
+        if (tx.IsConfirmed() == true)
+        {
+            Assert.NotNull(tx.GetBlock());
+            Assert.Contains(tx, tx.GetBlock()!.GetTxs()!);
+            Assert.True(tx.GetBlock()!.GetHeight() > 0);
+            Assert.True(tx.GetBlock()!.GetTimestamp() > 0);
+            Assert.Equal(true, tx.GetRelay());
+            Assert.Equal(true, tx.IsRelayed());
+            Assert.Equal(false, tx.IsFailed());
+            Assert.Equal(false, tx.InTxPool());
+            Assert.Equal(false, tx.IsDoubleSpendSeen());
+            Assert.True(tx.GetNumConfirmations() > 0);
+        }
+        else
+        {
+            Assert.Null(tx.GetBlock());
+            Assert.True(tx.GetNumConfirmations() == 0);
+        }
+
+        // test in _tx pool
+        if (tx.InTxPool() == true)
+        {
+            Assert.Equal(false, tx.IsConfirmed());
+            Assert.Equal(true, tx.GetRelay());
+            Assert.Equal(true, tx.IsRelayed());
+            Assert.Equal(false, tx.IsDoubleSpendSeen()); // TODO: test double spend attempt
+            Assert.Equal(true, tx.IsLocked());
+
+            // these should be initialized unless a response from sending
+            if (ctx.IsSendResponse != true)
+            {
+                //Assert.True(_tx.GetReceivedTimestamp() > 0);  // TODO: re-enable when received timestamp returned in wallet rpc
+            }
+        }
+        else
+        {
+            Assert.Null(tx.GetLastRelayedTimestamp());
+        }
+
+        // test miner _tx
+        if (tx.IsMinerTx() == true)
+        {
+            Assert.True(tx.GetFee() == 0);
+            Assert.True(tx.GetIncomingTransfers()!.Count > 0);
+        }
+
+        // test failed  // TODO: what else to test associated with failed
+        if (tx.IsFailed() == true)
+        {
+            Assert.True(tx.GetOutgoingTransfer() is MoneroTransfer);
+            //Assert.True(_tx.GetReceivedTimestamp() > 0);  // TODO: re-enable when received timestamp returned in wallet rpc
+        }
+        else
+        {
+            if (tx.IsRelayed() == true)
+            {
+                Assert.Equal(tx.IsDoubleSpendSeen(), false);
+            }
+            else
+            {
+                Assert.Equal(false, tx.GetRelay());
+                Assert.Equal(false, tx.IsRelayed());
+                Assert.Null(tx.IsDoubleSpendSeen());
+            }
+        }
+        Assert.Null(tx.GetLastFailedHeight());
+        Assert.Null(tx.GetLastFailedHash());
+
+        // received time only for _tx pool or failed txs
+        if (tx.GetReceivedTimestamp() != null)
+        {
+            Assert.True(tx.InTxPool() == true || tx.IsFailed() == true);
+        }
+
+        // test relayed _tx
+        if (tx.IsRelayed() == true)
+        {
+            Assert.Equal(tx.GetRelay(), true);
+        }
+
+        if (!tx.GetRelay() == true)
+        {
+            Assert.True(!tx.IsRelayed());
+        }
+
+        // test outgoing transfer per configuration
+        if (ctx.HasOutgoingTransfer == false)
+        {
+            Assert.Null(tx.GetOutgoingTransfer());
+        }
+
+        if (ctx.HasDestinations == true)
+        {
+            Assert.True(tx.GetOutgoingTransfer()!.GetDestinations()!.Count > 0);
+        }
+
+        // test outgoing transfer
+        if (tx.GetOutgoingTransfer() != null)
+        {
+            Assert.True(tx.IsOutgoing());
+            TestTransfer(tx.GetOutgoingTransfer(), ctx);
+            if (ctx.IsSweepResponse == true)
+            {
+                Assert.Single(tx.GetOutgoingTransfer()!.GetDestinations()!);
+            }
+
+            // TODO: handle special cases
+        }
+        else
+        {
+            Assert.True(tx.GetIncomingTransfers()!.Count > 0);
+            Assert.Null(tx.GetOutgoingAmount());
+            Assert.Null(tx.GetOutgoingTransfer());
+            Assert.Null(tx.GetRingSize());
+            Assert.Null(tx.GetFullHex());
+            Assert.Null(tx.GetMetadata());
+            Assert.Null(tx.GetKey());
+        }
+
+        // test incoming transfers
+        if (tx.GetIncomingTransfers() != null)
+        {
+            Assert.True(tx.IsIncoming());
+            Assert.True(tx.GetIncomingTransfers()!.Count > 0);
+            TestUtils.TestUnsignedBigInteger(tx.GetIncomingAmount());
+            Assert.Equal(tx.IsFailed(), false);
+
+            // test each transfer and collect transfer sum
+            ulong transferSum = 0;
+            foreach (MoneroIncomingTransfer transfer in tx.GetIncomingTransfers()!)
+            {
+                TestTransfer(transfer, ctx);
+                transferSum += transfer.GetAmount() ?? 0;
+                if (ctx.Wallet != null)
+                {
+                    Assert.Equal(ctx.Wallet.GetAddress((uint)transfer.GetAccountIndex()!, (uint)transfer.GetSubaddressIndex()!).GetAwaiter().GetResult(), transfer.GetAddress());
+                }
+
+                // TODO special case: transfer amount of 0
+            }
+
+            // incoming transfers add up to incoming _tx amount
+            Assert.Equal(tx.GetIncomingAmount(), transferSum);
+        }
+        else
+        {
+            Assert.NotNull(tx.GetOutgoingTransfer());
+            Assert.Null(tx.GetIncomingAmount());
+            Assert.Null(tx.GetIncomingTransfers());
+        }
+
+        // test _tx results from send or relay
+        if (ctx.IsSendResponse == true)
+        {
+
+            // test _tx set
+            Assert.NotNull(tx.GetTxSet());
+            bool found = false;
+            foreach (MoneroTxWallet aTx in tx.GetTxSet()!.GetTxs()!)
+            {
+                if (aTx == tx)
+                {
+                    found = true;
+                    break;
+                }
+            }
+            if (ctx.IsCopy == true)
+            {
+                Assert.False(found); // copy will not have back the reference from _tx set
+            }
+            else
+            {
+                Assert.True(found);
+            }
+
+            // test common attributes
+            MoneroTxConfig? config = ctx.Config;
+
+            if (config == null)
+            {
+                throw new MoneroError("Config is null");
+            }
+
+            Assert.Equal(false, tx.IsConfirmed());
+            TestTransfer(tx.GetOutgoingTransfer(), ctx);
+            Assert.Equal(MoneroUtils.RingSize, (uint)tx.GetRingSize()!);
+            Assert.True(0 == tx.GetUnlockTime());
+            Assert.Null(tx.GetBlock());
+            Assert.True(tx.GetKey()!.Length > 0);
+            Assert.NotNull(tx.GetFullHex());
+            Assert.True(tx.GetFullHex()!.Length > 0);
+            Assert.NotNull(tx.GetMetadata());
+            Assert.Null(tx.GetReceivedTimestamp());
+            Assert.True(tx.IsLocked());
+
+            // test locked state
+            if (tx.GetUnlockTime() == 0)
+            {
+                Assert.Equal(tx.IsConfirmed(), !tx.IsLocked());
+            }
+            else
+            {
+                Assert.Equal(true, tx.IsLocked());
+            }
+            foreach (MoneroOutputWallet output in tx.GetOutputsWallet())
+            {
+                Assert.Equal(tx.IsLocked(), output.IsLocked());
+            }
+
+            // test destinations of sent _tx
+            if (tx.GetOutgoingTransfer()!.GetDestinations() == null)
+            {
+                Assert.True(config.GetCanSplit());
+                Console.WriteLine("Destinations not returned from split transactions"); // TODO: remove this after >18.3.1 when amounts_by_dest_list official
+            }
+            else
+            {
+                Assert.NotNull(tx.GetOutgoingTransfer()!.GetDestinations());
+                Assert.True(tx.GetOutgoingTransfer()!.GetDestinations()!.Count > 0);
+                bool subtractFeeFromDestinations = ctx.Config != null && ctx.Config.GetSubtractFeeFrom() != null && ctx.Config.GetSubtractFeeFrom()!.Count > 0;
+                if (ctx.IsSweepResponse == true)
+                {
+                    Assert.True(1 == config.GetDestinations()!.Count);
+                    Assert.Null(config.GetDestinations()![0].GetAmount());
+                    if (!subtractFeeFromDestinations)
+                    {
+                        Assert.Equal(tx.GetOutgoingTransfer()!.GetAmount().ToString(), tx.GetOutgoingTransfer()!.GetDestinations()![0].GetAmount().ToString());
+                    }
+                }
+            }
+
+
+            // test relayed txs
+            if (config.GetRelay() == true)
+            {
+                Assert.Equal(true, tx.InTxPool());
+                Assert.Equal(true, tx.GetRelay());
+                Assert.Equal(true, tx.IsRelayed());
+                Assert.True(tx.GetLastRelayedTimestamp() > 0);
+                Assert.Equal(false, tx.IsDoubleSpendSeen());
+            }
+
+            // test non-relayed txs
+            else
+            {
+                Assert.Equal(false, tx.InTxPool());
+                Assert.Equal(false, tx.GetRelay());
+                Assert.Equal(false, tx.IsRelayed());
+                Assert.Null(tx.GetLastRelayedTimestamp());
+                Assert.Null(tx.IsDoubleSpendSeen());
+            }
+        }
+
+        // test _tx result query
+        else
+        {
+            Assert.Null(tx.GetTxSet());  // _tx set only initialized on send responses
+            Assert.Null(tx.GetRingSize());
+            Assert.Null(tx.GetKey());
+            Assert.Null(tx.GetFullHex());
+            Assert.Null(tx.GetMetadata());
+            Assert.Null(tx.GetLastRelayedTimestamp());
+        }
+
+        // test inputs
+        if (tx.IsOutgoing() == true && ctx.IsSendResponse == true)
+        {
+            Assert.NotNull(tx.GetInputs());
+            Assert.True(tx.GetInputs()!.Count > 0);
+        }
+
+        if (tx.GetInputs() != null)
+        {
+            foreach (MoneroOutputWallet input in tx.GetInputsWallet())
+            {
+                TestInputWallet(input);
+            }
+        }
+
+        // test outputs
+        if (tx.IsIncoming() == true && ctx.IncludeOutputs == true)
+        {
+            if (tx.IsConfirmed() == true)
+            {
+                Assert.NotNull(tx.GetOutputs());
+                Assert.True(tx.GetOutputs()!.Count > 0);
+            }
+            else
+            {
+                Assert.Null(tx.GetOutputs());
+            }
+        }
+
+        if (tx.GetOutputs() != null)
+        {
+            foreach (MoneroOutputWallet output in tx.GetOutputsWallet())
+            {
+                TestOutputWallet(output);
+            }
+        }
+
+        // test deep copy
+        if (ctx.IsCopy != true)
+        {
+            TestTxWalletCopy(tx, ctx);
+        }
+    }
+
+    private static void TestTransfer(MoneroTransfer? transfer, TxContext? ctx)
+    {
+        if (transfer == null)
+        {
+            throw new MoneroError("Transfer is null");
+        }
+
+        if (ctx == null)
+        {
+            ctx = new TxContext();
+        }
+        TestUtils.TestUnsignedBigInteger(transfer.GetAmount());
+        if (ctx.IsSweepOutputResponse != true)
+        {
+            Assert.True(transfer.GetAccountIndex() >= 0);
+        }
+
+        if (transfer.IsIncoming() == true)
+        {
+            TestIncomingTransfer((MoneroIncomingTransfer?)transfer);
+        }
+        else
+        {
+            TestOutgoingTransfer((MoneroOutgoingTransfer?)transfer, ctx);
+        }
+
+        // transfer and _tx reference each other
+        MoneroTxWallet? transferTx = transfer.GetTx();
+
+        if (transferTx == null)
+        {
+            throw new MoneroError("Transfer transaction is null");
+        }
+
+        if (!transfer.Equals(transferTx.GetOutgoingTransfer()))
+        {
+            List<MoneroIncomingTransfer>? incomingTransfers = transferTx.GetIncomingTransfers();
+
+            if (incomingTransfers == null)
+            {
+                throw new MoneroError("No incoming transfers found");
+            }
+            Assert.True(incomingTransfers.Contains(transfer), "Transaction does not reference given transfer");
+        }
+    }
+
+    private static void TestIncomingTransfer(MoneroIncomingTransfer? transfer)
+    {
+        if (transfer == null)
+        {
+            throw new MoneroError("Incoming transfer is null");
+        }
+
+        Assert.True(transfer.IsIncoming());
+        Assert.False(transfer.IsOutgoing());
+        Assert.NotNull(transfer.GetAddress());
+        Assert.True(transfer.GetSubaddressIndex() >= 0);
+        Assert.True(transfer.GetNumSuggestedConfirmations() > 0);
+    }
+
+    private static void TestOutgoingTransfer(MoneroOutgoingTransfer? transfer, TxContext? ctx)
+    {
+        if (ctx == null)
+        {
+            throw new MoneroError("Tx context is null");
+        }
+
+        if (transfer == null)
+        {
+            throw new MoneroError("Outgoing transfer is null");
+        }
+
+        Assert.False(transfer.IsIncoming());
+        Assert.True(transfer.IsOutgoing());
+        if (ctx.IsSendResponse != true)
+        {
+            Assert.NotNull(transfer.GetSubaddressIndices());
+        }
+        if (transfer.GetSubaddressIndices() != null)
+        {
+            Assert.True(transfer.GetSubaddressIndices()!.Count >= 1);
+        }
+        if (transfer.GetAddresses() != null)
+        {
+            Assert.Equal(transfer.GetSubaddressIndices()!.Count, transfer.GetAddresses()!.Count);
+            foreach (string address in transfer.GetAddresses()!)
+            {
+                Assert.NotNull(address);
+            }
+        }
+
+        // test destinations sum to outgoing amount
+        List<MoneroDestination>? destinations = transfer.GetDestinations();
+        if (destinations != null)
+        {
+            Assert.True(destinations.Count > 0);
+            ulong sum = 0;
+            foreach (MoneroDestination destination in destinations)
+            {
+                TestDestination(destination);
+                sum += destination.GetAmount() ?? 0;
+            }
+
+            Assert.Equal(sum, transfer.GetAmount());
+        }
+    }
+
+    private static void TestDestination(MoneroDestination? destination)
+    {
+        if (destination == null)
+        {
+            throw new MoneroError("Destination is null");
+        }
+        MoneroUtils.ValidateAddress(destination.GetAddress(), TestUtils.NETWORK_TYPE);
+        TestUtils.TestUnsignedBigInteger(destination.GetAmount(), true);
+    }
+
+    private static void TestInputWallet(MoneroOutputWallet? input)
+    {
+        if (input == null)
+        {
+            throw new MoneroError("Input is null");
+        }
+
+        MoneroKeyImage? keyImage = input.GetKeyImage();
+
+        if (keyImage == null)
+        {
+            throw new MoneroError("Input key image is null");
+        }
+
+        string? keyImageHex = keyImage.GetHex();
+
+        if (keyImageHex == null)
+        {
+            throw new MoneroError("Input key image hex is null");
+        }
+
+        Assert.True(keyImageHex.Length > 0);
+        Assert.Null(input.GetAmount()); // must get info separately
+    }
+
+    private static void TestOutputWallet(MoneroOutputWallet? output)
+    {
+        if (output == null)
+        {
+            throw new MoneroError("Output is null");
+        }
+        Assert.True(output.GetAccountIndex() >= 0);
+        Assert.True(output.GetSubaddressIndex() >= 0);
+        Assert.True(output.GetIndex() >= 0);
+        Assert.NotNull(output.IsSpent());
+        Assert.NotNull(output.IsLocked());
+        Assert.NotNull(output.IsFrozen());
+        MoneroKeyImage? keyImage = output.GetKeyImage();
+
+        if (keyImage == null)
+        {
+            throw new MoneroError("Input key image is null");
+        }
+
+        string? keyImageHex = keyImage.GetHex();
+
+        if (keyImageHex == null)
+        {
+            throw new MoneroError("Input key image hex is null");
+        }
+
+        Assert.True(keyImageHex.Length > 0);
+        TestUtils.TestUnsignedBigInteger(output.GetAmount(), true);
+
+        // output has circular reference to its transaction which has some initialized fields
+        MoneroTxWallet? tx = output.GetTx();
+        if (tx == null)
+        {
+            throw new MoneroError("Tx is null");
+        }
+
+        List<MoneroOutput> outputs = tx.GetOutputs() ?? [];
+
+        Assert.Contains(output, outputs);
+        Assert.NotNull(tx.GetHash());
+        Assert.NotNull(tx.IsLocked());
+        Assert.Equal(true, tx.IsConfirmed());  // TODO monero-wallet-rpc: possible to get unconfirmed outputs?
+        Assert.Equal(true, tx.IsRelayed());
+        Assert.Equal(false, tx.IsFailed());
+        Assert.True(tx.GetHeight() > 0);
+
+        // test copying
+        MoneroOutputWallet copy = output.Clone();
+        Assert.True(copy != output);
+        Assert.Equal(output.ToString(), copy.ToString());
+        Assert.Null(copy.GetTx());  // TODO: should output copy do deep copy of _tx so models are graph instead of tree?  Would need to work out circular references
+    }
+
+    private void TestTxWalletCopy(MoneroTxWallet? tx, TxContext? txCtx)
+    {
+        if (tx == null)
+        {
+            throw new MoneroError("Cannot copy null tx");
+        }
+
+        // copy _tx and Assert. deep equality
+        MoneroTxWallet copy = tx.Clone();
+        Assert.True(copy is MoneroTxWallet);
+        Assert.True(copy.Equals(tx));
+
+        // test different references
+        if (tx.GetOutgoingTransfer() != null)
+        {
+            Assert.True(tx.GetOutgoingTransfer() != copy.GetOutgoingTransfer());
+            Assert.True(tx.GetOutgoingTransfer()!.GetTx() != copy.GetOutgoingTransfer()!.GetTx());
+            if (tx.GetOutgoingTransfer()!.GetDestinations() != null)
+            {
+                Assert.True(tx.GetOutgoingTransfer()!.GetDestinations() != copy.GetOutgoingTransfer()!.GetDestinations());
+                for (int i = 0; i < tx.GetOutgoingTransfer()!.GetDestinations()!.Count; i++)
+                {
+                    Assert.True(copy.GetOutgoingTransfer()!.GetDestinations()![i].Equals(tx.GetOutgoingTransfer()!.GetDestinations()![i]));
+                    Assert.True(tx.GetOutgoingTransfer()!.GetDestinations()![i] != copy.GetOutgoingTransfer()!.GetDestinations()![i]);
+                }
+            }
+        }
+        if (tx.GetIncomingTransfers() != null)
+        {
+            for (int i = 0; i < tx.GetIncomingTransfers()!.Count; i++)
+            {
+                Assert.True(copy.GetIncomingTransfers()![i].Equals(tx.GetIncomingTransfers()![i]));
+                Assert.True(tx.GetIncomingTransfers()![i] != copy.GetIncomingTransfers()![i]);
+            }
+        }
+        if (tx.GetInputs() != null)
+        {
+            for (int i = 0; i < tx.GetInputs()!.Count; i++)
+            {
+                Assert.True(copy.GetInputs()![i].Equals(tx.GetInputs()![i]));
+                Assert.True(tx.GetInputs()![i] != copy.GetInputs()![i]);
+            }
+        }
+        if (tx.GetOutputs() != null)
+        {
+            for (int i = 0; i < tx.GetOutputs()!.Count; i++)
+            {
+                Assert.True(copy.GetOutputs()![i].Equals(tx.GetOutputs()![i]));
+                Assert.True(tx.GetOutputs()![i] != copy.GetOutputs()![i]);
+            }
+        }
+
+        // test copied _tx
+        TxContext ctx = new(txCtx);
+        ctx.IsCopy = true;
+        if (tx.GetBlock() != null)
+        {
+            copy.SetBlock(tx.GetBlock()!.Clone().SetTxs([copy])); // copy block for testing
+        }
+        TestTxWallet(copy, ctx);
+
+        // test merging with copy
+        MoneroTxWallet merged = copy.Merge(copy.Clone());
+        Assert.Equal(merged.ToString(), tx.ToString());
+    }
+
+    private async Task<List<MoneroTransfer>> GetAndTestTransfers(IMoneroWallet wallet, MoneroTransferQuery? query, TxContext? ctx, bool? isExpected)
+    {
+        MoneroTransferQuery? copy = null;
+        if (query != null)
+        {
+            copy = query.Clone();
+        }
+
+        List<MoneroTransfer> transfers = await wallet.GetTransfers(query);
+        if (isExpected == false)
+        {
+            Assert.True(0 == transfers.Count);
+        }
+
+        if (isExpected == true)
+        {
+            Assert.True(transfers.Count > 0, "Transfers were expected but not found; run send tests?");
+        }
+
+        if (ctx == null)
+        {
+            ctx = new TxContext();
+        }
+
+        ctx.Wallet = wallet;
+        foreach (MoneroTransfer transfer in transfers)
+        {
+            TestTxWallet(transfer.GetTx(), ctx);
+        }
+
+        if (query != null)
+        {
+            Assert.NotNull(copy);
+            Assert.True(copy.Equals(query));
+        }
+        return transfers;
     }
 
     #endregion

--- a/Monero.IntegrationTests/Utils/StartMining.cs
+++ b/Monero.IntegrationTests/Utils/StartMining.cs
@@ -2,13 +2,34 @@ namespace Monero.IntegrationTests.Utils;
 
 public static class StartMining
 {
-    public static void Start()
+    public static async Task Start()
     {
-        Start(1);
+        await Start(1);
     }
 
-    private static void Start(ulong numThreads)
+    public static async Task Start(string? address)
     {
-        TestUtils.GetDaemonRpc().StartMining(TestUtils.GetMiningAddress(), numThreads, false, false); // testnet
+        await Start(1, address);
+    }
+
+    public static async Task Start(ulong numThreads)
+    {
+        await Start(numThreads, null);
+    }
+
+    public static async Task<bool> IsMining()
+    {
+        return (await TestUtils.GetDaemonRpc().GetMiningStatus()).IsActive() == true;
+    }
+
+    private static async Task Start(ulong numThreads, string? address)
+    {
+        if (await IsMining())
+        {
+            return;
+        }
+
+        string miningAddress = string.IsNullOrEmpty(address) ? TestUtils.GetMiningAddress() : address;
+        await TestUtils.GetDaemonRpc().StartMining(miningAddress, numThreads, false, false); // testnet
     }
 }

--- a/Monero.IntegrationTests/Utils/StopMining.cs
+++ b/Monero.IntegrationTests/Utils/StopMining.cs
@@ -2,8 +2,18 @@ namespace Monero.IntegrationTests.Utils;
 
 public static class StopMining
 {
-    public static void Stop()
+    public static async Task<bool> IsStopped()
     {
-        TestUtils.GetDaemonRpc().StopMining();
+        return (await TestUtils.GetDaemonRpc().GetMiningStatus()).IsActive() != true;
+    }
+
+    public static async Task Stop()
+    {
+        if (await IsStopped())
+        {
+            return;
+        }
+
+        await TestUtils.GetDaemonRpc().StopMining();
     }
 }

--- a/Monero.IntegrationTests/Utils/TestUtils.cs
+++ b/Monero.IntegrationTests/Utils/TestUtils.cs
@@ -54,13 +54,16 @@ internal abstract class TestUtils
     public static readonly string SEED =
         "arena fossil anchor tapestry iguana tubes javelin gotten cafe damp talent angled onslaught haggled moon roles gills cigar cowl awning vapidly sighting buzzer delayed iguana";
 
+    public static readonly string MINING_SEED =
+        "journal dying mittens orders fight summon framed wrap rumble lemon video dented dazed teeming gills refer factual wildly phase cycling madness software emulate fierce madness";
+
     public static readonly string ADDRESS =
         "4B7nn4hBQhaJ2MBWHLpdUHQMoMqgE2BWtZfofNxTDAJoGgckeEGm4f9WaBuFJmCKuwZ7FE3Di7biKbdafqE4JDj19MWPvQ9";
 
     public static readonly string PRIVATE_VIEW_KEY = "395d05e724f4c08f072895eab08ee4d00b3b2848902cf939fd3c07288454f804";
 
     public static readonly ulong
-        FIRST_RECEIVE_HEIGHT = 171; // NOTE: this value must be the height of the wallet's first tx for tests
+        FIRST_RECEIVE_HEIGHT = 1; // NOTE: this value must be the height of the wallet's first tx for tests
 
     public static readonly int SYNC_PERIOD_IN_MS = 5000; // period between wallet syncs in milliseconds
 

--- a/Monero.IntegrationTests/Utils/TxContext.cs
+++ b/Monero.IntegrationTests/Utils/TxContext.cs
@@ -1,0 +1,43 @@
+using Monero.Wallet;
+using Monero.Wallet.Common;
+
+namespace Monero.IntegrationTests.Utils;
+
+public class TxContext
+{
+    public IMoneroWallet? Wallet;
+    public MoneroTxConfig? Config;
+    public bool? HasOutgoingTransfer;
+    public bool? HasIncomingTransfers;
+    public bool? HasDestinations;
+    public bool? IsCopy;                 // indicates if a copy is being tested which means back references won't be the same
+    public bool? IncludeOutputs;
+    public bool? IsSendResponse;
+    public bool? IsSweepResponse;
+    public bool? IsSweepOutputResponse;  // TODO monero-wallet-rpc: this only necessary because sweep_output does not return account index
+
+    public TxContext() { }
+
+    public TxContext(TxContext? ctx)
+    {
+        if (ctx == null)
+        {
+            return;
+        }
+        Wallet = ctx.Wallet;
+        Config = ctx.Config;
+        HasOutgoingTransfer = ctx.HasOutgoingTransfer;
+        HasIncomingTransfers = ctx.HasIncomingTransfers;
+        HasDestinations = ctx.HasDestinations;
+        IsCopy = ctx.IsCopy;
+        IncludeOutputs = ctx.IncludeOutputs;
+        IsSendResponse = ctx.IsSendResponse;
+        IsSweepResponse = ctx.IsSweepResponse;
+        IsSweepOutputResponse = ctx.IsSweepOutputResponse;
+    }
+
+    public TxContext Clone()
+    {
+        return new TxContext(this);
+    }
+}

--- a/Monero.IntegrationTests/Utils/WalletTxTracker.cs
+++ b/Monero.IntegrationTests/Utils/WalletTxTracker.cs
@@ -83,7 +83,7 @@ public class WalletTxTracker
                 {
                     try
                     {
-                        StartMining.Start();
+                        await StartMining.Start();
                         miningStarted = true;
                     }
                     catch (Exception)

--- a/Monero.IntegrationTests/docker-compose.yml
+++ b/Monero.IntegrationTests/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       dockerfile: Monero.IntegrationTests/Dockerfile
     environment:
       XMR_DAEMON_URI: http://node_2:18081
+      XMR_MINING_DAEMON_URI: http://node_1:18089
       XMR_WALLET_1_URI: http://xmr_wallet_1:18082
       XMR_WALLET_2_URI: http://xmr_wallet_2:18083
       TESTS_INCONTAINER: "true"
@@ -47,7 +48,7 @@ services:
       "--no-zmq",
       "--max-connections-per-ip=100",
       "--rpc-max-connections-per-private-ip=100",
-      "--start-mining=42U9v3qs5CjZEePHBZHwuSckQXebuZu299NSmVEmQ41YJZQhKcPyujyMSzpDH4VMMVSBo3U3b54JaNvQLwAjqDhKS3rvM3L",
+      "--start-mining=46FYVJUS4FwT7eBQjgYJViSwhZmziAQmDTHbCrzvMEKCSiFY9pSxBtEW4bB1nRR2XMKKEd2jgHvwoKzwUAeUY5VU8uo3nZP",
       "--mining-threads=1",
       "--non-interactive"
     ]

--- a/Monero/Common/MoneroTx.cs
+++ b/Monero/Common/MoneroTx.cs
@@ -119,6 +119,142 @@ public class MoneroTx
         return new MoneroTx(this);
     }
 
+    public virtual bool Equals(MoneroTx? other)
+    {
+        return Equals(other, true);
+    }
+
+    public virtual bool Equals(MoneroTx? other, bool checkInputs)
+    {
+        return Equals(other, checkInputs, true);
+    }
+
+    public virtual bool Equals(MoneroTx? other, bool checkInputs, bool checkOutputs)
+    {
+        if (other == null)
+        {
+            return false;
+        }
+        if (this == other)
+        {
+            return true;
+        }
+
+        if (checkInputs)
+        {
+            var inputs = GetInputs() ?? [];
+            var otherInputs = other.GetInputs() ?? [];
+
+            if (inputs.Count != otherInputs.Count)
+            {
+                return false;
+            }
+            int i = 0;
+            foreach (var input in inputs)
+            {
+                var otherInput = otherInputs[i]!;
+                if (!input.Equals(otherInput))
+                {
+                    return false;
+                }
+
+                i++;
+            }
+
+        }
+
+        if (checkOutputs)
+        {
+            var outputs = GetOutputs() ?? [];
+            var otherOutputs = other.GetOutputs() ?? [];
+
+            if (outputs.Count != otherOutputs.Count)
+            {
+                return false;
+            }
+            int i = 0;
+            foreach (var output in outputs)
+            {
+                var otherOutput = otherOutputs[i]!;
+                if (!output.Equals(otherOutput))
+                {
+                    return false;
+                }
+                i++;
+            }
+        }
+
+        var signatures = GetSignatures() ?? [];
+        var otherSignatures = other.GetSignatures() ?? [];
+
+        if (signatures.Count != otherSignatures.Count)
+        {
+            return false;
+        }
+
+        int j = 0;
+
+        foreach (var signature in signatures)
+        {
+            if (signature != otherSignatures[j])
+            {
+                return false;
+            }
+            j++;
+        }
+
+        var indices = GetOutputIndices() ?? [];
+        var otherIndices = other.GetOutputIndices() ?? [];
+
+        if (indices.Count != otherIndices.Count)
+        {
+            return false;
+        }
+
+        int k = 0;
+
+        foreach (var index in indices)
+        {
+            if (index != otherIndices[k])
+            {
+                return false;
+            }
+            k++;
+        }
+
+        return GetHash() == other.GetHash() &&
+               GetVersion() == other.GetVersion() &&
+               IsMinerTx() == other.IsMinerTx() &&
+               GetPaymentId() == other.GetPaymentId() &&
+               GetFee() == other.GetFee() &&
+               GetRingSize() == other.GetRingSize() &&
+               GetRelay() == other.GetRelay() &&
+               IsRelayed() == other.IsRelayed() &&
+               IsConfirmed() == other.IsConfirmed() &&
+               InTxPool() == other.InTxPool() &&
+               GetNumConfirmations() == other.GetNumConfirmations() &&
+               GetUnlockTime() == other.GetUnlockTime() &&
+               GetLastRelayedTimestamp() == other.GetLastRelayedTimestamp() &&
+               GetReceivedTimestamp() == other.GetReceivedTimestamp() &&
+               IsDoubleSpendSeen() == other.IsDoubleSpendSeen() &&
+               GetKey() == other.GetKey() &&
+               GetFullHex() == other.GetFullHex() &&
+               GetPrunedHex() == other.GetPrunedHex() &&
+               GetPrunableHash() == other.GetPrunableHash() &&
+               GetSize() == other.GetSize() &&
+               GetWeight() == other.GetWeight() &&
+               GetMetadata() == other.GetMetadata() &&
+               GetExtra() == other.GetExtra() &&
+               GetRctSignatures() == other.GetRctSignatures() &&
+               GetRctSigPrunable() == other.GetRctSigPrunable() &&
+               IsKeptByBlock() == other.IsKeptByBlock() &&
+               IsFailed() == other.IsFailed() &&
+               GetLastFailedHeight() == other.GetLastFailedHeight() &&
+               GetLastFailedHash() == other.GetLastFailedHash() &&
+               GetMaxUsedBlockHeight() == other.GetMaxUsedBlockHeight() &&
+               GetMaxUsedBlockHash() == other.GetMaxUsedBlockHash();
+    }
+
     public MoneroBlock? GetBlock()
     {
         return _block;
@@ -531,7 +667,7 @@ public class MoneroTx
         return this;
     }
 
-    public MoneroTx Merge(MoneroTx? tx)
+    public virtual MoneroTx Merge(MoneroTx? tx)
     {
         if (tx == null)
         {

--- a/Monero/Wallet/Common/MoneroDestination.cs
+++ b/Monero/Wallet/Common/MoneroDestination.cs
@@ -1,3 +1,7 @@
+using System.Text;
+
+using Monero.Common;
+
 namespace Monero.Wallet.Common;
 
 public class MoneroDestination
@@ -48,5 +52,29 @@ public class MoneroDestination
     {
         _amount = amount;
         return this;
+    }
+
+    public bool Equals(MoneroDestination? other)
+    {
+        if (other == null)
+        {
+            return false;
+        }
+
+        if (this == other)
+        {
+            return true;
+        }
+
+        return _address == other._address && _amount == other._amount;
+    }
+
+    public string ToString(int indent)
+    {
+        var sb = new StringBuilder();
+        sb.Append(GenUtils.KvLine("Address", GetAddress(), indent));
+        sb.Append(GenUtils.KvLine("Amount", GetAmount() != null ? GetAmount().ToString() : null, indent));
+        string str = sb.ToString();
+        return str.Substring(0, str.Length - 1);
     }
 }

--- a/Monero/Wallet/Common/MoneroIncomingTransfer.cs
+++ b/Monero/Wallet/Common/MoneroIncomingTransfer.cs
@@ -1,3 +1,7 @@
+using System.Text;
+
+using Monero.Common;
+
 namespace Monero.Wallet.Common;
 
 public class MoneroIncomingTransfer : MoneroTransfer
@@ -65,5 +69,38 @@ public class MoneroIncomingTransfer : MoneroTransfer
     {
         _numSuggestedConfirmations = numSuggestedConfirmations;
         return this;
+    }
+
+    public bool Equals(MoneroIncomingTransfer? other)
+    {
+        if (other == null)
+        {
+            return false;
+        }
+
+        if (other == this)
+        {
+            return true;
+        }
+
+        if (!base.Equals(other))
+        {
+            return false;
+        }
+
+        return _subaddressIndex == other._subaddressIndex &&
+               _address == other._address &&
+               _numSuggestedConfirmations == other._numSuggestedConfirmations;
+    }
+
+    public override string ToString(int indent)
+    {
+        var sb = new StringBuilder();
+        sb.Append(base.ToString(indent) + "\n");
+        sb.Append(GenUtils.KvLine("Subaddress index", GetSubaddressIndex(), indent));
+        sb.Append(GenUtils.KvLine("Address", GetAddress(), indent));
+        sb.Append(GenUtils.KvLine("Num suggested confirmations", GetNumSuggestedConfirmations(), indent));
+        string str = sb.ToString();
+        return str.Substring(0, str.Length - 1);
     }
 }

--- a/Monero/Wallet/Common/MoneroOutgoingTransfer.cs
+++ b/Monero/Wallet/Common/MoneroOutgoingTransfer.cs
@@ -1,3 +1,7 @@
+using System.Text;
+
+using Monero.Common;
+
 namespace Monero.Wallet.Common;
 
 public class MoneroOutgoingTransfer : MoneroTransfer
@@ -80,5 +84,132 @@ public class MoneroOutgoingTransfer : MoneroTransfer
     {
         _destinations = destinations;
         return this;
+    }
+
+    public bool Equals(MoneroOutgoingTransfer? other)
+    {
+        if (other == null)
+        {
+            return false;
+        }
+
+        if (other == this)
+        {
+            return true;
+        }
+
+        if (_subaddressIndices == null)
+        {
+            if (other._subaddressIndices != null)
+            {
+                return false;
+            }
+        }
+        else
+        {
+            if (other._subaddressIndices == null)
+            {
+                return false;
+            }
+
+            if (_subaddressIndices.Count != other._subaddressIndices.Count)
+            {
+                return false;
+            }
+            int i = 0;
+
+            foreach (var index in _subaddressIndices)
+            {
+                var otherIndex = other._subaddressIndices[i]!;
+                if (index != otherIndex)
+                {
+                    return false;
+                }
+                i++;
+            }
+        }
+
+        if (_addresses == null)
+        {
+            if (other._addresses != null)
+            {
+                return false;
+            }
+        }
+        else
+        {
+            if (other._addresses == null)
+            {
+                return false;
+            }
+
+            if (_addresses.Count != other._addresses.Count)
+            {
+                return false;
+            }
+            int i = 0;
+
+            foreach (var address in _addresses)
+            {
+                var otherAddress = other._addresses[i]!;
+                if (address != otherAddress)
+                {
+                    return false;
+                }
+                i++;
+            }
+        }
+
+        if (_destinations == null)
+        {
+            if (other._destinations != null)
+            {
+                return false;
+            }
+        }
+        else
+        {
+            if (other._destinations == null)
+            {
+                return false;
+            }
+
+            if (_destinations.Count != other._destinations.Count)
+            {
+                return false;
+            }
+
+            int i = 0;
+            foreach (var destination in _destinations)
+            {
+                var otherDest = other._destinations[i];
+                if (destination.Equals(otherDest))
+                {
+                    return false;
+                }
+                i++;
+            }
+        }
+
+        return true;
+    }
+
+    public override string ToString(int indent)
+    {
+        var sb = new StringBuilder();
+        sb.Append(base.ToString(indent) + "\n");
+        sb.Append(GenUtils.KvLine("Subaddress indices", GetSubaddressIndices(), indent));
+        sb.Append(GenUtils.KvLine("Addresses", GetAddresses(), indent));
+        if (GetDestinations() != null)
+        {
+            sb.Append(GenUtils.KvLine("Destinations", "", indent));
+            for (int i = 0; i < GetDestinations()!.Count; i++)
+            {
+                sb.Append(GenUtils.KvLine(i + 1, "", indent + 1));
+                sb.Append(GetDestinations()![i].ToString(indent + 2) + "\n");
+            }
+        }
+        string str = sb.ToString();
+        return str.Substring(0, str.Length - 1);
     }
 }

--- a/Monero/Wallet/Common/MoneroOutputQuery.cs
+++ b/Monero/Wallet/Common/MoneroOutputQuery.cs
@@ -64,8 +64,13 @@ public class MoneroOutputQuery : MoneroOutputWallet
 
     public MoneroOutputQuery SetTxQuery(MoneroTxQuery? txQuery)
     {
+        return SetTxQuery(txQuery, true);
+    }
+
+    public MoneroOutputQuery SetTxQuery(MoneroTxQuery? txQuery, bool setOutputQuery)
+    {
         _txQuery = txQuery;
-        if (txQuery != null)
+        if (setOutputQuery && txQuery != null)
         {
             txQuery.SetOutputQuery(this);
         }
@@ -86,6 +91,83 @@ public class MoneroOutputQuery : MoneroOutputWallet
 
     public bool MeetsCriteria(MoneroOutputWallet? output)
     {
-        throw new NotImplementedException();
+        if (output == null)
+        {
+            return false;
+        }
+
+        // filter on output
+        if (GetAccountIndex() != null && !GetAccountIndex().Equals(output.GetAccountIndex()))
+        {
+            return false;
+        }
+
+        if (GetSubaddressIndex() != null && !GetSubaddressIndex().Equals(output.GetSubaddressIndex()))
+        {
+            return false;
+        }
+
+        if (GetAmount() != null && ((uint)GetAmount()!).CompareTo(output.GetAmount()) != 0)
+        {
+            return false;
+        }
+
+        if (IsSpent() != null && !IsSpent().Equals(output.IsSpent()))
+        {
+            return false;
+        }
+
+        if (IsFrozen() != null && !IsFrozen().Equals(output.IsFrozen()))
+        {
+            return false;
+        }
+
+        // filter on output key image
+        if (GetKeyImage() != null)
+        {
+            if (output.GetKeyImage() == null)
+            {
+                return false;
+            }
+
+            if (GetKeyImage()!.GetHex() != null && !GetKeyImage()!.GetHex()!.Equals(output.GetKeyImage()!.GetHex()))
+            {
+                return false;
+            }
+
+            if (GetKeyImage()!.GetSignature() != null &&
+                !GetKeyImage()!.GetSignature()!.Equals(output.GetKeyImage()!.GetSignature()))
+            {
+                return false;
+            }
+        }
+
+        // filter on extensions
+        if (GetSubaddressIndices() != null && !GetSubaddressIndices()!.Contains((uint)output.GetSubaddressIndex()!))
+        {
+            return false;
+        }
+
+        // filter with tx query
+        if (GetTxQuery() != null && !GetTxQuery()!.MeetsCriteria(output.GetTx()!, false))
+        {
+            return false;
+        }
+
+        // filter on remaining fields
+        if (GetMinAmount() != null &&
+            (output.GetAmount() == null || ((ulong)output.GetAmount()!).CompareTo(GetMinAmount()) < 0))
+        {
+            return false;
+        }
+
+        if (GetMaxAmount() != null &&
+            (output.GetAmount() == null || ((ulong)output.GetAmount()!).CompareTo(GetMaxAmount()) > 0))
+        {
+            return false;
+        }
+
+        // output Meets query
+        return true;
     }
 }

--- a/Monero/Wallet/Common/MoneroTransfer.cs
+++ b/Monero/Wallet/Common/MoneroTransfer.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 using Monero.Common;
 
 namespace Monero.Wallet.Common;
@@ -99,5 +101,57 @@ public abstract class MoneroTransfer
         }
 
         return this;
+    }
+
+    public bool Equals(MoneroTransfer? other)
+    {
+        if (other == null)
+        {
+            return false;
+        }
+
+        if (this == other)
+        {
+            return true;
+        }
+        if (_accountIndex == null)
+        {
+            if (other._accountIndex != null)
+            {
+                return false;
+            }
+        }
+        else if (!_accountIndex.Equals(other._accountIndex))
+        {
+            return false;
+        }
+        if (_amount == null)
+        {
+            if (other._amount != null)
+            {
+                return false;
+            }
+        }
+        else if (!_amount.Equals(other._amount))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    public override string ToString()
+    {
+        return ToString(0);
+    }
+
+    public virtual string ToString(int indent)
+    {
+        StringBuilder sb = new();
+        sb.Append(GenUtils.KvLine("Is incoming", this.IsIncoming(), indent));
+        sb.Append(GenUtils.KvLine("Amount", this.GetAmount() != null ? this.GetAmount().ToString() : null, indent));
+        sb.Append(GenUtils.KvLine("Account index", this.GetAccountIndex(), indent));
+        string str = sb.ToString();
+        return str.Length == 0 ? str : str.Substring(0, str.Length - 1);	  // strip last newline
     }
 }

--- a/Monero/Wallet/Common/MoneroTxSet.cs
+++ b/Monero/Wallet/Common/MoneroTxSet.cs
@@ -1,3 +1,5 @@
+using Monero.Common;
+
 namespace Monero.Wallet.Common;
 
 public class MoneroTxSet
@@ -48,6 +50,36 @@ public class MoneroTxSet
     public MoneroTxSet SetSignedTxHex(string? signedTxHex)
     {
         _signedTxHex = signedTxHex;
+        return this;
+    }
+
+    public MoneroTxSet Merge(MoneroTxSet? txSet)
+    {
+        if (txSet == null)
+        {
+            throw new MoneroError("Tx set is null");
+        }
+
+        if (this == txSet)
+        {
+            return this;
+        }
+
+        // merge sets
+        SetMultisigTxHex(GenUtils.Reconcile(GetMultisigTxHex(), txSet.GetMultisigTxHex()));
+        SetUnsignedTxHex(GenUtils.Reconcile(GetUnsignedTxHex(), txSet.GetUnsignedTxHex()));
+        SetSignedTxHex(GenUtils.Reconcile(GetSignedTxHex(), txSet.GetSignedTxHex()));
+
+        // merge txs
+        if (txSet.GetTxs() != null)
+        {
+            foreach (MoneroTxWallet tx in txSet.GetTxs()!)
+            {
+                tx.SetTxSet(this);
+                MoneroUtils.MergeTx(_txs!, tx);
+            }
+        }
+
         return this;
     }
 }

--- a/Monero/Wallet/IMoneroWallet.cs
+++ b/Monero/Wallet/IMoneroWallet.cs
@@ -614,7 +614,7 @@ public interface IMoneroWallet
      * @param query specifies attributes of transfers to get
      * @return list of wallet transfers that meet the query
      */
-    Task<List<MoneroTransfer>> GetTransfers(MoneroTransferQuery query);
+    Task<List<MoneroTransfer>> GetTransfers(MoneroTransferQuery? query);
 
     /**
      * Get all the wallet's incoming transfers.
@@ -695,7 +695,7 @@ public interface IMoneroWallet
      * @param query specifies attributes of outputs to Get
      * @return the queried outputs
      */
-    Task<List<MoneroOutputWallet>> GetOutputs(MoneroOutputQuery query);
+    Task<List<MoneroOutputWallet>> GetOutputs(MoneroOutputQuery? query);
 
 
     /**

--- a/Monero/Wallet/MoneroWalletDefault.cs
+++ b/Monero/Wallet/MoneroWalletDefault.cs
@@ -254,7 +254,7 @@ public abstract class MoneroWalletDefault : IMoneroWallet
         return await GetOutputs(new MoneroOutputQuery());
     }
 
-    public abstract Task<List<MoneroOutputWallet>> GetOutputs(MoneroOutputQuery query);
+    public abstract Task<List<MoneroOutputWallet>> GetOutputs(MoneroOutputQuery? query);
 
     public abstract Task<string> GetPath();
 
@@ -337,7 +337,7 @@ public abstract class MoneroWalletDefault : IMoneroWallet
         return await GetTransfers(query);
     }
 
-    public abstract Task<List<MoneroTransfer>> GetTransfers(MoneroTransferQuery query);
+    public abstract Task<List<MoneroTransfer>> GetTransfers(MoneroTransferQuery? query);
 
     public virtual async Task<MoneroTxWallet?> GetTx(string txHash)
     {
@@ -382,12 +382,12 @@ public abstract class MoneroWalletDefault : IMoneroWallet
 
     public virtual async Task<ulong> GetUnlockedBalance()
     {
-        return await GetBalance(null);
+        return await GetUnlockedBalance(null);
     }
 
     public virtual async Task<ulong> GetUnlockedBalance(uint? accountIdx)
     {
-        return await GetBalance(accountIdx, null);
+        return await GetUnlockedBalance(accountIdx, null);
     }
 
     public abstract Task<ulong> GetUnlockedBalance(uint? accountIdx, uint? subaddressIdx);

--- a/Monero/Wallet/MoneroWalletRpc.cs
+++ b/Monero/Wallet/MoneroWalletRpc.cs
@@ -1025,7 +1025,7 @@ public class MoneroWalletRpc : MoneroWalletDefault
         return txs;
     }
 
-    public override async Task<List<MoneroTransfer>> GetTransfers(MoneroTransferQuery query)
+    public override async Task<List<MoneroTransfer>> GetTransfers(MoneroTransferQuery? query)
     {
         // copy and normalize query up to block
         query = NormalizeTransferQuery(query);
@@ -1047,7 +1047,7 @@ public class MoneroWalletRpc : MoneroWalletDefault
         return transfers;
     }
 
-    public override async Task<List<MoneroOutputWallet>> GetOutputs(MoneroOutputQuery query)
+    public override async Task<List<MoneroOutputWallet>> GetOutputs(MoneroOutputQuery? query)
     {
         // get outputs directly if query does not require tx context (other outputs, transfers)
         if (!IsContextual(query))
@@ -1057,6 +1057,12 @@ public class MoneroWalletRpc : MoneroWalletDefault
 
         // otherwise get txs with full models to fulfill query
         List<MoneroOutputWallet> outputs = [];
+
+        if (query == null)
+        {
+            throw new MoneroError("Query is null");
+        }
+
         foreach (MoneroTxWallet tx in await GetTxs(query.GetTxQuery()))
         {
             outputs.AddRange(tx.FilterOutputsWallet(query));
@@ -3032,9 +3038,9 @@ public class MoneroWalletRpc : MoneroWalletDefault
         }
 
         MoneroTxSet txSet = new();
-        txSet.SetMultisigTxHex((string?)rpcMap["multisig_txset"]);
-        txSet.SetUnsignedTxHex((string?)rpcMap["unsigned_txset"]);
-        txSet.SetSignedTxHex((string?)rpcMap["signed_txset"]);
+        txSet.SetMultisigTxHex((string?)rpcMap.GetValueOrDefault("multisig_txset"));
+        txSet.SetUnsignedTxHex((string?)rpcMap.GetValueOrDefault("unsigned_txset"));
+        txSet.SetSignedTxHex((string?)rpcMap.GetValueOrDefault("signed_txset"));
         if (string.IsNullOrEmpty(txSet.GetMultisigTxHex()))
         {
             txSet.SetMultisigTxHex(null);
@@ -3108,7 +3114,7 @@ public class MoneroWalletRpc : MoneroWalletDefault
             object val = rpcTxs[key]!;
             if (key.Equals("tx_hash_list"))
             {
-                List<string> hashes = (List<string>)val;
+                List<string> hashes = ((JArray)val).ToObject<List<string>>()!;
                 for (int i = 0; i < hashes.Count; i++)
                 {
                     txs[i].SetHash(hashes[i]);
@@ -3116,7 +3122,7 @@ public class MoneroWalletRpc : MoneroWalletDefault
             }
             else if (key.Equals("tx_key_list"))
             {
-                List<string> keys = (List<string>)val;
+                List<string> keys = ((JArray)val).ToObject<List<string>>()!;
                 for (int i = 0; i < keys.Count; i++)
                 {
                     txs[i].SetKey(keys[i]);
@@ -3124,7 +3130,7 @@ public class MoneroWalletRpc : MoneroWalletDefault
             }
             else if (key.Equals("tx_blob_list"))
             {
-                List<string> blobs = (List<string>)val;
+                List<string> blobs = ((JArray)val).ToObject<List<string>>()!;
                 for (int i = 0; i < blobs.Count; i++)
                 {
                     txs[i].SetFullHex(blobs[i]);
@@ -3132,7 +3138,7 @@ public class MoneroWalletRpc : MoneroWalletDefault
             }
             else if (key.Equals("tx_metadata_list"))
             {
-                List<string> metadatas = (List<string>)val;
+                List<string> metadatas = ((JArray)val).ToObject<List<string>>()!;
                 for (int i = 0; i < metadatas.Count; i++)
                 {
                     txs[i].SetMetadata(metadatas[i]);
@@ -3140,7 +3146,7 @@ public class MoneroWalletRpc : MoneroWalletDefault
             }
             else if (key.Equals("fee_list"))
             {
-                List<ulong> fees = (List<ulong>)val;
+                List<ulong> fees = ((JArray)val).ToObject<List<ulong>>()!;
                 for (int i = 0; i < fees.Count; i++)
                 {
                     txs[i].SetFee(fees[i]);
@@ -3148,7 +3154,7 @@ public class MoneroWalletRpc : MoneroWalletDefault
             }
             else if (key.Equals("amount_list"))
             {
-                List<ulong> amounts = (List<ulong>)val;
+                List<ulong> amounts = ((JArray)val).ToObject<List<ulong>>()!;
                 for (int i = 0; i < amounts.Count; i++)
                 {
                     if (txs[i].GetOutgoingTransfer() == null)
@@ -3161,7 +3167,7 @@ public class MoneroWalletRpc : MoneroWalletDefault
             }
             else if (key.Equals("weight_list"))
             {
-                List<ulong> weights = (List<ulong>)val;
+                List<ulong> weights = ((JArray)val).ToObject<List<ulong>>()!;
                 for (int i = 0; i < weights.Count; i++)
                 {
                     txs[i].SetWeight(weights[i]);
@@ -3290,7 +3296,7 @@ public class MoneroWalletRpc : MoneroWalletDefault
             }
             else if (key.Equals("fee"))
             {
-                tx.SetFee((ulong?)val);
+                tx.SetFee(Convert.ToUInt64(val));
             }
             else if (key.Equals("note"))
             {
@@ -3309,15 +3315,15 @@ public class MoneroWalletRpc : MoneroWalletDefault
             }
             else if (key.Equals("tx_size"))
             {
-                tx.SetSize((ulong?)val);
+                tx.SetSize(Convert.ToUInt64(val));
             }
             else if (key.Equals("unlock_time"))
             {
-                tx.SetUnlockTime((ulong?)val);
+                tx.SetUnlockTime(Convert.ToUInt64(val));
             }
             else if (key.Equals("weight"))
             {
-                tx.SetWeight((ulong?)val);
+                tx.SetWeight(Convert.ToUInt64(val));
             }
             else if (key.Equals("locked"))
             {
@@ -3344,7 +3350,7 @@ public class MoneroWalletRpc : MoneroWalletDefault
                         header = new MoneroBlockHeader();
                     }
 
-                    header.SetHeight((ulong?)val);
+                    header.SetHeight(Convert.ToUInt64(val));
                 }
             }
             else if (key.Equals("timestamp"))
@@ -3356,13 +3362,13 @@ public class MoneroWalletRpc : MoneroWalletDefault
                         header = new MoneroBlockHeader();
                     }
 
-                    header.SetTimestamp((ulong?)val);
+                    header.SetTimestamp(Convert.ToUInt64(val));
                 }
                 // timestamp of unconfirmed tx is current request time
             }
             else if (key.Equals("confirmations"))
             {
-                tx.SetNumConfirmations((ulong?)val);
+                tx.SetNumConfirmations(Convert.ToUInt64(val));
             }
             else if (key.Equals("suggested_confirmations_threshold"))
             {
@@ -3374,7 +3380,7 @@ public class MoneroWalletRpc : MoneroWalletDefault
 
                 if (_isOutgoing != true)
                 {
-                    ((MoneroIncomingTransfer)transfer).SetNumSuggestedConfirmations((ulong?)val);
+                    ((MoneroIncomingTransfer)transfer).SetNumSuggestedConfirmations(Convert.ToUInt64(val));
                 }
             }
             else if (key.Equals("amount"))
@@ -3385,7 +3391,7 @@ public class MoneroWalletRpc : MoneroWalletDefault
                     transfer.SetTx(tx);
                 }
 
-                transfer.SetAmount((ulong?)val);
+                transfer.SetAmount(Convert.ToUInt64(val));
             }
             else if (key.Equals("amounts"))
             {
@@ -3495,11 +3501,11 @@ public class MoneroWalletRpc : MoneroWalletDefault
             }
             else if (key.Equals("amount_in"))
             {
-                tx.SetInputSum((ulong?)val);
+                tx.SetInputSum(Convert.ToUInt64(val));
             }
             else if (key.Equals("amount_out"))
             {
-                tx.SetOutputSum((ulong?)val);
+                tx.SetOutputSum(Convert.ToUInt64(val));
             }
             else if (key.Equals("change_address"))
             {
@@ -3510,11 +3516,11 @@ public class MoneroWalletRpc : MoneroWalletDefault
             }
             else if (key.Equals("change_amount"))
             {
-                tx.SetChangeAmount((ulong?)val);
+                tx.SetChangeAmount(Convert.ToUInt64(val));
             }
             else if (key.Equals("dummy_outputs"))
             {
-                tx.SetNumDummyOutputs((uint?)val);
+                tx.SetNumDummyOutputs(Convert.ToUInt32(val));
             }
             else if (key.Equals("extra"))
             {
@@ -3525,14 +3531,16 @@ public class MoneroWalletRpc : MoneroWalletDefault
             }
             else if (key.Equals("ring_size"))
             {
-                tx.SetRingSize((uint?)val);
+                tx.SetRingSize(Convert.ToUInt32(val));
             }
             else if (key.Equals("spent_key_images"))
             {
-                if (val is MoneroJsonRpcParams dict &&
-                    dict.TryGetValue("key_images", out object? keyImagesObj) &&
-                    keyImagesObj is List<string> inputKeyImages)
+                var valMap = ((JObject)val!).ToObject<Dictionary<string, object>>();
+
+                if (valMap != null)
                 {
+                    List<string> inputKeyImages = ((JArray)valMap["key_images"]).ToObject<List<string>>() ?? [];
+
                     if (tx.GetInputs() != null)
                     {
                         throw new MoneroError("Expected null inputs");
@@ -3560,10 +3568,11 @@ public class MoneroWalletRpc : MoneroWalletDefault
                     throw new MoneroError("Expected outgoing transfer, but got incoming transfer");
                 }
 
-                if (val is MoneroJsonRpcParams dict &&
-                    dict.TryGetValue("amounts", out object? amountsObj) &&
-                    amountsObj is List<ulong> amountsByDest)
+                Dictionary<string, object>? valMap = ((JObject)val!).ToObject<Dictionary<string, object>>();
+                if (valMap != null)
                 {
+                    List<ulong> amountsByDest = ((JArray)valMap["amounts"]).ToObject<List<UInt64>>() ?? [];
+
                     if (config == null)
                     {
                         throw new MoneroError("Must provide a valid tx config");
@@ -3818,7 +3827,7 @@ public class MoneroWalletRpc : MoneroWalletDefault
         // merge tx's block if confirmed
         if (tx.GetHeight() != null)
         {
-            MoneroBlock? aBlock = blockMap[txHeight];
+            MoneroBlock? aBlock = blockMap.GetValueOrDefault(txHeight);
             if (aBlock == null)
             {
                 blockMap.Add(txHeight, tx.GetBlock()); // cache new block


### PR DESCRIPTION
This PR consolidates basic functionality of `MoneroWalletRpc.GetTransfers(MoneroTransferQuery query)`.

1. Implemented new test `TestMoneroWalletRpc.TestGetTransfers()`
2. Implemented wallet funding at startup
3. DTO fixes for `MoneroWalletRpc`
4. Implemented missing `Equals` and `MeetsCriteria` logic needed by `MoneroWallet.GetTransfers` for
   -  `MoneroTxQuery`
   - `MoneroOutputQuery`
   - `MoneroTransferQuery`
   - `MoneroTransfer`
   - `MoneroIncomingTransfer`
   - `MoneroOutgoingTransfer`
   - `MoneroDestination`
   - `MoneroTx`
   - `MoneroTxWallet`
 5. Other minor fixes
